### PR TITLE
Update it.po to fix variable translation

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -1460,7 +1460,7 @@ msgstr "Invia combinazione di tasti"
 #: ../virtManager/console.py:289
 #, python-format
 msgid "%(vm-name)s on %(connection-name)s"
-msgstr "%(nome-mv)s su %(nome-connessione)s"
+msgstr "%(vm-name)s su %(connection-name)s"
 
 #: ../virtManager/console.py:296
 #, python-format


### PR DESCRIPTION
Fixed also on Zanata, related to: https://bugzilla.redhat.com/show_bug.cgi?id=1350185
