### PR TITLE
Support "bochs" display

### DIFF
--- a/virtManager/addhardware.py
+++ b/virtManager/addhardware.py
@@ -663,7 +663,7 @@ class vmmAddHardware(vmmGObjectUI):
         if guest.conn.is_xen():
             return ["xen", "vga"]
         if guest.conn.is_qemu() or guest.conn.is_test():
-            return ["vga", "qxl", "virtio"]
+            return ["vga", "bochs", "qxl", "virtio"]
         return []
 
     @staticmethod

--- a/virtinst/devices/video.py
+++ b/virtinst/devices/video.py
@@ -39,6 +39,9 @@ class DeviceVideo(Device):
             if guest.has_gl():
                 return "virtio"
             return "qxl"
+        if (guest.is_uefi() and
+            guest.lookup_domcaps().supports_video_bochs()):
+            return "bochs"
         if guest.conn.is_qemu():
             return "qxl"
         return "vga"

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -95,6 +95,7 @@ class _Devices(_CapsBlock):
     XML_NAME = "devices"
     hostdev = XMLChildProperty(_make_capsblock("hostdev"), is_single=True)
     disk = XMLChildProperty(_make_capsblock("disk"), is_single=True)
+    video = XMLChildProperty(_make_capsblock("video"), is_single=True)
 
 
 class _Features(_CapsBlock):

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -325,6 +325,14 @@ class DomainCapabilities(XMLBuilder):
         """
         return bool(self.features.sev.supported)
 
+    def supports_video_bochs(self):
+        """
+        Returns False if either libvirt or qemu do not have support to bochs
+        video type.
+        """
+        models = self.devices.video.get_enum("modelType").get_values()
+        return bool("bochs" in models)
+
     XML_NAME = "domainCapabilities"
     os = XMLChildProperty(_OS, is_single=True)
     cpu = XMLChildProperty(_CPU, is_single=True)


### PR DESCRIPTION
This series **tries** to add support to "bochs" display. Emphasis on tries as the code path where it'd be used is never ever triggered, as expressed in the commit message.

"bochs" display has also been added to virt-manager "Add Hardware" UI.

Note: In a conversation with Cole, we agreed that virt-install should revisit the video defaults in the near future in order to be aligned with Gerd's recommendations, present as part of this blog post https://www.kraxel.org/blog/2019/09/display-devices-in-qemu/ ... However, that's a different PR material.