### PR TITLE
Fix typo: vachine -> machine

### DIFF
--- a/data/virt-manager.appdata.xml.in
+++ b/data/virt-manager.appdata.xml.in
@@ -25,7 +25,7 @@
     </screenshot>
     <screenshot>
       <image>http://virt-manager.org/appdata/en_US/console.png</image>
-      <_caption>Graphical console connection for a virtual vachine</_caption>
+      <_caption>Graphical console connection for a virtual machine</_caption>
     </screenshot>
   </screenshots>
   <url type="homepage">http://www.virt-manager.org/</url>


### PR DESCRIPTION
Thanks for fixing this typo.