### PR TITLE
virtinst: Fix os-variant ordering

### DIFF
--- a/virt-install
+++ b/virt-install
@@ -394,12 +394,13 @@ def set_install_media(guest, location, cdpath, distro_variant):
         if location or cdpath:
             guest.installer.location = (location or cdpath)
 
-        guest.installer.check_location(guest)
-
         if distro_variant == "auto":
             guest.os_variant = guest.installer.detect_distro(guest)
         elif distro_variant != "none":
             guest.os_variant = distro_variant
+
+        guest.installer.check_location(guest)
+
     except ValueError as e:
         fail(_("Error validating install location: %s") % str(e))
 


### PR DESCRIPTION
Previously os-variant was not being set before performing location
checks.  This lead to a sitation where the os-variant data could not be
acted on.  This commit re-orders the process to ensure that the correct
ordering happens.

CLI:  `virt-install --debug    -l https://example.com/repo/rhel/7/rhel-7-server-rpms/ --disk size=2 -w network=default  --memory 512 --name z --console pty,target_type=virtio --os-variant rhel7.3`

Previous behavior:
```
[Thu, 11 May 2017 12:28:30 virt-install 19296] DEBUG (distroinstaller:180) DistroInstaller location is a network source.
[Thu, 11 May 2017 12:28:30 virt-install 19296] DEBUG (distroinstaller:181) Sanitized value is https://example.com/repo/rhel/7/rhel-7-server-rpms/
[Thu, 11 May 2017 12:28:30 virt-install 19296] DEBUG (urlfetcher:57) Using scratchdir=/home/bharrington/.cache/virt-manager/boot
[Thu, 11 May 2017 12:28:30 virt-install 19296] DEBUG (urlfetcher:477) Finding distro store for location=https://example.com/repo/rhel/7/rhel-7-server-rpms/
[Thu, 11 May 2017 12:28:30 virt-install 19296] DEBUG (urlfetcher:484) Using os-variant=generic
[Thu, 11 May 2017 12:28:30 virt-install 19296] DEBUG (urlfetcher:486) Supplying urldistro=None
[Thu, 11 May 2017 12:28:34 virt-install 19296] DEBUG (urlfetcher:186) HTTP hasFile request failed: 404 Client Error: Not Found for url: https://example.com/repo/rhel/7/rhel-7-server-rpms/Fedora
[Thu, 11 May 2017 12:28:34 virt-install 19296] DEBUG (urlfetcher:145) hasFile(https://example.com/repo/rhel/7/rhel-7-server-rpms/Fedora) returning False
[Thu, 11 May 2017 12:28:34 virt-install 19296] DEBUG (urlfetcher:1114) No treearch found in uri, defaulting to arch=i386
...
```

Current behavior:
```
[Thu, 11 May 2017 13:20:37 virt-install 22335] DEBUG (distroinstaller:180) DistroInstaller location is a network source.
[Thu, 11 May 2017 13:20:37 virt-install 22335] DEBUG (guest:250) Setting Guest.os_variant to 'rhel7.3'
[Thu, 11 May 2017 13:20:37 virt-install 22335] DEBUG (urlfetcher:57) Using scratchdir=/home/bharrington/.cache/virt-manager/boot
[Thu, 11 May 2017 13:20:37 virt-install 22335] DEBUG (urlfetcher:477) Finding distro store for location=https://example.com/repo/rhel/7/rhel-7-server-rpms/
[Thu, 11 May 2017 13:20:38 virt-install 22335] DEBUG (urlfetcher:499) Prioritizing distro store=<class 'virtinst.urlfetcher.RHELDistro'>
```