### PR TITLE
connection: avoid failing on NoneType in _hostinfo

### DIFF
--- a/virtManager/connection.py
+++ b/virtManager/connection.py
@@ -318,12 +318,12 @@ class vmmConnection(vmmGObject):
     caps = property(lambda self: getattr(self, "_backend").caps)
 
     def host_memory_size(self):
-        if not self._backend.is_open():
+        if not self._backend.is_open() or self._hostinfo is None:
             return 0
         return self._hostinfo[1] * 1024
 
     def host_active_processor_count(self):
-        if not self._backend.is_open():
+        if not self._backend.is_open() or self._hostinfo is None:
             return 0
         return self._hostinfo[2]
 


### PR DESCRIPTION
There is a potential race of a backend to be opened and being true on
self._backend.is_open but self._hostinfo not being set yet.

Avoid spurial bugs due to that by also checking against None before
accessing subelements ot self._hostinfo

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>