### PR TITLE
virtinst: fix detection if baselineHypervisorCPU API is available

### DIFF
--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -278,7 +278,7 @@ class DomainCapabilities(XMLBuilder):
             expandedXML = self.conn.baselineHypervisorCPU(
                     self.path, self.arch, self.machine, self.domain, [cpuXML],
                     libvirt.VIR_CONNECT_BASELINE_CPU_EXPAND_FEATURES)
-        except libvirt.libvirtError:
+        except (libvirt.libvirtError, AttributeError):
             expandedXML = self.conn.baselineCPU([cpuXML],
                     libvirt.VIR_CONNECT_BASELINE_CPU_EXPAND_FEATURES)
 


### PR DESCRIPTION
With libvirt-python >= 4.4.0 and libvirt < 4.4.0 we would receive
libvirt.libvirtError exception because the python binding knows about
the function but it's not supported by libvirt.  However, in case that
the python binding is older then 4.4.0 it will raise AttributeError
because the function is not implemented in python binding as well.

Signed-off-by: Pavel Hrdina <phrdina@redhat.com>

Fixes #57 