### PR TITLE
Make SpiceClientGtk optional

### DIFF
--- a/virtManager/console.py
+++ b/virtManager/console.py
@@ -29,7 +29,7 @@ from .baseclass import vmmGObjectUI
 from .details import DETAILS_PAGE_CONSOLE
 from .serialcon import vmmSerialConsole
 from .sshtunnels import ConnectionInfo
-from .viewers import SpiceViewer, VNCViewer
+from .viewers import SpiceViewer, VNCViewer, have_spice_gtk
 
 
 # console-pages IDs
@@ -665,7 +665,12 @@ class vmmConsolePages(vmmGObjectUI):
             if ginfo.gtype == "vnc":
                 viewer_class = VNCViewer
             elif ginfo.gtype == "spice":
-                viewer_class = SpiceViewer
+                if have_spice_gtk:
+                    viewer_class = SpiceViewer
+                else:
+                    raise RuntimeError("Error opening Spice console, "
+                                       "SpiceClientGtk missing")
+
 
             self._viewer = viewer_class(ginfo)
             self._connect_viewer_signals()

--- a/virtManager/viewers.py
+++ b/virtManager/viewers.py
@@ -25,9 +25,13 @@ from gi.repository import Gdk
 import gi
 gi.require_version('GtkVnc', '2.0')
 from gi.repository import GtkVnc
-gi.require_version('SpiceClientGtk', '3.0')
-from gi.repository import SpiceClientGtk
-from gi.repository import SpiceClientGLib
+try:
+    gi.require_version('SpiceClientGtk', '3.0')
+    from gi.repository import SpiceClientGtk
+    from gi.repository import SpiceClientGLib
+    have_spice_gtk = True
+except (ValueError, ImportError):
+    have_spice_gtk = False
 
 import logging
 import socket


### PR DESCRIPTION
Not all architectures supported by Debian have it. This will allow to
make VNC work nevertheless.