### PR TITLE
Add support for installing pre & post installable drivers

### DIFF
--- a/virt-install
+++ b/virt-install
@@ -470,6 +470,12 @@ def set_cli_defaults(options, guest):
     if guest.os.is_container():
         return
 
+    if (options.unattended and
+        guest.osinfo.is_windows() and
+        guest.osinfo.supports_unattended_drivers(guest.os.arch)):
+        guest.add_extra_drivers(
+                guest.osinfo.get_pre_installable_devices(guest.os.arch))
+
     res = guest.osinfo.get_recommended_resources()
     storage = res.get_recommended_storage(guest.os.arch)
     ram = res.get_recommended_ram(guest.os.arch)

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -487,13 +487,13 @@ class Guest(XMLBuilder):
         return False
 
     def supports_virtionet(self):
-        return self._supports_virtio(self.osinfo.supports_virtionet())
+        return self._supports_virtio(self.osinfo.supports_virtionet(self._extra_drivers))
     def supports_virtiodisk(self):
-        return self._supports_virtio(self.osinfo.supports_virtiodisk())
+        return self._supports_virtio(self.osinfo.supports_virtiodisk(self._extra_drivers))
     def supports_virtioscsi(self):
-        return self._supports_virtio(self.osinfo.supports_virtioscsi())
+        return self._supports_virtio(self.osinfo.supports_virtioscsi(self._extra_drivers))
     def _supports_virtioserial(self):
-        return self._supports_virtio(self.osinfo.supports_virtioserial())
+        return self._supports_virtio(self.osinfo.supports_virtioserial(self._extra_drivers))
 
 
     ###############################
@@ -838,7 +838,7 @@ class Guest(XMLBuilder):
             self.add_device(dev)
 
         # s390x guests need VirtIO input devices
-        if self.os.is_s390x() and self.osinfo.supports_virtioinput():
+        if self.os.is_s390x() and self.osinfo.supports_virtioinput(self._extra_drivers):
             dev = DeviceInput(self.conn)
             dev.type = "tablet"
             dev.bus = "virtio"
@@ -945,7 +945,7 @@ class Guest(XMLBuilder):
             return
 
         if (self.conn.is_qemu() and
-            self.osinfo.supports_virtiorng() and
+            self.osinfo.supports_virtiorng(self._extra_drivers) and
             self.conn.support.conn_rng_urandom()):
             dev = DeviceRng(self.conn)
             dev.type = "random"
@@ -978,7 +978,7 @@ class Guest(XMLBuilder):
                 self.os.is_pseries()):
             return
 
-        if self.osinfo.supports_virtioballoon():
+        if self.osinfo.supports_virtioballoon(self._extra_drivers):
             dev = DeviceMemballoon(self.conn)
             dev.model = "virtio"
             self.add_device(dev)

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -235,6 +235,7 @@ class Guest(XMLBuilder):
         self.__osinfo = None
         self._capsinfo = None
         self._domcaps = None
+        self._extra_drivers = None
 
 
     ######################
@@ -754,6 +755,9 @@ class Guest(XMLBuilder):
 
         self._add_implied_controllers()
         self._add_spice_devices()
+
+    def add_extra_drivers(self, extra_drivers):
+        self._extra_drivers = extra_drivers
 
 
     ########################

--- a/virtinst/install/installer.py
+++ b/virtinst/install/installer.py
@@ -219,7 +219,7 @@ class Installer(object):
     # Internal API overrides #
     ##########################
 
-    def _prepare_unattended_data(self, guest, scripts):
+    def _prepare_unattended_data(self, guest, meter, scripts):
         injections = []
         for script in scripts:
             expected_filename = script.get_expected_filename()
@@ -229,6 +229,13 @@ class Installer(object):
             scriptpath = script.write()
             self._tmpfiles.append(scriptpath)
             injections.append((scriptpath, expected_filename))
+
+        drivers_location = guest.osinfo.get_pre_installable_drivers_location(
+                guest.os.arch)
+        drivers = unattended.download_drivers(drivers_location,
+                InstallerTreeMedia.make_scratchdir(guest), meter)
+        if drivers:
+            injections.extend(drivers)
 
         iso = perform_cdrom_injections(injections,
                 InstallerTreeMedia.make_scratchdir(guest))
@@ -270,7 +277,7 @@ class Installer(object):
                     unattended_scripts)
 
         elif unattended_scripts:
-            self._prepare_unattended_data(guest, unattended_scripts)
+            self._prepare_unattended_data(guest, meter, unattended_scripts)
 
     def _cleanup(self, guest):
         if self._treemedia:

--- a/virtinst/install/unattended.py
+++ b/virtinst/install/unattended.py
@@ -10,6 +10,7 @@ import getpass
 import locale
 import os
 import pwd
+import re
 import tempfile
 
 from gi.repository import Libosinfo
@@ -68,6 +69,12 @@ def _make_installconfig(script, osobj, unattended_data, arch, hostname, url):
 
     # Set hardware architecture and hostname
     config.set_hardware_arch(arch)
+
+    # Some installations will bail if the Computer's name contains one of the
+    # following characters: "[{|}~[\\]^':; <=>?@!\"#$%`()+/.,*&]".
+    # In order to take a safer path, let's ensure that we never set those,
+    # replacing them by "-".
+    hostname = re.sub("[{|}~[\\]^':; <=>?@!\"#$%`()+/.,*&]", "-", hostname)
     config.set_hostname(hostname)
 
     # Try to guess the timezone from '/etc/localtime', in case it's not

--- a/virtinst/install/unattended.py
+++ b/virtinst/install/unattended.py
@@ -15,6 +15,8 @@ import tempfile
 
 from gi.repository import Libosinfo
 
+from . import urlfetcher
+from .. import progress
 from ..logger import log
 
 
@@ -365,3 +367,18 @@ def prepare_install_scripts(guest, unattended_data,
         script.set_config(config)
         scripts.append(script)
     return scripts
+
+
+def download_drivers(locations, scratchdir, meter):
+    meter = progress.ensure_meter(meter)
+    fetcher = urlfetcher.DirectFetcher(None, scratchdir, meter)
+    fetcher.meter = meter
+
+    drivers = []
+
+    for location in locations:
+        filename = location.rsplit('/', 1)[1]
+        driver = fetcher.acquireFile(location)
+        drivers.append((driver, filename))
+
+    return drivers

--- a/virtinst/install/urlfetcher.py
+++ b/virtinst/install/urlfetcher.py
@@ -365,11 +365,13 @@ class _LocalURLFetcher(_URLFetcher):
     For grabbing files from a local directory
     """
     def _hasFile(self, url):
-        return os.path.exists(url)
+        parsed = urllib.parse.urlparse(url)
+        return os.path.exists(parsed.path)
 
     def _grabber(self, url):
-        urlobj = open(url, "rb")
-        size = os.path.getsize(url)
+        parsed = urllib.parse.urlparse(url)
+        urlobj = open(parsed.path, "rb")
+        size = os.path.getsize(parsed.path)
         return urlobj, size
 
 

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -732,6 +732,13 @@ class _OsVariant(object):
 
         return self._get_drivers_location(post_inst_drivers)
 
+    def get_pre_installable_devices(self, arch):
+        drivers = self._get_pre_installable_drivers(arch)
+        devices = []
+        for driver in drivers:
+            devices += list(_OsinfoIter(driver.get_devices()))
+        return devices
+
     def supports_unattended_drivers(self, arch):
         if self._get_pre_installable_drivers(arch):
             return True

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -576,7 +576,8 @@ class _OsVariant(object):
 
     def supports_chipset_q35(self, extra_devs=None):
         # For our purposes, check for the union of q35 + virtio1.0 support
-        if self.supports_virtionet() and not self.supports_virtio1():
+        if (self.supports_virtionet(extra_devs=extra_devs) and
+            not self.supports_virtio1(extra_devs=extra_devs)):
             return False
         devids = ["http://qemu.org/chipset/x86/q35"]
         return bool(self._device_filter(devids=devids, extra_devs=extra_devs))

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -431,7 +431,7 @@ class _OsVariant(object):
             return []
         return list(_OsinfoIter(self._os.get_all_devices()))
 
-    def _device_filter(self, devids=None, cls=None):
+    def _device_filter(self, devids=None, cls=None, extra_devs=None):
         ret = []
         devids = devids or []
         for dev in self._get_all_devices():
@@ -440,6 +440,13 @@ class _OsVariant(object):
             if cls and not re.match(cls, dev.get_class()):
                 continue
             ret.append(dev.get_name())
+
+        extra_devs = extra_devs or []
+        for dev in extra_devs:
+            if dev.get_id() not in devids:
+                continue
+            ret.append(dev.get_name())
+
         return ret
 
 

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -512,7 +512,7 @@ class _OsVariant(object):
     def supported_netmodels(self):
         return self._device_filter(cls="net")
 
-    def supports_usbtablet(self):
+    def supports_usbtablet(self, extra_devs=None):
         # If no OS specified, still default to tablet
         if not self._os:
             return True
@@ -520,37 +520,37 @@ class _OsVariant(object):
         devids = ["http://usb.org/usb/80ee/0021"]
         return bool(self._device_filter(devids=devids))
 
-    def supports_virtiodisk(self):
+    def supports_virtiodisk(self, extra_devs=None):
         # virtio-block and virtio1.0-block
         devids = ["http://pcisig.com/pci/1af4/1001",
                   "http://pcisig.com/pci/1af4/1042"]
         return bool(self._device_filter(devids=devids))
 
-    def supports_virtioscsi(self):
+    def supports_virtioscsi(self, extra_devs=None):
         # virtio-scsi and virtio1.0-scsi
         devids = ["http://pcisig.com/pci/1af4/1004",
                   "http://pcisig.com/pci/1af4/1048"]
         return bool(self._device_filter(devids=devids))
 
-    def supports_virtionet(self):
+    def supports_virtionet(self, extra_devs=None):
         # virtio-net and virtio1.0-net
         devids = ["http://pcisig.com/pci/1af4/1000",
                   "http://pcisig.com/pci/1af4/1041"]
         return bool(self._device_filter(devids=devids))
 
-    def supports_virtiorng(self):
+    def supports_virtiorng(self, extra_devs=None):
         # virtio-rng and virtio1.0-rng
         devids = ["http://pcisig.com/pci/1af4/1005",
                   "http://pcisig.com/pci/1af4/1044"]
         return bool(self._device_filter(devids=devids))
 
-    def supports_virtioballoon(self):
+    def supports_virtioballoon(self, extra_devs=None):
         # virtio-balloon and virtio1.0-balloon
         devids = ["http://pcisig.com/pci/1af4/1002",
                   "http://pcisig.com/pci/1af4/1045"]
         return bool(self._device_filter(devids=devids))
 
-    def supports_virtioserial(self):
+    def supports_virtioserial(self, extra_devs=None):
         devids = ["http://pcisig.com/pci/1af4/1003",
                   "http://pcisig.com/pci/1af4/1043"]
         if self._device_filter(devids=devids):
@@ -559,22 +559,22 @@ class _OsVariant(object):
         # Remove this hack after 6 months or so
         return self._is_related_to("rhel6.0")
 
-    def supports_virtioinput(self):
+    def supports_virtioinput(self, extra_devs=None):
         # virtio1.0-input
         devids = ["http://pcisig.com/pci/1af4/1052"]
         return bool(self._device_filter(devids=devids))
 
-    def supports_usb3(self):
+    def supports_usb3(self, extra_devs=None):
         # qemu-xhci
         devids = ["http://pcisig.com/pci/1b36/0004"]
         return bool(self._device_filter(devids=devids))
 
-    def supports_virtio1(self):
+    def supports_virtio1(self, extra_devs=None):
         # Use virtio1.0-net device as a proxy for virtio1.0 as a whole
         devids = ["http://pcisig.com/pci/1af4/1041"]
         return bool(self._device_filter(devids=devids))
 
-    def supports_chipset_q35(self):
+    def supports_chipset_q35(self, extra_devs=None):
         # For our purposes, check for the union of q35 + virtio1.0 support
         if self.supports_virtionet() and not self.supports_virtio1():
             return False

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -737,6 +737,11 @@ class _OsVariant(object):
             return True
         return False
 
+    def supports_unattended_agents(self, arch):
+        if self._get_post_installable_drivers(arch):
+            return True
+        return False
+
 
 class _OsMedia(object):
     def __init__(self, osinfo_media):

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -518,42 +518,42 @@ class _OsVariant(object):
             return True
 
         devids = ["http://usb.org/usb/80ee/0021"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def supports_virtiodisk(self, extra_devs=None):
         # virtio-block and virtio1.0-block
         devids = ["http://pcisig.com/pci/1af4/1001",
                   "http://pcisig.com/pci/1af4/1042"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def supports_virtioscsi(self, extra_devs=None):
         # virtio-scsi and virtio1.0-scsi
         devids = ["http://pcisig.com/pci/1af4/1004",
                   "http://pcisig.com/pci/1af4/1048"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def supports_virtionet(self, extra_devs=None):
         # virtio-net and virtio1.0-net
         devids = ["http://pcisig.com/pci/1af4/1000",
                   "http://pcisig.com/pci/1af4/1041"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def supports_virtiorng(self, extra_devs=None):
         # virtio-rng and virtio1.0-rng
         devids = ["http://pcisig.com/pci/1af4/1005",
                   "http://pcisig.com/pci/1af4/1044"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def supports_virtioballoon(self, extra_devs=None):
         # virtio-balloon and virtio1.0-balloon
         devids = ["http://pcisig.com/pci/1af4/1002",
                   "http://pcisig.com/pci/1af4/1045"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def supports_virtioserial(self, extra_devs=None):
         devids = ["http://pcisig.com/pci/1af4/1003",
                   "http://pcisig.com/pci/1af4/1043"]
-        if self._device_filter(devids=devids):
+        if self._device_filter(devids=devids, extra_devs=extra_devs):
             return True
         # osinfo data was wrong for RHEL/centos here until Oct 2018
         # Remove this hack after 6 months or so
@@ -562,24 +562,24 @@ class _OsVariant(object):
     def supports_virtioinput(self, extra_devs=None):
         # virtio1.0-input
         devids = ["http://pcisig.com/pci/1af4/1052"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def supports_usb3(self, extra_devs=None):
         # qemu-xhci
         devids = ["http://pcisig.com/pci/1b36/0004"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def supports_virtio1(self, extra_devs=None):
         # Use virtio1.0-net device as a proxy for virtio1.0 as a whole
         devids = ["http://pcisig.com/pci/1af4/1041"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def supports_chipset_q35(self, extra_devs=None):
         # For our purposes, check for the union of q35 + virtio1.0 support
         if self.supports_virtionet() and not self.supports_virtio1():
             return False
         devids = ["http://qemu.org/chipset/x86/q35"]
-        return bool(self._device_filter(devids=devids))
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
     def get_recommended_resources(self):
         minimum = self._os and self._os.get_minimum_resources() or None

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -733,8 +733,7 @@ class _OsVariant(object):
         return self._get_drivers_location(post_inst_drivers)
 
     def supports_unattended_drivers(self, arch):
-        if (self._get_pre_installable_drivers(arch) and
-            self._get_post_installable_drivers(arch)):
+        if self._get_pre_installable_drivers(arch):
             return True
         return False
 


### PR DESCRIPTION
Windows supports installing pre & post installable drivers. Pre installable drivers are useful in order to have the guest disk using virtio instead of sata. Post installable drivers are useful in order to have spice-guest-tools, which brings all virtio drivers plus the QXL driver.

In order to have this done, I've also changed the unattended and installer* classes so those would be able to deal with multiple install scripts, which is exactly the Windows case.