### PR TITLE
Remove minor redundancy in action_remove_device()

### DIFF
--- a/virt-xml
+++ b/virt-xml
@@ -217,7 +217,7 @@ def action_remove_device(guest, options, parserclass):
         getattr(options, parserclass.cli_arg_name)[-1], parserclass)
 
     devs = util.listify(devs)
-    for dev in util.listify(devs):
+    for dev in devs:
         guest.remove_device(dev)
     return devs
 


### PR DESCRIPTION
There's no need to call util.listify() twice.