### PR TITLE
Add missing argument in message translation

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -158,7 +158,7 @@ msgid ""
 msgstr ""
 "Nośnik CD-ROM domyślnie nie wyświetla do konsoli tekstowej, więc "
 "prawdopodobnie wyjście tekstowe instalacji nie będzie widoczne. Warto "
-"rozważyć użycie parametru "
+"rozważyć użycie parametru --location."
 
 #: ../virt-install:511
 msgid ""


### PR DESCRIPTION
Add missing "--location" in PL translation of "CDROM media does not print..."