### PR TITLE
tests: osdict: fix ordering issue with new osinfo

### DIFF
--- a/tests/osdict.py
+++ b/tests/osdict.py
@@ -71,12 +71,12 @@ class TestOSDB(unittest.TestCase):
         found_fedora = False
         found_rhel = False
         for idx, osobj in enumerate(pref_list[:]):
-            if osobj.name.startswith("fedora"):
+            if osobj.urldistro == "fedora":
                 found_fedora = True
                 continue
 
             for osobj2 in pref_list[idx:]:
-                if osobj2.name.startswith("rhel"):
+                if osobj2.urldistro == "rhel":
                     found_rhel = True
                     continue
                 break


### PR DESCRIPTION
Newer versions of the osinfo database have entries for silverblue which
is derived from fedora and shares its urldistro (=fedora).

That makes silverblue clumped and ordered with fedora entries which
breaks some assumptions that the test 'test_list_os' makes leading to:
  File "/<<PKGBUILDDIR>>/tests/osdict.py", line 85, in test_list_os
    assert found_fedora and found_rhel

Fix those wrong assumptions to only expect ordering/grouping on the
.urldistro instead of the .name of the _OsVariant objects.

Note: The code on master is unaffected due to [1], but the currently released
1.5.x series will fail to build due to that with recent versions of osinfo.

Fixes https://bugs.launchpad.net/ubuntu/+source/virt-manager/+bug/1796932

[1]: https://github.com/virt-manager/virt-manager/commit/d52d9885c85623b8d924dbf0aceecb08b33e9122

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>