### PR TITLE
support username and password in prepareLocation

### DIFF
--- a/virtinst/urlfetcher.py
+++ b/virtinst/urlfetcher.py
@@ -207,13 +207,20 @@ class _FTPURLFetcher(_URLFetcher):
             return
 
         try:
-            parsed = urllib.parse.urlparse(self.location)
-            self._ftp = ftplib.FTP()
-            self._ftp.connect(parsed.hostname, parsed.port or 0)
-            self._ftp.login()
-            # Force binary mode
-            self._ftp.voidcmd("TYPE I")
-        except Exception as e:
+             parsed = urllib.parse.urlparse(self.location)
+             self._ftp = ftplib.FTP()
+             from urllib2 import unquote
+             parsed = urlparse.urlparse(self.location)
+             username = parsed.username or ''
+             username = unquote(username).decode('utf8')
+             password = parsed.password or ''
+             password = unquote(password).decode('utf8')
+             self._ftp = ftplib.FTP(parsed.hostname, username, password)
+             self._ftp.connect(parsed.hostname, parsed.port or 0)
+             self._ftp.login(username, password)
+             # Force binary mode
+             self._ftp.voidcmd("TYPE I")
+         except Exception as e:
             raise ValueError(_("Opening URL %s failed: %s.") %
                               (self.location, str(e)))
 


### PR DESCRIPTION
If --location is an ftp url with a username and password
then virt-install fails to install with an error:
ERROR Error validating install location: Opening URL u failed: 530 Login incorrect..