### PR TITLE
Add "user-login" option for unattended installation

### DIFF
--- a/man/virt-install.pod
+++ b/man/virt-install.pod
@@ -628,12 +628,18 @@ password-file.
 Note that only the first line of the file will be considered, including
 any whitespace characters and excluding new-line.
 
+=item B<user-login=>
+
+The user login name to be used in th VM. virt-install will default to your
+current host username if this is unspecified.
+
 =item B<user-password-file=>
 
 A file used to set the VM user password. This option can be used either as
 "user-password-file=/path/to/password-file" or as
 "user-password-file=/dev/fd/n", being n the file descriptor of the
-password-file. The username is your current host username.
+password-file. The username is either the user-login specified or your current
+host username.
 Note that only the first line of the file will be considered, including
 any whitespace characters and excluding new-line.
 

--- a/man/virt-install.pod
+++ b/man/virt-install.pod
@@ -632,6 +632,7 @@ any whitespace characters and excluding new-line.
 
 The user login name to be used in th VM. virt-install will default to your
 current host username if this is unspecified.
+Note that when running virt-install as "root", this option must be specified.
 
 =item B<user-password-file=>
 

--- a/tests/clitest.py
+++ b/tests/clitest.py
@@ -900,6 +900,8 @@ c.add_invalid("--os-variant fedora29 --unattended profile=desktop,admin-password
 c.add_invalid("--os-variant msdos --unattended profile=desktop --location http://example.com")  # msdos doesn't support unattended install
 c.add_invalid("--os-variant winxp --unattended profile=desktop --cdrom %(ISO-WIN7)s")  # winxp doesn't support expected injection method 'cdrom'
 c.add_invalid("--connect %(URI-TEST-REMOTE)s --os-variant win7 --cdrom %(EXISTIMG1)s --unattended")  # --unattended method=cdrom rejected for remote connections
+c.add_invalid("--install fedora29 --unattended user-login=root", grep="as user-login") # will trigger an invalid user-login error
+c.add_invalid("--cdrom %(ISO-WIN7)s --unattended user-login=Administrator", grep="as user-login") # will trigger an invalid user-login error
 
 
 #############################

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -1514,6 +1514,7 @@ class ParserUnattended(VirtCLIParser):
         VirtCLIParser._init_class(**kwargs)
         cls.add_arg("profile", "profile")
         cls.add_arg("admin-password-file", "admin_password_file")
+        cls.add_arg("user-login", "user_login")
         cls.add_arg("user-password-file", "user_password_file")
         cls.add_arg("product-key", "product_key")
 

--- a/virtinst/install/unattended.py
+++ b/virtinst/install/unattended.py
@@ -36,9 +36,14 @@ def _make_installconfig(script, osobj, unattended_data, arch, hostname, url):
 
     config = Libosinfo.InstallConfig()
 
-    # Set user login and name based on the one from the system
-    config.set_user_login(getpass.getuser())
-    config.set_user_realname(pwd.getpwnam(getpass.getuser()).pw_gecos)
+    # Set user login and name
+    # In case it's specified via command-line, use the specified one as login
+    # and realname. Otherwise, fallback fto the one from the system
+    login = unattended_data.user_login or getpass.getuser()
+    login = login.lower()
+    realname = unattended_data.user_login or pwd.getpwnam(login).pw_gecos
+    config.set_user_login(login)
+    config.set_user_realname(realname)
 
     # Set user-password.
     # In case it's required and not passed, just raise a RuntimeError.
@@ -252,6 +257,7 @@ class OSInstallScript:
 class UnattendedData():
     profile = None
     admin_password_file = None
+    user_login = None
     user_password_file = None
     product_key = None
 


### PR DESCRIPTION
This series adds the possibility to pass "user-login" option when doing an unattended installation. Together with this change, we have to restrict the names used in order to avoid user reserved names (as root, administrator and a few other forbidden names for Windows).

This seems to be a reasonable solution for the case when an admin decides to run an unattended installation using either sudo or root, and the user set for the VM would be "root" ... breaking then the installation process for the most part of the distros (if not all).