### PR TITLE
Suport port number in FTP urls

### DIFF
--- a/virtinst/urlfetcher.py
+++ b/virtinst/urlfetcher.py
@@ -214,7 +214,12 @@ class _FTPURLFetcher(_URLFetcher):
 
         try:
             server = urlparse.urlparse(self.location)[1]
-            self._ftp = ftplib.FTP(server)
+            if re.match('(.+):(\d*)', server):
+                self._ftp = ftplib.FTP()
+                self._ftp.connect(server.split(':')[0],
+                                  int(server.split(':')[1]))
+            else:
+                self._ftp = ftplib.FTP(server)
             self._ftp.login()
         except Exception, e:
             raise ValueError(_("Opening URL %s failed: %s.") %


### PR DESCRIPTION
Current version of _virt-manager_ doesn't handle FTP urls correctly: _"ftp://server:port/"_ causes exception because the **FTP()** constructor only support hostname, without port definition. To connect to a different port the only way is with **FTP().connect()** method.