### PR TITLE
installertreemedia: Respect --os-variant

### DIFF
--- a/virt-install
+++ b/virt-install
@@ -531,13 +531,16 @@ def set_explicit_guest_options(options, guest):
 
 def installer_detect_distro(guest, installer, osdata):
     try:
+        # OS name has to be set firstly whenever --os-variant is passed,
+        # otherwise it won't be respected when the installer creates the
+        # Distro Store.
+        if osdata.name:
+            guest.set_os_name(osdata.name)
+
         # This also validates the install location
         autodistro = installer.detect_distro(guest)
-        name = osdata.name
-        if osdata.is_auto:
-            name = autodistro
-        if name:
-            guest.set_os_name(name)
+        if osdata.is_auto and autodistro:
+            guest.set_os_name(autodistro)
     except ValueError as e:
         fail(_("Error validating install location: %s") % str(e))
 


### PR DESCRIPTION
**Problem**: When calling virt-install, explicitly passing `--os-variant`, depending on the `--location` used virt-install will consider the distro a "Generic" one and will **not** respect the passed `--os-variant` argument, resulting on a broken kernel command line (at least).

**Reproducer**:
```
./virt-install -r 4096 -n centos8-foobar  -w bridge=virbr0 --disk pool=default,size=10   --os-variant=rhel7.7 --location https://mirrors.mit.edu/cen
tos/8-stream/BaseOS/x86_64/os/ --extra-args='console=tty0 console=ttyS0,57600' --debug --dry-run
```
When using the reproducer above, you'll notice that inst.repo=$location_url will **not** be set.

**Notes**: Setting the os-variant seems to be quite (if not too much) tied to the guest / installer codes, which is not so easy to understand. Maybe there's a way simpler way to solve the issue and I'm more than happy on just dropping the patch in favour of a cleaner approach. However, this patch (which, IMHO, looks a little bit too hack-ish) was the best I could come up with.