### PR TITLE
osdict: Always return the most generic tree

### DIFF
--- a/tests/osdict.py
+++ b/tests/osdict.py
@@ -52,10 +52,14 @@ class TestOSDB(unittest.TestCase):
 
     def test_tree_url(self):
         f26 = OSDB.lookup_os("fedora26")
+        f29 = OSDB.lookup_os("fedora29")
         winxp = OSDB.lookup_os("winxp")
 
         # Valid tree URL
         assert "fedoraproject.org" in f26.get_location("x86_64")
+
+        # Most generic tree URL
+        assert "Everything" in f29.get_location("x86_64")
 
         # Has tree URLs, but none for arch
         try:

--- a/tests/osdict.py
+++ b/tests/osdict.py
@@ -61,6 +61,10 @@ class TestOSDB(unittest.TestCase):
         # Most generic tree URL
         assert "Everything" in f29.get_location("x86_64")
 
+        # Specific tree
+        assert "Server" in f29.get_location("x86_64", "jeos")
+        assert "Workstation" in f29.get_location("x86_64", "desktop")
+
         # Has tree URLs, but none for arch
         try:
             f26.get_location("ia64")

--- a/virt-install
+++ b/virt-install
@@ -386,9 +386,9 @@ def show_warnings(options, guest, installer, osdata):
 # Guest building helpers #
 ##########################
 
-def get_location_for_os(guest, osname):
+def get_location_for_os(guest, osname, profile=None):
     osinfo = virtinst.OSDB.lookup_os(osname, raise_error=True)
-    location = osinfo.get_location(guest.os.arch)
+    location = osinfo.get_location(guest.os.arch, profile)
     print_stdout(_("Using {osname} --location {url}").format(
         osname=osname, url=location))
     return location
@@ -399,6 +399,7 @@ def build_installer(options, guest, installdata):
     location = None
     location_kernel = None
     location_initrd = None
+    unattended_data = None
     extra_args = options.extra_args
 
     install_bootdev = installdata.bootdev
@@ -413,8 +414,12 @@ def build_installer(options, guest, installdata):
         else:
             extra_args = [installdata.kernel_args]
 
+    if options.unattended:
+        unattended_data = cli.parse_unattended(options.unattended)
+
     if install_os:
-        location = get_location_for_os(guest, install_os)
+        profile = unattended_data.profile if unattended_data else None
+        location = get_location_for_os(guest, install_os, profile)
     elif options.location:
         (location,
          location_kernel,
@@ -443,8 +448,7 @@ def build_installer(options, guest, installdata):
             install_kernel_args=install_kernel_args,
             no_install=no_install)
 
-    if options.unattended:
-        unattended_data = cli.parse_unattended(options.unattended)
+    if unattended_data:
         installer.set_unattended_data(unattended_data)
     if extra_args:
         installer.set_extra_args(extra_args)

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -628,7 +628,11 @@ class _OsVariant(object):
             return None
 
         fallback_tree = None
-        if not profile:
+        if profile == "jeos":
+            profile = "Server"
+        elif profile == "desktop":
+            profile = "Workstation"
+        elif not profile:
             profile = "Everything"
 
         for tree in treelist:


### PR DESCRIPTION
Some OSes, as Fedora, have variants (which we rely to be standardised on
osinfo-db side), which we can use to return the most generic tree
possible, in case no profile is specified, in order to avoid failing to
install a "Workstation" system because a "Server" variant tree was used.

https://bugzilla.redhat.com/show_bug.cgi?id=1749865

NOTE: We **may** want to use the appropriate tree in the future as in using a Workstation tree for desktop installations or a Server tree for jeos installations. However, for now, let's not try to solve this issue as the "Everything" tree is a good enough fallback.