### PR TITLE
unattended: Never use "root" as user-login

### DIFF
--- a/man/virt-install.pod
+++ b/man/virt-install.pod
@@ -632,6 +632,7 @@ any whitespace characters and excluding new-line.
 
 The user login name to be used in th VM. virt-install will default to your
 current host username if this is unspecified.
+Note that when running virt-install as "root", this option must be specified.
 
 =item B<user-password-file=>
 

--- a/tests/clitest.py
+++ b/tests/clitest.py
@@ -900,6 +900,7 @@ c.add_invalid("--os-variant fedora29 --unattended profile=desktop,admin-password
 c.add_invalid("--os-variant msdos --unattended profile=desktop --location http://example.com")  # msdos doesn't support unattended install
 c.add_invalid("--os-variant winxp --unattended profile=desktop --cdrom %(ISO-WIN7)s")  # winxp doesn't support expected injection method 'cdrom'
 c.add_invalid("--connect %(URI-TEST-REMOTE)s --os-variant win7 --cdrom %(EXISTIMG1)s --unattended")  # --unattended method=cdrom rejected for remote connections
+c.add_invalid("--install fedora29 --unattended user-login=root", grep="as user-login") # will trigger an invalid user-login error
 
 
 #############################

--- a/virtinst/install/unattended.py
+++ b/virtinst/install/unattended.py
@@ -34,6 +34,9 @@ def _make_installconfig(script, osobj, unattended_data, arch, hostname, url):
     def get_language():
         return locale.getlocale()[0]
 
+    def is_user_login_safe(login):
+        return login != "root"
+
     config = Libosinfo.InstallConfig()
 
     # Set user login and name
@@ -41,6 +44,10 @@ def _make_installconfig(script, osobj, unattended_data, arch, hostname, url):
     # and realname. Otherwise, fallback fto the one from the system
     login = unattended_data.user_login or getpass.getuser()
     login = login.lower()
+    if not is_user_login_safe(login):
+        raise RuntimeError(
+            _("%s cannot use '%s' as user-login.") % (login, osobj.name))
+
     realname = unattended_data.user_login or pwd.getpwnam(login).pw_gecos
     config.set_user_login(login)
     config.set_user_realname(realname)


### PR DESCRIPTION
When running virt-install as root, user-login would be automatically set
to "root", causing an installation failure in the most part of the
distros (if not all of them).

In order to avoid such failures, let's raise a runtime error in case the
user-login used is "root".

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>