### PR TITLE
Infinite recursion if something is related to itself

### DIFF
--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -320,6 +320,13 @@ class _OsVariant(object):
             _extend(os.get_related(
                 libosinfo.ProductRelationship.UPGRADES).get_elements())
 
+        # check this explicitly to avoid infinitely recursing if something is
+        # related to itself for some reason, like a buggy libosinfo
+        if os in check_list:
+            # If we were checking we are related to ourself then we would have
+            # returned True above already when looking at related_os_list
+            return False
+
         for checkobj in check_list:
             if (checkobj.get_short_id() in related_os_list or
                 self._is_related_to(related_os_list, os=checkobj,


### PR DESCRIPTION
We had a buggy libosinfo in Ubuntu Xenial just now which was causing virt-manager to infinitely recurse inside "_is_related_to". See:

  https://bugs.launchpad.net/ubuntu/+source/virt-manager/+bug/1531722

We had XML like this:

```xml
  <os id="http://ubuntu.com/ubuntu/16.04">
    <short-id>ubuntu16.04</short-id>
    <short-id>ubuntutxenial</short-id>
    <_name>Ubuntu 16.04</_name>
    <version>16.04</version>
    <_vendor>Canonical Ltd</_vendor>
    <family>linux</family>
    <distro>ubuntu</distro>
    <codename>Xenial Xerus</codename>
    <upgrades id="http://ubuntu.com/ubuntu/16.04"/>
    <derives-from id="http://ubuntu.com/ubuntu/16.04"/>
    …
```

It's possible to mitigate this in virt-manager too, by doing something like this PR (or by removing "os" from "check_list" at the same place).