### PR TITLE
Adding rebootTimout CLI supprort. this will allow the following -

### DIFF
--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -1649,6 +1649,7 @@ ParserBoot.add_arg(None, "uefi", cb=ParserBoot.set_uefi_cb, is_novalue=True)
 
 ParserBoot.add_arg("useserial", "useserial", is_onoff=True)
 ParserBoot.add_arg("enable_bootmenu", "menu", is_onoff=True)
+ParserBoot.add_arg("os.rebootTimeout", "rebootTimeout")
 ParserBoot.add_arg("kernel", "kernel")
 ParserBoot.add_arg("initrd", "initrd")
 ParserBoot.add_arg("dtb", "dtb")

--- a/virtinst/domain/os.py
+++ b/virtinst/domain/os.py
@@ -89,6 +89,7 @@ class DomainOs(XMLBuilder):
             obj.val = val
 
     enable_bootmenu = XMLProperty("./bootmenu/@enable", is_yesno=True)
+    rebootTimeout = XMLProperty("./bios/@rebootTimeout")
     useserial = XMLProperty("./bios/@useserial", is_yesno=True)
 
     kernel = XMLProperty("./kernel", do_abspath=True)


### PR DESCRIPTION
virt-install -n blah -r 1024 --vcpu=1 --disk=/root/vm/blah.qcow2,size=10\
 --network=bridge:br-public --pxe --boot=network,rebootTimeout=3

By default, in case of (first) pxe boot failure the VM will simply
stop trying.
By adding the above, VM will re-try pxe boot. ( useful when DHCP not
replys on first attempt.

Libvirt support it and VM XML will look as follow : ( 'bios rebootTimeout'
will be created under OS section. )

<Snippet>
..
....
<currentMemory unit='KiB'>3276800</currentMemory>
  <vcpu placement='static'>1</vcpu>
  <os>
    <type arch='x86_64' machine='pc-i440fx-rhel7.5.0'>hvm</type>
    <boot dev='network'/>
    <bios rebootTimeout='3'/>
  </os>
  <features>
    <acpi/>
    <apic/>
    <vmport state='off'/>
  </features>
..
....
<Snippet>