### PR TITLE
setup: Install files in new virtinst folders

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -671,6 +671,8 @@ distutils.core.setup(
         ("share/virt-manager/virtcli",
          glob.glob("virtcli/*.py") + glob.glob("virtcli/cli.cfg")),
         ("share/virt-manager/virtinst", glob.glob("virtinst/*.py")),
+        ("share/virt-manager/virtinst/devices", glob.glob("virtinst/devices/*.py")),
+        ("share/virt-manager/virtinst/domain", glob.glob("virtinst/domain/*.py")),
         ("share/virt-manager/virtconv", glob.glob("virtconv/*.py")),
     ],
 


### PR DESCRIPTION
In commits fe9ed23 and 3909c10 several files were moved to subfolder of
virtinst, but they are not covered by the existing glob in the setup.py
file. Fix that by adding those subfolders explicitely.