### PR TITLE
virtManager: disambiguize LXC

### DIFF
--- a/po/as.po
+++ b/po/as.po
@@ -1373,10 +1373,6 @@ msgstr "সংযোগ ডাইলগ আৰম্ভ কৰোতে ত্�
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "দূৰৱৰ্তী সংযোগসমূহৰ বাবে এটা হস্টনামৰ প্ৰয়োজন।"

--- a/po/bg.po
+++ b/po/bg.po
@@ -1299,10 +1299,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -1377,10 +1377,6 @@ msgstr "সংযোগের ডায়লগ প্রদর্শন করত
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "দূরবর্তী সংযোগের জন্য হোস্ট-নেম আবশ্যক।"

--- a/po/bs.po
+++ b/po/bs.po
@@ -1297,10 +1297,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -1411,10 +1411,6 @@ msgstr "Error en llançar el diàleg de connexió: %s"
 msgid "user session"
 msgstr "sessió d'usuari"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Contenidors Linux"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Es requereix un nom d'amfitrió per a les connexions remotes."

--- a/po/cmn.po
+++ b/po/cmn.po
@@ -1293,10 +1293,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -1423,10 +1423,6 @@ msgstr "Chyba při spouštění dialogu připojení: %s"
 msgid "user session"
 msgstr "uživatelská relace"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Linuxové kontejnery"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Pro připojení na dálku je zapotřebí název hostitele."

--- a/po/da.po
+++ b/po/da.po
@@ -1308,10 +1308,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Et værtsnavn er påkrævet for fjernforbindelser."

--- a/po/de.po
+++ b/po/de.po
@@ -1420,10 +1420,6 @@ msgstr "Fehler beim Starten des Verbindungsdialogs: %s"
 msgid "user session"
 msgstr "Benutzer-Session"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Linux Container"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Ein Rechnername wird für die entfernte Verbindung benötigt. "

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1383,10 +1383,6 @@ msgstr "Error launching connect dialogue: %s"
 msgid "user session"
 msgstr "user session"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Linux Containers"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "A hostname is required for remote connections."

--- a/po/es.po
+++ b/po/es.po
@@ -1428,10 +1428,6 @@ msgstr "Error al lanzar diálogo de conexión: %s "
 msgid "user session"
 msgstr "sesión de usuario"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Contenedores Linux"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Es necesario un nombre de equipo para conexiones remotas."

--- a/po/fi.po
+++ b/po/fi.po
@@ -1326,10 +1326,6 @@ msgstr "Virhe käynnistäessä yhteysikkunaa: %s"
 msgid "user session"
 msgstr "käyttäjäistunto"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Linux-säiliöt"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -1439,10 +1439,6 @@ msgstr "Erreur lors du lancement de la boîte de dialogue de connexion : %s"
 msgid "user session"
 msgstr "session utilisateur"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Conteneurs Linux"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Un nom d’hôte est requis pour les connexions distantes."

--- a/po/gu.po
+++ b/po/gu.po
@@ -1345,10 +1345,6 @@ msgstr "સંવાદને જોડવાનુ શરૂ કરતી વ�
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "યજમાનનામ દૂરસ્ત જોડાણો માટે જરૂરી છે."

--- a/po/hi.po
+++ b/po/hi.po
@@ -1326,10 +1326,6 @@ msgstr "कनेक्ट संवाद शुभारंभ में त�
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "मेजबाननाम दूरस्थ के कनेक्शन के लिए आवश्यक है."

--- a/po/hr.po
+++ b/po/hr.po
@@ -1299,10 +1299,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -1348,10 +1348,6 @@ msgstr "Hiba a kapcsolódás párbeszédablak indításakor: %s"
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Kiszolgálónév szükséges a távoli kapcsolatokhoz."

--- a/po/is.po
+++ b/po/is.po
@@ -1296,10 +1296,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -1410,10 +1410,6 @@ msgstr "Errore nell'avvio della finestra della connessione: %s"
 msgid "user session"
 msgstr "sessione utente"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Contenitori Linux"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Il nome host è obbligatorio per connessioni remote."

--- a/po/ja.po
+++ b/po/ja.po
@@ -1421,10 +1421,6 @@ msgstr "接続ダイアログを表示する際にエラーが発生しました
 msgid "user session"
 msgstr "ユーザーセッション"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Linux コンテナー"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "リモート接続を行うにはホスト名が必要です。"

--- a/po/kn.po
+++ b/po/kn.po
@@ -1387,10 +1387,6 @@ msgstr "ಸಂಪರ್ಕದ ಸಂವಾದ ಚೌಕವನ್ನು ಆರಂ
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "ದೂರಸ್ಥ ಸಂಪರ್ಕಗಳಿಗೆ ಆತಿಥೇಯ ಗಣಕದ ಹೆಸರಿನ ಅಗತ್ಯವಿರುತ್ತದೆ."

--- a/po/ko.po
+++ b/po/ko.po
@@ -1381,10 +1381,6 @@ msgstr "연결 대화를 시작하는 도중 오류 발생: %s"
 msgid "user session"
 msgstr "사용자 세션"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Linux 컨테이너"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "원격 연결을 위해 호스트 이름이 필요합니다."

--- a/po/ml.po
+++ b/po/ml.po
@@ -1328,10 +1328,6 @@ msgstr "കണക്ട് ഡയലോഗ് ലഭ്യമാക്കുന�
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "റിമോട്ട് കണക്ഷനുകള്‍ക്കായി ഒരു ഹോസ്റ്റ്നാമം ആവശ്യമുണ്ടു്."

--- a/po/mr.po
+++ b/po/mr.po
@@ -1371,10 +1371,6 @@ msgstr "जोडणी संवाद सुरू करतेवेळी �
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "रिमोट जोडणीकरीता यजमाननाव आवश्यक आहे."

--- a/po/ms.po
+++ b/po/ms.po
@@ -1296,10 +1296,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -1296,10 +1296,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -1335,10 +1335,6 @@ msgstr "Fout bij lanceren van verbinding dialoog: %s"
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Een host naam wordt vereist voor verbindingen op afstand."

--- a/po/or.po
+++ b/po/or.po
@@ -1326,10 +1326,6 @@ msgstr "ସଂଯୁକ୍ତ ସଂଳାପକୁ ଆରମ୍ଭ କରିବ
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "ସୁଦୂର ସଂଯୋଗଗୁଡ଼ିକ ପାଇଁ ହୋଷ୍ଟନାମ ଆବଶ୍ୟକ।"

--- a/po/pa.po
+++ b/po/pa.po
@@ -1330,10 +1330,6 @@ msgstr "ਕੁਨੈਕਟ ਡਾਇਲਾਗ ਚਲਾਉਣ ਤੇ ਗਲਤ�
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "ਰਿਮੋਟ ਕੁਨੈਕਸ਼ਨ ਲਈ ਹੋਸਟ-ਨਾਂ ਲੋੜੀਂਦਾ ਹੈ।"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1424,10 +1424,6 @@ msgstr "Błąd podczas uruchamiania okna dialogowego łączenia: %s"
 msgid "user session"
 msgstr "sesja użytkownika"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Kontenery systemu Linux"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Wymagana jest nazwa gospodarza dla zdalnych połączeń."

--- a/po/pt.po
+++ b/po/pt.po
@@ -1404,10 +1404,6 @@ msgstr "Erro ao lançar o diálogo de conexão: %s"
 msgid "user session"
 msgstr "sessão de utilizador"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Contentores Linux"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Um hostname é necessário para conexões remotas."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1425,10 +1425,6 @@ msgstr "Erro ao lançar o diálogo de conexão: %s"
 msgid "user session"
 msgstr "sessão do usuário"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Recipientes Linux "
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Um hostname é necessário para criar conexões remotas."

--- a/po/ro.po
+++ b/po/ro.po
@@ -1298,10 +1298,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -1414,10 +1414,6 @@ msgstr "Ошибка запуска диалога «Соединение»: %s"
 msgid "user session"
 msgstr "сеанс пользователя"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Контейнеры Linux"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Для удаленного подключения необходимо указать имя узла."

--- a/po/sk.po
+++ b/po/sk.po
@@ -1330,10 +1330,6 @@ msgstr ""
 msgid "user session"
 msgstr "používateľská relácia"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Pre vzdialené pripojenia je vyžadovaný názov hostiteľa."

--- a/po/sr.po
+++ b/po/sr.po
@@ -1316,10 +1316,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1304,10 +1304,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -1393,10 +1393,6 @@ msgstr "Fel vid start av anslutningsdialogen: %s"
 msgid "user session"
 msgstr "användarsession"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Linuxbehållare"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Ett värdnamn krävs för fjärranslutningar."

--- a/po/ta.po
+++ b/po/ta.po
@@ -1391,10 +1391,6 @@ msgstr "இணைத்தல் உரையாடலை துவக்கு�
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "தொலைநிலை இணைப்புகளுக்கு வழங்கி பெயர் தேவை."

--- a/po/te.po
+++ b/po/te.po
@@ -1362,10 +1362,6 @@ msgstr "అనుసంధానం డైలాగ్ ఆరంభించు�
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "రిమోట్ అనుసంధానముల కొరకు అతిథేయిపేరు అవసరమైంది."

--- a/po/tr.po
+++ b/po/tr.po
@@ -1330,10 +1330,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Uzaktan bağlantılar için ana makine adı girilmesi gereklidir."

--- a/po/uk.po
+++ b/po/uk.po
@@ -1435,10 +1435,6 @@ msgstr "Помилка під час спроби відкриття діало�
 msgid "user session"
 msgstr "сеанс користувача"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Контейнери Linux"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "Для встановлення віддалених з’єднань слід вказати назву вузла."

--- a/po/vi.po
+++ b/po/vi.po
@@ -1293,10 +1293,6 @@ msgstr ""
 msgid "user session"
 msgstr ""
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr ""
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1367,10 +1367,6 @@ msgstr "启动连接对话出错：%s"
 msgid "user session"
 msgstr "用户会话"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Linux 容器"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "远程连接需要主机名。"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1323,10 +1323,6 @@ msgstr "啟動連線對話視窗時發生錯誤：%s"
 msgid "user session"
 msgstr "使用者 session"
 
-#: ../virtManager/createconn.py:119
-msgid "Linux Containers"
-msgstr "Linux 容器"
-
 #: ../virtManager/createconn.py:241
 msgid "A hostname is required for remote connections."
 msgstr "遠端連線需要主機名稱。"

--- a/virtManager/createconn.py
+++ b/virtManager/createconn.py
@@ -116,7 +116,7 @@ class vmmCreateConn(vmmGObjectUI):
         _add_hv_row(HV_QEMU, "qemu", "QEMU/KVM")
         _add_hv_row(HV_QEMU_SESSION, "qemu", "QEMU/KVM " + _("user session"))
         _add_hv_row(HV_XEN, "xen", "Xen")
-        _add_hv_row(HV_LXC, "lxc", "LXC (" + _("Linux Containers") + ")")
+        _add_hv_row(HV_LXC, "lxc", "Libvirt-LXC (" + _("Linux Containers") + ")")
         _add_hv_row(HV_BHYVE, "bhyve", "Bhyve")
         _add_hv_row(HV_VZ, "vz", "Virtuozzo")
         _add_hv_row(-1, None, "")

--- a/virtManager/createconn.py
+++ b/virtManager/createconn.py
@@ -116,7 +116,7 @@ class vmmCreateConn(vmmGObjectUI):
         _add_hv_row(HV_QEMU, "qemu", "QEMU/KVM")
         _add_hv_row(HV_QEMU_SESSION, "qemu", "QEMU/KVM " + _("user session"))
         _add_hv_row(HV_XEN, "xen", "Xen")
-        _add_hv_row(HV_LXC, "lxc", "Libvirt-LXC (" + _("Linux Containers") + ")")
+        _add_hv_row(HV_LXC, "lxc", "Libvirt-LXC")
         _add_hv_row(HV_BHYVE, "bhyve", "Bhyve")
         _add_hv_row(HV_VZ, "vz", "Virtuozzo")
         _add_hv_row(-1, None, "")


### PR DESCRIPTION
LXC can be many things and in particular when seeing just "LXC" in the
virt-manager UI one might think of either
- Libvirt-LXC => https://libvirt.org/drvlxc.html
- Linuxcontainers LXC => https://linuxcontainers.org

Especially with the "Linux Containers" that follows in brackets that is misleading. Lets get rid of this ambiguity and name the backend clearly to be the former and not the latter.

This change is in [Ubuntu since 2015](https://git.launchpad.net/ubuntu/+source/virt-manager/tree/debian/patches/mark-libvirt-lxc.patch?h=applied/ubuntu/focal-devel) so it might have been discussed (and denied?) in another context already. I feel like even I might have discussed it once, but too long ago to remember or find it.
Never the less I think this is helpful to the users in general so lets try (again?)