### PR TITLE
virt-install.pod: make example command match commentary

### DIFF
--- a/man/virt-install.pod
+++ b/man/virt-install.pod
@@ -1741,7 +1741,7 @@ a graphical client.
        --memory 500 \
        --disk size=10 \
        --cdrom /dev/cdrom \
-       --os-variant fedora13
+       --os-variant fedora20
 
 Install a Fedora 9 plain QEMU guest, using LVM partition, virtual networking,
 booting from PXE, using VNC server/viewer, with virtio-scsi disk


### PR DESCRIPTION
The example commentary says Fedora 20, so make the command line match that.