### PR TITLE
virtinst: quickfix ubuntu net-preseed insert cdrom error

### DIFF
--- a/virtinst/urldetect.py
+++ b/virtinst/urldetect.py
@@ -684,6 +684,9 @@ class DebianDistro(Distro):
             media_type = "url"
         elif check_manifest("daily/MANIFEST"):
             media_type = "daily"
+        elif cache.content_regex("install/netboot/version.info",
+                "%s.*" % cls._debname.capitalize()):
+            media_type = "mounted_iso_url"
         elif cache.content_regex(".disk/info",
                 "%s.*" % cls._debname.capitalize()):
             media_type = "disk"
@@ -732,6 +735,9 @@ class DebianDistro(Distro):
         url_prefix = "current/images"
         if self.cache.debian_media_type == "daily":
             url_prefix = "daily"
+
+        if self.cache.debian_media_type == "mounted_iso_url":
+            url_prefix = "install"
 
         self._boot_iso_paths = ["%s/netboot/mini.iso" % url_prefix]
 


### PR DESCRIPTION
 The proper kernel/initrd pair for booting from an http server is found in install/netboot/... on a mounted ubuntu iso. This last worked in v1.4.2

I am sure this is not a proper fix, please point me in the right direction.

I am using virt-install to preseed Ubuntu machines from an http server. The issue is that in urldetect.py the media_type is identified by this

```
 elif cache.content_regex(".disk/info",
                "%s.*" % cls._debname.capitalize()):
            media_type = "disk"
```

Therefore if the install source where kernel/initrd is pulled from is an http server with the mounted ubuntu iso, it gets identified as a normal local disk install and the wrong kernel is loaded: install/vmlinuz or something that is decided in:

`_set_installcd_paths(self)`

It should rather jump to the network install method:

 `def _set_url_paths(self):`

See the commit for how I quickfixed tis.

I suppose the better approach would be to also check here in line 687 wether we this url is definitely from a network server and therefore should be prefered instead of the kernel for install directly from a cdrom:

```
       elif cache.content_regex("install/netboot/version.info",
                "%s.*" % cls._debname.capitalize()):
            media_type = "mounted_iso_url"

```

In 1.4.2 it just worked like this:

class UbuntuDistro(DebianDistro):
-    # http://archive.ubuntu.com/ubuntu/dists/natty/main/installer-amd64/
-    name = "Ubuntu"
-    urldistro = "ubuntu"
-
-    def isValidStore(self):
-        if self.fetcher.hasFile("%s/MANIFEST" % self._url_prefix):
-            # For regular trees
-            filename = "%s/MANIFEST" % self._url_prefix
-            regex = ".*%s.*" % self._installer_dirname
-        elif self.fetcher.hasFile("install/netboot/version.info"):
-            # For trees based on ISO's
-            self._url_prefix = "install"
-            self._set_media_paths()
-            filename = "%s/netboot/version.info" % self._url_prefix
-            regex = "%s*" % self.name
-        elif self.fetcher.hasFile(".disk/info") and self.arch == "s390x":
-            self._hvm_kernel_paths += [("boot/kernel.ubuntu", "boot/initrd.ubuntu")]
-            self._xen_kernel_paths += [("boot/kernel.ubuntu", "boot/initrd.ubuntu")]
-            filename = ".disk/info"
-            regex = "%s*" % self.name
-        else:
-            return False



Thanks for any hints for getting this fixed properly.

all the best!
Jojo