### PR TITLE
virt-install: Fix guest-os deprecation msg

### DIFF
--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -197,7 +197,7 @@ class _OSDB(object):
             # Added 2018-10-02. Maybe remove aliases in a year
             logging.warning(
                 _("OS name '%s' is deprecated, using '%s' instead. "
-                  "This alias will be removed in the future."), (key, alias))
+                  "This alias will be removed in the future."), key, alias)
             key = alias
         return self._all_variants.get(key)
 


### PR DESCRIPTION
Arguments to logging needs to be individual args, otherwise it
fails with "not enough arguments for format string"                             

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>