### PR TITLE
Corrected translation of "Send Key"

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -6022,7 +6022,7 @@ msgstr "Gereedschap _balk"
 
 #: ../ui/details.ui.h:21
 msgid "Send _Key"
-msgstr "Verst_uur sleutel"
+msgstr "Verst_uur toets"
 
 #: ../ui/details.ui.h:22
 msgid "Show the graphical console"


### PR DESCRIPTION
Menu item "Send key" got translated to "Verstuur sleutel" ("sleutel
means "key" as in encryption), corrected to "Verstuur toets".