### PR TITLE
Fix ambigous label on Autostart checkbox

### DIFF
--- a/virtManager/host.py
+++ b/virtManager/host.py
@@ -482,9 +482,6 @@ class vmmHost(vmmGObjectUI):
 
     def net_autostart_changed(self, src_ignore):
         auto = self.widget("net-autostart").get_active()
-        self.widget("net-autostart").set_label(auto and
-                                               _("On Boot") or
-                                               _("Never"))
         self.enable_net_apply(EDIT_NET_AUTOSTART)
 
     def current_network(self):
@@ -640,9 +637,8 @@ class vmmHost(vmmGObjectUI):
         self.widget("net-delete").set_sensitive(not active)
 
         autostart = net.get_autostart()
-        autolabel = autostart and _("On Boot") or _("Never")
         self.widget("net-autostart").set_active(autostart)
-        self.widget("net-autostart").set_label(autolabel)
+        self.widget("net-autostart").set_label(_("On Boot"))
 
         self._populate_net_ipv4_state(net)
         self._populate_net_ipv6_state(net)
@@ -659,7 +655,7 @@ class vmmHost(vmmGObjectUI):
         self.widget("net-start").set_sensitive(False)
         self.widget("net-stop").set_sensitive(False)
         self.widget("net-delete").set_sensitive(False)
-        self.widget("net-autostart").set_label(_("Never"))
+        self.widget("net-autostart").set_label(_("On Boot"))
         self.widget("net-autostart").set_active(False)
         self.widget("net-ipv4-network").set_text("")
         self.widget("net-ipv4-dhcp-range").set_text("")

--- a/virtManager/storagelist.py
+++ b/virtManager/storagelist.py
@@ -314,7 +314,7 @@ class vmmStorageList(vmmGObjectUI):
             ICON_SHUTOFF, Gtk.IconSize.BUTTON)
         self.widget("pool-state").set_text(_("Inactive"))
         self.widget("vol-list").get_model().clear()
-        self.widget("pool-autostart").set_label(_("Never"))
+        self.widget("pool-autostart").set_label(_("On Boot"))
         self.widget("pool-autostart").set_active(False)
 
         self.widget("pool-delete").set_sensitive(False)
@@ -345,8 +345,7 @@ class vmmStorageList(vmmGObjectUI):
                 Gtk.IconSize.BUTTON)
         self.widget("pool-state").set_text(
                 (active and _("Active")) or _("Inactive"))
-        self.widget("pool-autostart").set_label(
-                (auto and _("On Boot")) or _("Never"))
+        self.widget("pool-autostart").set_label(_("On Boot"))
         self.widget("pool-autostart").set_active(auto)
 
         self.widget("vol-list").set_sensitive(active)
@@ -537,8 +536,6 @@ class vmmStorageList(vmmGObjectUI):
     def _pool_autostart_changed(self, src):
         ignore = src
         auto = self.widget("pool-autostart").get_active()
-        self.widget("pool-autostart").set_label(
-            auto and _("On Boot") or _("Never"))
         self._enable_pool_apply(EDIT_POOL_AUTOSTART)
 
     def _vol_selected(self, src):


### PR DESCRIPTION
When the Autostart checkbox on the host Virtual Network or Storage tabs
is deselected, the label reads "Never", and when selected the label reads
"On Boot". This changes these labels to always read "On Boot".