### PR TITLE
Update virt-install man with path to Fedora 25 ISO

### DIFF
--- a/man/virt-install.pod
+++ b/man/virt-install.pod
@@ -381,7 +381,7 @@ Some distro specific url samples:
 
 =item Fedora/Red Hat Based
 
-http://download.fedoraproject.org/pub/fedora/linux/releases/21/Server/x86_64/os
+http://download.fedoraproject.org/pub/fedora/linux/releases/25/Server/x86_64/os
 
 =item Debian
 


### PR DESCRIPTION
The path was to an outdated Fedora 21. Updated for Fedora 25.