### PR TITLE
Fixed Vte version to be compatible with Ubuntu 14.04

### DIFF
--- a/virtManager/serialcon.py
+++ b/virtManager/serialcon.py
@@ -29,7 +29,7 @@ import gi
 from gi.repository import Gdk
 from gi.repository import GLib
 from gi.repository import Gtk
-gi.require_version("Vte", "2.91")
+gi.require_version("Vte", "2.90")
 from gi.repository import Vte
 
 import libvirt


### PR DESCRIPTION
This will fix an error in Ubuntu 14.04 as only Vte 2.90 is available.