### PR TITLE
Pass vmmDetails's remove_device function to vmmDeleteStorage

### DIFF
--- a/virtManager/delete.py
+++ b/virtManager/delete.py
@@ -359,7 +359,7 @@ class vmmDeleteStorage(_vmmDeleteBase):
 
     def _delete_disks(self, vm, paths, conn, meter):
         storage_errors = []
-        vm.remove_device(self.disk)
+        vmmDeleteStorage.remove_devobj_internal(vm, self.err, self.disk)
         if paths:
             super()._delete_disks(vm, paths, conn, meter)
         return storage_errors

--- a/virtManager/details/details.py
+++ b/virtManager/details/details.py
@@ -1925,8 +1925,7 @@ class vmmDetails(vmmGObjectUI):
                                           kwargs, self.vm, self.err,
                                           devobj=devobj)
 
-    # Device removal
-    def remove_device(self, devobj):
+    def remove_devobj_internal(self, devobj):
         log.debug("Removing device: %s", devobj)
 
         # Define the change
@@ -1946,8 +1945,7 @@ class vmmDetails(vmmGObjectUI):
             detach_err = (str(e), "".join(traceback.format_exc()))
 
         if not detach_err:
-            self.disable_apply()
-            return
+            return True
 
         self.err.show_err(
             _("Device could not be removed from the running machine"),
@@ -1956,6 +1954,12 @@ class vmmDetails(vmmGObjectUI):
                     "shutdown."),
             buttons=Gtk.ButtonsType.OK,
             dialog_type=Gtk.MessageType.INFO)
+
+    # Device removal
+    def remove_device(self, devobj):
+        success = self.remove_devobj_internal(devobj)
+        if success:
+            self.disable_apply()
 
     #######################
     # vmwindow Public API #

--- a/virtManager/details/details.py
+++ b/virtManager/details/details.py
@@ -27,6 +27,7 @@ from ..lib.graphwidgets import Sparkline
 from ..oslist import vmmOSList
 from ..storagebrowse import vmmStorageBrowser
 from ..xmleditor import vmmXMLEditor
+from ..delete import vmmDeleteStorage
 
 
 # Parameters that can be edited in the details window
@@ -1109,7 +1110,6 @@ class vmmDetails(vmmGObjectUI):
         self.remove_device(devobj)
 
     def remove_disk(self, disk):
-        from ..delete import vmmDeleteStorage
         dialog = vmmDeleteStorage(disk)
         dialog.show(self.topwin, self.vm)
 
@@ -1925,39 +1925,9 @@ class vmmDetails(vmmGObjectUI):
                                           kwargs, self.vm, self.err,
                                           devobj=devobj)
 
-    def remove_devobj_internal(self, vm, err, devobj):
-        log.debug("Removing device: %s", devobj)
-
-        # Define the change
-        try:
-            vm.remove_device(devobj)
-        except Exception as e:
-            err.show_err(_("Error Removing Device: %s") % str(e))
-            return
-
-        # Try to hot remove
-        detach_err = ()
-        try:
-            if vm.is_active():
-                vm.detach_device(devobj)
-        except Exception as e:
-            log.debug("Device could not be hotUNplugged: %s", str(e))
-            detach_err = (str(e), "".join(traceback.format_exc()))
-
-        if not detach_err:
-            return True
-
-        err.show_err(
-            _("Device could not be removed from the running machine"),
-            details=(detach_err[0] + "\n\n" + detach_err[1]),
-            text2=_("This change will take effect after the next guest "
-                    "shutdown."),
-            buttons=Gtk.ButtonsType.OK,
-            dialog_type=Gtk.MessageType.INFO)
-
     # Device removal
     def remove_device(self, devobj):
-        success = self.remove_devobj_internal(self.vm, self.err, devobj)
+        success = vmmDeleteStorage.remove_devobj_internal(self.vm, self.err, devobj)
         if success:
             self.disable_apply()
 

--- a/virtManager/details/details.py
+++ b/virtManager/details/details.py
@@ -1925,21 +1925,21 @@ class vmmDetails(vmmGObjectUI):
                                           kwargs, self.vm, self.err,
                                           devobj=devobj)
 
-    def remove_devobj_internal(self, devobj):
+    def remove_devobj_internal(self, vm, err, devobj):
         log.debug("Removing device: %s", devobj)
 
         # Define the change
         try:
-            self.vm.remove_device(devobj)
+            vm.remove_device(devobj)
         except Exception as e:
-            self.err.show_err(_("Error Removing Device: %s") % str(e))
+            err.show_err(_("Error Removing Device: %s") % str(e))
             return
 
         # Try to hot remove
         detach_err = ()
         try:
-            if self.vm.is_active():
-                self.vm.detach_device(devobj)
+            if vm.is_active():
+                vm.detach_device(devobj)
         except Exception as e:
             log.debug("Device could not be hotUNplugged: %s", str(e))
             detach_err = (str(e), "".join(traceback.format_exc()))
@@ -1947,7 +1947,7 @@ class vmmDetails(vmmGObjectUI):
         if not detach_err:
             return True
 
-        self.err.show_err(
+        err.show_err(
             _("Device could not be removed from the running machine"),
             details=(detach_err[0] + "\n\n" + detach_err[1]),
             text2=_("This change will take effect after the next guest "
@@ -1957,7 +1957,7 @@ class vmmDetails(vmmGObjectUI):
 
     # Device removal
     def remove_device(self, devobj):
-        success = self.remove_devobj_internal(devobj)
+        success = self.remove_devobj_internal(self.vm, self.err, devobj)
         if success:
             self.disable_apply()
 


### PR DESCRIPTION
the remove_device function in vmmDetails handles more things than vm.remove_device.
We should call it first before performing the storage deletion.