### PR TITLE
Deprecated GtkVBox and GtkHBox

### DIFF
--- a/ui/addhardware.ui
+++ b/ui/addhardware.ui
@@ -29,13 +29,15 @@
     <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="on_vmm_create_delete_event" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox23">
+      <object class="GtkBox" id="vbox23">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">12</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkHBox" id="mainhbox">
+          <object class="GtkBox" id="mainhbox">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">12</property>
@@ -67,7 +69,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkVBox" id="create-vbox">
+              <object class="GtkBox" id="create-vbox">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="spacing">12</property>
@@ -125,7 +128,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox10">
+                          <object class="GtkBox" id="vbox10">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">start</property>
@@ -389,7 +393,8 @@
                                 <property name="row_spacing">9</property>
                                 <property name="column_spacing">6</property>
                                 <child>
-                                  <object class="GtkHBox" id="hbox2">
+                                  <object class="GtkBox" id="hbox2">
+                                    <property name="orientation">horizontal</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="spacing">6</property>
@@ -771,7 +776,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="hbox4">
+                              <object class="GtkBox" id="hbox4">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -820,7 +826,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="hbox10">
+                              <object class="GtkBox" id="hbox10">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -1297,7 +1304,8 @@
                             <property name="row_spacing">6</property>
                             <property name="column_spacing">12</property>
                             <child>
-                              <object class="GtkHBox" id="usbredir-host-box">
+                              <object class="GtkBox" id="usbredir-host-box">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -1572,7 +1580,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="rng-connect-host-box">
+                              <object class="GtkBox" id="rng-connect-host-box">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -1637,7 +1646,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="rng-bind-host-box">
+                              <object class="GtkBox" id="rng-bind-host-box">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>

--- a/ui/addstorage.ui
+++ b/ui/addstorage.ui
@@ -7,7 +7,8 @@
     <property name="step_increment">0.10000000000000001</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkVBox" id="storage-box">
+  <object class="GtkBox" id="storage-box">
+    <property name="orientation">vertical</property>
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="spacing">6</property>
@@ -47,12 +48,14 @@
             <property name="can_focus">False</property>
             <property name="left_padding">22</property>
             <child>
-              <object class="GtkVBox" id="vbox1">
+              <object class="GtkBox" id="vbox1">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="spacing">4</property>
                 <child>
-                  <object class="GtkHBox" id="hbox1">
+                  <object class="GtkBox" id="hbox1">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -124,7 +127,8 @@
       </packing>
     </child>
     <child>
-      <object class="GtkHBox" id="hbox9">
+      <object class="GtkBox" id="hbox9">
+        <property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
       </object>
@@ -167,7 +171,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="storage-browse-box">
+          <object class="GtkBox" id="storage-browse-box">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="sensitive">False</property>
             <property name="can_focus">False</property>

--- a/ui/choosecd.ui
+++ b/ui/choosecd.ui
@@ -84,7 +84,8 @@
                     <property name="column_spacing">6</property>
                     <property name="row_spacing">6</property>
                     <child>
-                      <object class="GtkHBox" id="hbox1">
+                      <object class="GtkBox" id="hbox1">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>

--- a/ui/clone.ui
+++ b/ui/clone.ui
@@ -13,7 +13,8 @@
     <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="on_clone_delete_event" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -22,7 +23,8 @@
             <property name="can_focus">False</property>
             <property name="resize_mode">queue</property>
             <child>
-              <object class="GtkHBox" id="hbox77">
+              <object class="GtkBox" id="hbox77">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">6</property>
@@ -41,7 +43,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox2">
+                  <object class="GtkBox" id="hbox2">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
@@ -75,18 +78,21 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox4">
+          <object class="GtkBox" id="vbox4">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">12</property>
             <property name="spacing">12</property>
             <child>
-              <object class="GtkVBox" id="vbox3">
+              <object class="GtkBox" id="vbox3">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="spacing">18</property>
                 <child>
-                  <object class="GtkVBox" id="vbox5">
+                  <object class="GtkBox" id="vbox5">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">12</property>
@@ -168,7 +174,8 @@
                             <property name="column_spacing">12</property>
                             <property name="row_spacing">10</property>
                             <child>
-                              <object class="GtkVBox" id="vbox6">
+                              <object class="GtkBox" id="vbox6">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -185,7 +192,8 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkVBox" id="clone-network-box">
+                                  <object class="GtkBox" id="clone-network-box">
+                                    <property name="orientation">vertical</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="spacing">6</property>
@@ -225,7 +233,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkVBox" id="vbox77">
+                              <object class="GtkBox" id="vbox77">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -251,11 +260,13 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <child>
-                                          <object class="GtkVBox" id="vbox7">
+                                          <object class="GtkBox" id="vbox7">
+                                            <property name="orientation">vertical</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <child>
-                                              <object class="GtkHBox" id="hbox6">
+                                              <object class="GtkBox" id="hbox6">
+                                                <property name="orientation">horizontal</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <child>
@@ -264,7 +275,8 @@
                                                     <property name="can_focus">False</property>
                                                     <property name="right_padding">6</property>
                                                     <child>
-                                                      <object class="GtkVBox" id="clone-storage-box">
+                                                      <object class="GtkBox" id="clone-storage-box">
+                                                        <property name="orientation">vertical</property>
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">False</property>
                                                         <property name="spacing">12</property>
@@ -615,12 +627,14 @@ like change passwords or static IPs, please see the virt-sysprep(1) tool.&lt;/sp
             <property name="top_padding">6</property>
             <property name="left_padding">6</property>
             <child>
-              <object class="GtkVBox" id="vbox8">
+              <object class="GtkBox" id="vbox8">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="spacing">12</property>
                 <child>
-                  <object class="GtkHBox" id="hbox4">
+                  <object class="GtkBox" id="hbox4">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">12</property>
@@ -847,7 +861,8 @@ like change passwords or static IPs, please see the virt-sysprep(1) tool.&lt;/sp
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox2">
+          <object class="GtkBox" id="vbox2">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">6</property>

--- a/ui/create.ui
+++ b/ui/create.ui
@@ -26,7 +26,8 @@
     <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="on_vmm_newcreate_delete_event" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -35,7 +36,8 @@
             <property name="can_focus">False</property>
             <property name="resize_mode">queue</property>
             <child>
-              <object class="GtkHBox" id="hbox77">
+              <object class="GtkBox" id="hbox77">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">6</property>
@@ -54,11 +56,13 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox2">
+                  <object class="GtkBox" id="hbox2">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkVBox" id="vbox3">
+                      <object class="GtkBox" id="vbox3">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
@@ -113,7 +117,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox2">
+          <object class="GtkBox" id="vbox2">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">12</property>
@@ -143,7 +148,8 @@
                             <property name="vexpand">False</property>
                             <property name="row_spacing">12</property>
                             <child>
-                              <object class="GtkVBox" id="vz-install-box">
+                              <object class="GtkBox" id="vz-install-box">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">8</property>
@@ -166,7 +172,8 @@
                                     <property name="can_focus">False</property>
                                     <property name="left_padding">15</property>
                                     <child>
-                                      <object class="GtkVBox" id="vbox5">
+                                      <object class="GtkBox" id="vbox5">
+                                        <property name="orientation">vertical</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">3</property>
@@ -222,7 +229,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkVBox" id="virt-install-box">
+                              <object class="GtkBox" id="virt-install-box">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="vexpand">False</property>
@@ -246,7 +254,8 @@
                                     <property name="can_focus">False</property>
                                     <property name="left_padding">15</property>
                                     <child>
-                                      <object class="GtkVBox" id="vbox19">
+                                      <object class="GtkBox" id="vbox19">
+                                        <property name="orientation">vertical</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">3</property>
@@ -338,7 +347,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkVBox" id="container-install-box">
+                              <object class="GtkBox" id="container-install-box">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">8</property>
@@ -361,7 +371,8 @@
                                     <property name="can_focus">False</property>
                                     <property name="left_padding">15</property>
                                     <child>
-                                      <object class="GtkVBox" id="vbox23">
+                                      <object class="GtkBox" id="vbox23">
+                                        <property name="orientation">vertical</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">3</property>
@@ -445,7 +456,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="hbox3">
+                              <object class="GtkBox" id="hbox3">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -752,7 +764,8 @@ bar</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox7">
+                      <object class="GtkBox" id="vbox7">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">24</property>
@@ -767,7 +780,8 @@ bar</property>
                                 <property name="can_focus">False</property>
                                 <property name="bottom_padding">10</property>
                                 <child>
-                                  <object class="GtkVBox" id="vbox9">
+                                  <object class="GtkBox" id="vbox9">
+                                    <property name="orientation">vertical</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="spacing">6</property>
@@ -790,12 +804,14 @@ bar</property>
                                         <property name="can_focus">False</property>
                                         <property name="left_padding">15</property>
                                         <child>
-                                          <object class="GtkVBox" id="vbox13">
+                                          <object class="GtkBox" id="vbox13">
+                                            <property name="orientation">vertical</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">4</property>
                                             <child>
-                                              <object class="GtkVBox" id="vbox123">
+                                              <object class="GtkBox" id="vbox123">
+                                                <property name="orientation">vertical</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="spacing">4</property>
@@ -858,7 +874,8 @@ bar</property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkHBox" id="hbox4">
+                                              <object class="GtkBox" id="hbox4">
+                                                <property name="orientation">horizontal</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="spacing">5</property>
@@ -940,7 +957,8 @@ bar</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkVBox" id="vbox10">
+                              <object class="GtkBox" id="vbox10">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -1102,7 +1120,8 @@ bar</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="hbox5">
+                              <object class="GtkBox" id="hbox5">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -1140,7 +1159,8 @@ User shouldn't see this.</property>
                                 <property name="orientation">vertical</property>
                                 <property name="spacing">24</property>
                                 <child>
-                                  <object class="GtkVBox" id="vbox20">
+                                  <object class="GtkBox" id="vbox20">
+                                    <property name="orientation">vertical</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="spacing">6</property>
@@ -1165,7 +1185,8 @@ User shouldn't see this.</property>
                                         <property name="can_focus">False</property>
                                         <property name="left_padding">15</property>
                                         <child>
-                                          <object class="GtkHBox" id="hbox1">
+                                          <object class="GtkBox" id="hbox1">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">6</property>
@@ -1474,7 +1495,8 @@ User shouldn't see this.</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkVBox" id="vbox5678">
+                              <object class="GtkBox" id="vbox5678">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="valign">start</property>
@@ -1501,7 +1523,8 @@ User shouldn't see this.</property>
                                     <property name="can_focus">False</property>
                                     <property name="left_padding">12</property>
                                     <child>
-                                      <object class="GtkHBox" id="hbox15">
+                                      <object class="GtkBox" id="hbox15">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">6</property>
@@ -1563,7 +1586,8 @@ User shouldn't see this.</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkVBox" id="vbozzz">
+                              <object class="GtkBox" id="vbozzz">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -1588,12 +1612,14 @@ User shouldn't see this.</property>
                                     <property name="can_focus">False</property>
                                     <property name="left_padding">12</property>
                                     <child>
-                                      <object class="GtkVBox" id="vbox21">
+                                      <object class="GtkBox" id="vbox21">
+                                        <property name="orientation">vertical</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">12</property>
                                         <child>
-                                          <object class="GtkHBox" id="hbox17">
+                                          <object class="GtkBox" id="hbox17">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">6</property>
@@ -1637,7 +1663,8 @@ User shouldn't see this.</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkHBox" id="hbox16">
+                                          <object class="GtkBox" id="hbox16">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">6</property>
@@ -1701,7 +1728,8 @@ is not yet supported.&lt;/small&gt;</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkVBox" id="vbox67">
+                              <object class="GtkBox" id="vbox67">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -1726,7 +1754,8 @@ is not yet supported.&lt;/small&gt;</property>
                                     <property name="can_focus">False</property>
                                     <property name="left_padding">12</property>
                                     <child>
-                                      <object class="GtkHBox" id="hbox6">
+                                      <object class="GtkBox" id="hbox6">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">6</property>
@@ -1775,12 +1804,14 @@ is not yet supported.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="install-os-distro-box">
+                          <object class="GtkBox" id="install-os-distro-box">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkVBox" id="install-detect-os-box">
+                              <object class="GtkBox" id="install-detect-os-box">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <signal name="hide" handler="on_install_detect_os_box_hide" swapped="no"/>
@@ -1986,12 +2017,14 @@ is not yet supported.&lt;/small&gt;</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox11">
+                      <object class="GtkBox" id="vbox11">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">40</property>
                         <child>
-                          <object class="GtkVBox" id="vbox12">
+                          <object class="GtkBox" id="vbox12">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -2014,7 +2047,8 @@ is not yet supported.&lt;/small&gt;</property>
                                 <property name="can_focus">False</property>
                                 <property name="left_padding">15</property>
                                 <child>
-                                  <object class="GtkHBox" id="hbox11">
+                                  <object class="GtkBox" id="hbox11">
+                                    <property name="orientation">horizontal</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="spacing">6</property>
@@ -2154,7 +2188,8 @@ is not yet supported.&lt;/small&gt;</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkHBox" id="hbox12">
+                                          <object class="GtkBox" id="hbox12">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">6</property>
@@ -2220,7 +2255,8 @@ is not yet supported.&lt;/small&gt;</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="storage-area">
+                      <object class="GtkBox" id="storage-area">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>
@@ -2274,12 +2310,14 @@ is not yet supported.&lt;/small&gt;</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox15">
+                      <object class="GtkBox" id="vbox15">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">15</property>
                         <child>
-                          <object class="GtkVBox" id="vbox16">
+                          <object class="GtkBox" id="vbox16">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -2554,7 +2592,8 @@ is not yet supported.&lt;/small&gt;</property>
                             <property name="can_focus">False</property>
                             <property name="left_padding">6</property>
                             <child>
-                              <object class="GtkHBox" id="finish-warn-os">
+                              <object class="GtkBox" id="finish-warn-os">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">3</property>
@@ -2603,7 +2642,8 @@ is not yet supported.&lt;/small&gt;</property>
                                 <property name="can_focus">False</property>
                                 <property name="left_padding">20</property>
                                 <child>
-                                  <object class="GtkVBox" id="vbox14">
+                                  <object class="GtkBox" id="vbox14">
+                                    <property name="orientation">vertical</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="spacing">6</property>

--- a/ui/createinterface.ui
+++ b/ui/createinterface.ui
@@ -125,7 +125,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkHBox" id="hbox6">
+                      <object class="GtkBox" id="hbox6">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">3</property>
@@ -267,7 +268,8 @@
                 <property name="top_padding">3</property>
                 <property name="left_padding">12</property>
                 <child>
-                  <object class="GtkVBox" id="vbox7">
+                  <object class="GtkBox" id="vbox7">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -390,7 +392,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHBox" id="hbox7">
+                                      <object class="GtkBox" id="hbox7">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">3</property>
@@ -443,7 +446,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHBox" id="hbox8">
+                                      <object class="GtkBox" id="hbox8">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <child>
@@ -581,7 +585,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHBox" id="hbox5">
+                                      <object class="GtkBox" id="hbox5">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">3</property>
@@ -619,7 +624,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHBox" id="hbox9">
+                                      <object class="GtkBox" id="hbox9">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">3</property>
@@ -659,7 +665,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHBox" id="hbox10">
+                                      <object class="GtkBox" id="hbox10">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">3</property>
@@ -699,7 +706,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHBox" id="hbox11">
+                                      <object class="GtkBox" id="hbox11">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <child>
@@ -818,7 +826,8 @@
     <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="on_vmm_create_interface_delete_event" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -827,7 +836,8 @@
             <property name="can_focus">False</property>
             <property name="resize_mode">queue</property>
             <child>
-              <object class="GtkHBox" id="hbox77">
+              <object class="GtkBox" id="hbox77">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">6</property>
@@ -846,11 +856,13 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox2">
+                  <object class="GtkBox" id="hbox2">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkVBox" id="vbox3">
+                      <object class="GtkBox" id="vbox3">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
@@ -905,7 +917,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox2">
+          <object class="GtkBox" id="vbox2">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">12</property>
@@ -917,7 +930,8 @@
                 <property name="show_border">False</property>
                 <signal name="switch-page" handler="on_pages_switch_page" swapped="no"/>
                 <child>
-                  <object class="GtkVBox" id="vbox4">
+                  <object class="GtkBox" id="vbox4">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -935,7 +949,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkHBox" id="hbox1">
+                      <object class="GtkBox" id="hbox1">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">12</property>
@@ -985,7 +1000,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkVBox" id="vbox5">
+                  <object class="GtkBox" id="vbox5">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">12</property>
@@ -1012,7 +1028,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHBox" id="hbox3">
+                          <object class="GtkBox" id="hbox3">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -1064,7 +1081,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHBox" id="hbox4">
+                          <object class="GtkBox" id="hbox4">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -1124,7 +1142,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox8">
+                          <object class="GtkBox" id="vbox8">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -1177,11 +1196,13 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox9">
+                          <object class="GtkBox" id="vbox9">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkHBox" id="vlan-box">
+                              <object class="GtkBox" id="vlan-box">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -1209,7 +1230,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="bridge-box">
+                              <object class="GtkBox" id="bridge-box">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -1249,7 +1271,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="bond-box">
+                              <object class="GtkBox" id="bond-box">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -1312,7 +1335,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHBox" id="ip-box">
+                          <object class="GtkBox" id="ip-box">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -1361,7 +1385,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox6">
+                      <object class="GtkBox" id="vbox6">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">3</property>
@@ -1570,12 +1595,14 @@
                 <property name="can_focus">False</property>
                 <property name="left_padding">3</property>
                 <child>
-                  <object class="GtkVBox" id="vbox10">
+                  <object class="GtkBox" id="vbox10">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
                     <child>
-                      <object class="GtkVBox" id="vbox11">
+                      <object class="GtkBox" id="vbox11">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>
@@ -1604,7 +1631,8 @@
                             <property name="can_focus">False</property>
                             <property name="left_padding">18</property>
                             <child>
-                              <object class="GtkHBox" id="ip-copy-interface-box">
+                              <object class="GtkBox" id="ip-copy-interface-box">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
@@ -1639,7 +1667,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox12">
+                      <object class="GtkBox" id="vbox12">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>
@@ -1671,13 +1700,15 @@
                                 <property name="can_focus">True</property>
                                 <property name="show_border">False</property>
                                 <child>
-                                  <object class="GtkVBox" id="vbox13">
+                                  <object class="GtkBox" id="vbox13">
+                                    <property name="orientation">vertical</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="border_width">6</property>
                                     <property name="spacing">12</property>
                                     <child>
-                                      <object class="GtkHBox" id="hbox14">
+                                      <object class="GtkBox" id="hbox14">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">12</property>
@@ -1719,7 +1750,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkVBox" id="ipv4-static-box">
+                                      <object class="GtkBox" id="ipv4-static-box">
+                                        <property name="orientation">vertical</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">6</property>
@@ -1834,13 +1866,15 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkVBox" id="vbox14">
+                                  <object class="GtkBox" id="vbox14">
+                                    <property name="orientation">vertical</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="border_width">6</property>
                                     <property name="spacing">12</property>
                                     <child>
-                                      <object class="GtkHBox" id="hbox16">
+                                      <object class="GtkBox" id="hbox16">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">12</property>
@@ -1895,7 +1929,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkVBox" id="ipv6-static-box">
+                                      <object class="GtkBox" id="ipv6-static-box">
+                                        <property name="orientation">vertical</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">6</property>
@@ -1918,12 +1953,14 @@
                                             <property name="can_focus">False</property>
                                             <property name="left_padding">6</property>
                                             <child>
-                                              <object class="GtkVBox" id="vbox15">
+                                              <object class="GtkBox" id="vbox15">
+                                                <property name="orientation">vertical</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="spacing">6</property>
                                                 <child>
-                                                  <object class="GtkVBox" id="vbox16">
+                                                  <object class="GtkBox" id="vbox16">
+                                                    <property name="orientation">vertical</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="spacing">3</property>
@@ -1941,7 +1978,8 @@
                                                       </packing>
                                                     </child>
                                                     <child>
-                                                      <object class="GtkHBox" id="hbox17">
+                                                      <object class="GtkBox" id="hbox17">
+                                                        <property name="orientation">horizontal</property>
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">False</property>
                                                         <property name="spacing">12</property>
@@ -1970,7 +2008,8 @@
                                                           </packing>
                                                         </child>
                                                         <child>
-                                                          <object class="GtkVBox" id="vbox17">
+                                                          <object class="GtkBox" id="vbox17">
+                                                            <property name="orientation">vertical</property>
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
                                                             <property name="spacing">6</property>
@@ -2040,7 +2079,8 @@
                                                   </packing>
                                                 </child>
                                                 <child>
-                                                  <object class="GtkHBox" id="hbox13">
+                                                  <object class="GtkBox" id="hbox13">
+                                                    <property name="orientation">horizontal</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="spacing">6</property>

--- a/ui/createnet.ui
+++ b/ui/createnet.ui
@@ -24,7 +24,8 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkHBox" id="box77">
+              <object class="GtkBox" id="box77">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">6</property>
@@ -43,11 +44,13 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox2">
+                  <object class="GtkBox" id="hbox2">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkVBox" id="vbox3">
+                      <object class="GtkBox" id="vbox3">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
@@ -102,7 +105,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox23">
+          <object class="GtkBox" id="vbox23">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">12</property>
@@ -114,7 +118,8 @@
                 <property name="show_border">False</property>
                 <signal name="switch-page" handler="on_create_pages_switch_page" swapped="no"/>
                 <child>
-                  <object class="GtkVBox" id="vbox25">
+                  <object class="GtkBox" id="vbox25">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">12</property>
@@ -166,7 +171,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="hbox26">
+                              <object class="GtkBox" id="hbox26">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -251,7 +257,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkVBox" id="vbox7">
+                  <object class="GtkBox" id="vbox7">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -669,7 +676,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkVBox" id="vbox6">
+                  <object class="GtkBox" id="vbox6">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -1086,7 +1094,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkVBox" id="vbox33">
+                  <object class="GtkBox" id="vbox33">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -1385,7 +1394,8 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkHBox" id="dns-domain-name-box">
+                              <object class="GtkBox" id="dns-domain-name-box">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>

--- a/ui/createpool.ui
+++ b/ui/createpool.ui
@@ -10,7 +10,8 @@
     <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="on_vmm_create_pool_delete_event" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -19,7 +20,8 @@
             <property name="can_focus">False</property>
             <property name="resize_mode">queue</property>
             <child>
-              <object class="GtkHBox" id="hbox77">
+              <object class="GtkBox" id="hbox77">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">6</property>
@@ -38,11 +40,13 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox2">
+                  <object class="GtkBox" id="hbox2">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkVBox" id="vbox3">
+                      <object class="GtkBox" id="vbox3">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
@@ -97,7 +101,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox2">
+          <object class="GtkBox" id="vbox2">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">12</property>
@@ -216,7 +221,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHBox" id="pool-iqn-box">
+                          <object class="GtkBox" id="pool-iqn-box">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>

--- a/ui/createvol.ui
+++ b/ui/createvol.ui
@@ -42,7 +42,8 @@
             <property name="can_focus">False</property>
             <property name="resize_mode">queue</property>
             <child>
-              <object class="GtkHBox" id="hbox77">
+              <object class="GtkBox" id="hbox77">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">6</property>
@@ -61,7 +62,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox2">
+                  <object class="GtkBox" id="hbox2">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
@@ -95,7 +97,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox1">
+          <object class="GtkBox" id="vbox1">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">12</property>
@@ -106,7 +109,8 @@
                 <property name="can_focus">False</property>
                 <property name="right_padding">1</property>
                 <child>
-                  <object class="GtkVBox" id="vbox2">
+                  <object class="GtkBox" id="vbox2">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">12</property>
@@ -136,7 +140,8 @@
                             <property name="row_spacing">4</property>
                             <property name="column_spacing">6</property>
                             <child>
-                              <object class="GtkHBox" id="hbox10">
+                              <object class="GtkBox" id="hbox10">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">2</property>
@@ -219,12 +224,14 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="size-box">
+                          <object class="GtkBox" id="size-box">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">5</property>
                             <child>
-                              <object class="GtkVBox" id="vbox6">
+                              <object class="GtkBox" id="vbox6">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -242,7 +249,8 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkHBox" id="hbox6">
+                                  <object class="GtkBox" id="hbox6">
+                                    <property name="orientation">horizontal</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="spacing">3</property>

--- a/ui/delete.ui
+++ b/ui/delete.ui
@@ -22,7 +22,8 @@
             <property name="can_focus">False</property>
             <property name="resize_mode">queue</property>
             <child>
-              <object class="GtkHBox" id="hbox77">
+              <object class="GtkBox" id="hbox77">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">6</property>
@@ -64,7 +65,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox1">
+          <object class="GtkBox" id="vbox1">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">12</property>
@@ -76,7 +78,8 @@
                 <property name="orientation">vertical</property>
                 <property name="row_spacing">6</property>
                 <child>
-                  <object class="GtkHBox" id="delete-warn-running-vm-box">
+                  <object class="GtkBox" id="delete-warn-running-vm-box">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">3</property>

--- a/ui/details.ui
+++ b/ui/details.ui
@@ -131,7 +131,8 @@
     <signal name="configure-event" handler="on_vmm_details_configure_event" swapped="no"/>
     <signal name="delete-event" handler="on_vmm_details_delete_event" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox2">
+      <object class="GtkBox" id="vbox2">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -398,7 +399,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="toolbar-box">
+          <object class="GtkBox" id="toolbar-box">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
@@ -590,13 +592,15 @@
             <property name="show_border">False</property>
             <signal name="switch-page" handler="on_details_pages_switch_page" after="yes" swapped="no"/>
             <child>
-              <object class="GtkHBox" id="hbox1">
+              <object class="GtkBox" id="hbox1">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">12</property>
                 <property name="spacing">12</property>
                 <child>
-                  <object class="GtkVBox" id="vbox53">
+                  <object class="GtkBox" id="vbox53">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -665,7 +669,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkVBox" id="vbox1">
+                  <object class="GtkBox" id="vbox1">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -676,7 +681,8 @@
                         <property name="tab_pos">left</property>
                         <property name="show_border">False</property>
                         <child>
-                          <object class="GtkVBox" id="vbox6">
+                          <object class="GtkBox" id="vbox6">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">12</property>
@@ -1695,7 +1701,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                             <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
-                              <object class="GtkVBox" id="vbox5">
+                              <object class="GtkBox" id="vbox5">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">12</property>
@@ -1982,7 +1989,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox14">
+                          <object class="GtkBox" id="vbox14">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">start</property>
@@ -2000,7 +2008,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                                     <property name="top_padding">3</property>
                                     <property name="left_padding">12</property>
                                     <child>
-                                      <object class="GtkHBox" id="hbox5">
+                                      <object class="GtkBox" id="hbox5">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">6</property>
@@ -2122,7 +2131,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkHBox" id="cpu-vcpus-warn-box">
+                                          <object class="GtkBox" id="cpu-vcpus-warn-box">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">6</property>
@@ -2281,7 +2291,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                                     <property name="left_padding">23</property>
                                     <property name="right_padding">12</property>
                                     <child>
-                                      <object class="GtkVBox" id="vbox15">
+                                      <object class="GtkBox" id="vbox15">
+                                        <property name="orientation">vertical</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">4</property>
@@ -2310,7 +2321,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                                             <property name="xalign">0</property>
                                             <property name="xscale">0</property>
                                             <child>
-                                              <object class="GtkHBox" id="hbox26">
+                                              <object class="GtkBox" id="hbox26">
+                                                <property name="orientation">horizontal</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="spacing">6</property>
@@ -2424,7 +2436,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                                                   </packing>
                                                 </child>
                                                 <child>
-                                                  <object class="GtkHBox" id="cpu-topology-warn-box">
+                                                  <object class="GtkBox" id="cpu-topology-warn-box">
+                                                    <property name="orientation">horizontal</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="spacing">6</property>
@@ -2513,7 +2526,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox7">
+                          <object class="GtkBox" id="vbox7">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -2597,7 +2611,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkHBox" id="hbox46">
+                                          <object class="GtkBox" id="hbox46">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">3</property>
@@ -2646,7 +2661,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkHBox" id="hbox47">
+                                          <object class="GtkBox" id="hbox47">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">3</property>
@@ -3174,7 +3190,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                                     <property name="top_padding">3</property>
                                     <property name="left_padding">12</property>
                                     <child>
-                                      <object class="GtkVBox" id="bootvbox">
+                                      <object class="GtkBox" id="bootvbox">
+                                        <property name="orientation">vertical</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">6</property>
@@ -3328,7 +3345,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox55">
+                          <object class="GtkBox" id="vbox55">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">12</property>
@@ -3345,7 +3363,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                                     <property name="top_padding">3</property>
                                     <property name="left_padding">12</property>
                                     <child>
-                                      <object class="GtkVBox" id="vbox13">
+                                      <object class="GtkBox" id="vbox13">
+                                        <property name="orientation">vertical</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">12</property>
@@ -3903,7 +3922,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox54">
+                          <object class="GtkBox" id="vbox54">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">12</property>
@@ -4088,7 +4108,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox56">
+                          <object class="GtkBox" id="vbox56">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">12</property>
@@ -4198,7 +4219,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox57">
+                          <object class="GtkBox" id="vbox57">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -4250,7 +4272,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox58">
+                          <object class="GtkBox" id="vbox58">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -4342,7 +4365,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox59">
+                          <object class="GtkBox" id="vbox59">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -4547,7 +4571,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox8">
+                          <object class="GtkBox" id="vbox8">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -4657,7 +4682,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox9">
+                          <object class="GtkBox" id="vbox9">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -4817,7 +4843,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox12">
+                          <object class="GtkBox" id="vbox12">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -5087,7 +5114,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox16">
+                          <object class="GtkBox" id="vbox16">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -5274,7 +5302,8 @@ if you know what you are doing.&lt;/small&gt;</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkVBox" id="vbox17">
+                          <object class="GtkBox" id="vbox17">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">12</property>

--- a/ui/fsdetails.ui
+++ b/ui/fsdetails.ui
@@ -13,7 +13,8 @@
     <property name="row_spacing">6</property>
     <property name="column_spacing">6</property>
     <child>
-      <object class="GtkHBox" id="fs-type-box">
+      <object class="GtkBox" id="fs-type-box">
+        <property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -48,7 +49,8 @@
       </packing>
     </child>
     <child>
-      <object class="GtkHBox" id="fs-mode-box">
+      <object class="GtkBox" id="fs-mode-box">
+        <property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -83,7 +85,8 @@
       </packing>
     </child>
     <child>
-      <object class="GtkHBox" id="fs-driver-box">
+      <object class="GtkBox" id="fs-driver-box">
+        <property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -118,7 +121,8 @@
       </packing>
     </child>
     <child>
-      <object class="GtkHBox" id="fs-wrpolicy-box">
+      <object class="GtkBox" id="fs-wrpolicy-box">
+        <property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -181,7 +185,8 @@
       </packing>
     </child>
     <child>
-      <object class="GtkHBox" id="fs-source-box">
+      <object class="GtkBox" id="fs-source-box">
+        <property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">6</property>
@@ -384,7 +389,8 @@
       </packing>
     </child>
     <child>
-      <object class="GtkHBox" id="fs-format-box">
+      <object class="GtkBox" id="fs-format-box">
+        <property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>

--- a/ui/host.ui
+++ b/ui/host.ui
@@ -18,7 +18,8 @@
     </accel-groups>
     <signal name="delete-event" handler="on_vmm_host_delete_event" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -94,7 +95,8 @@
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkVBox" id="vbox2">
+                  <object class="GtkBox" id="vbox2">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="border_width">6</property>
@@ -381,7 +383,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkVBox" id="vbox7">
+              <object class="GtkBox" id="vbox7">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">3</property>
@@ -426,7 +429,8 @@
                             <property name="can_focus">False</property>
                             <property name="left_padding">6</property>
                             <child>
-                              <object class="GtkVBox" id="net-details">
+                              <object class="GtkBox" id="net-details">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">12</property>
@@ -437,7 +441,8 @@
                                     <property name="row_spacing">5</property>
                                     <property name="column_spacing">6</property>
                                     <child>
-                                      <object class="GtkHBox" id="hbox3">
+                                      <object class="GtkBox" id="hbox3">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">3</property>
@@ -643,7 +648,8 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkHBox" id="hbox13">
+                                          <object class="GtkBox" id="hbox13">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">3</property>
@@ -794,7 +800,8 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkHBox" id="hbox6">
+                                          <object class="GtkBox" id="hbox6">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">3</property>
@@ -1168,12 +1175,14 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox15">
+                  <object class="GtkBox" id="hbox15">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="border_width">3</property>
                     <child>
-                      <object class="GtkHBox" id="hbox16">
+                      <object class="GtkBox" id="hbox16">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
@@ -1272,7 +1281,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkHBox" id="hbox17">
+                      <object class="GtkBox" id="hbox17">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
@@ -1346,7 +1356,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkVBox" id="vbox3">
+              <object class="GtkBox" id="vbox3">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">3</property>
@@ -1392,7 +1403,8 @@
                             <property name="can_focus">False</property>
                             <property name="left_padding">6</property>
                             <child>
-                              <object class="GtkVBox" id="interface-details">
+                              <object class="GtkBox" id="interface-details">
+                                <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="spacing">12</property>
@@ -1465,7 +1477,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHBox" id="hbox4">
+                                      <object class="GtkBox" id="hbox4">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="spacing">3</property>
@@ -1518,7 +1531,8 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHBox" id="hbox8">
+                                      <object class="GtkBox" id="hbox8">
+                                        <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <child>
@@ -1762,7 +1776,8 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkVBox" id="interface-child-box">
+                                  <object class="GtkBox" id="interface-child-box">
+                                    <property name="orientation">vertical</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="spacing">3</property>
@@ -1826,7 +1841,7 @@
                           <object class="GtkLabel" id="interface-error-label">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label">some message 
+                            <property name="label">some message
 here</property>
                             <property name="justify">center</property>
                           </object>
@@ -1859,12 +1874,14 @@ here</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHBox" id="hbox1">
+                  <object class="GtkBox" id="hbox1">
+                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="border_width">3</property>
                     <child>
-                      <object class="GtkHBox" id="hbox2">
+                      <object class="GtkBox" id="hbox2">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
@@ -1963,7 +1980,8 @@ here</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkHBox" id="hbox5">
+                      <object class="GtkBox" id="hbox5">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>

--- a/ui/manager.ui
+++ b/ui/manager.ui
@@ -30,7 +30,8 @@
     <signal name="configure-event" handler="on_vmm_manager_configure_event" swapped="no"/>
     <signal name="delete-event" handler="on_vm_manager_delete_event" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
@@ -268,7 +269,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkVBox" id="vbox2">
+          <object class="GtkBox" id="vbox2">
+            <property name="orientation">vertical</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>

--- a/ui/netlist.ui
+++ b/ui/netlist.ui
@@ -200,7 +200,8 @@
   <object class="GtkExpander" id="vport-expander">
     <property name="can_focus">True</property>
     <child>
-      <object class="GtkHBox" id="hbox1124">
+      <object class="GtkBox" id="hbox1124">
+        <property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -16,7 +16,8 @@
     <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="on_vmm_preferences_delete_event" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkBox" id="vbox1">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">12</property>
@@ -525,7 +526,8 @@ Redirection:</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHBox" id="hbox2">
+                          <object class="GtkBox" id="hbox2">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>

--- a/ui/storagelist.ui
+++ b/ui/storagelist.ui
@@ -12,13 +12,15 @@
     <property name="can_focus">False</property>
     <property name="border_width">3</property>
     <child>
-      <object class="GtkHBox" id="hbox9">
+      <object class="GtkBox" id="hbox9">
+        <property name="orientation">horizontal</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="valign">end</property>
         <property name="border_width">3</property>
         <child>
-          <object class="GtkHBox" id="hbox10">
+          <object class="GtkBox" id="hbox10">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
@@ -113,7 +115,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox11">
+          <object class="GtkBox" id="hbox11">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="spacing">6</property>
@@ -250,7 +253,8 @@
                 <property name="can_focus">False</property>
                 <property name="left_padding">6</property>
                 <child>
-                  <object class="GtkVBox" id="pool-details">
+                  <object class="GtkBox" id="pool-details">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -261,7 +265,8 @@
                         <property name="row_spacing">5</property>
                         <property name="column_spacing">8</property>
                         <child>
-                          <object class="GtkHBox" id="pool-state-box">
+                          <object class="GtkBox" id="pool-state-box">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">3</property>
@@ -418,12 +423,14 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox6">
+                      <object class="GtkBox" id="vbox6">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">3</property>
                         <child>
-                          <object class="GtkHBox" id="hbox12">
+                          <object class="GtkBox" id="hbox12">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>


### PR DESCRIPTION
Problem:
- GtkHBox and GtkVBox have been deprecated since version 3.2 and should not be used in newly-written code.

Solution:
- Replace GtkHBox and GtkVBox with GtkBox.