### PR TITLE
installerinject: Check for genisoimage and mkisofs before calling it

### DIFF
--- a/virtinst/install/installerinject.py
+++ b/virtinst/install/installerinject.py
@@ -45,7 +45,15 @@ def _run_initrd_commands(initrd, tempdir):
 
 
 def _run_iso_commands(iso, tempdir, cloudinit=False):
-    cmd = ["genisoimage",
+    # Some distros do not link mkisofs to genisoimage (or vice-versa). As a
+    # result of this, we have to actually check for both programs and use the
+    # most appropriate one.
+    programs = ["genisoimage", "mkisofs"]
+    for program in programs:
+        if shutil.which(program):
+            break
+
+    cmd = [program,
            "-o", iso,
            "-J",
            "-input-charset", "utf8",


### PR DESCRIPTION
Let's check for both genisoimage and mkisofs as some distros will ship
mkisofs without linking it to genisoimage, as OpenSUSE Leap 15.1 does.

And, I know, genisoimage is a requirement of the project. However, it's
not packaged on OpenSUSE Leap 15.1 while mkisofs is present there.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>