### PR TITLE
Fix URI parsing when username contains @ sign

### DIFF
--- a/virtinst/uri.py
+++ b/virtinst/uri.py
@@ -35,10 +35,11 @@ class URI(object):
     """
     def __init__(self, uri):
         self.uri = uri
-        unquoted_uri = urllib.parse.unquote(uri)
 
-        (self.scheme, self.username, self.hostname,
-         self.path, self.query, self.fragment) = self._split(unquoted_uri)
+        split_uri = self._split(uri)
+        self.scheme = split_uri[0]
+        (self.username, self.hostname, self.path, self.query,
+         self.fragment) = map(urllib.parse.unquote, split_uri[1:])
 
         self.transport = ''
         if "+" in self.scheme:


### PR DESCRIPTION
On a domain-joined host the URI wasn't getting properly parsed due to the username containing an @ sign.

Before:
DEBUG (sshtunnels:263) ['ssh', 'ssh', '-l', 'eduardok', 'ad.mydomain.com@kvmhost1', 'sh -c', '\'nc -q 2>&1 | grep "requires an argument" >/dev/null;if [ $? -eq 0 ] ; then   CMD="nc -q 0 127.0.0.1 5900";else   CMD="nc 127.0.0.1 5900";fi;eval "$CMD";\'']

After:
DEBUG (sshtunnels:263) ['ssh', 'ssh', '-l', 'eduardok@ad.mydomain.com', 'kvmhost1', 'sh -c', '\'nc -q 2>&1 | grep "requires an argument" >/dev/null;if [ $? -eq 0 ] ; then   CMD="nc -q 0 127.0.0.1 5900";else   CMD="nc 127.0.0.1 5900";fi;eval "$CMD";\'']