### PR TITLE
unattended: Add reg-login option to --unattended

### DIFF
--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -1496,6 +1496,7 @@ class ParserUnattended(VirtCLIParser):
         cls.add_arg("user-login", "user_login")
         cls.add_arg("user-password-file", "user_password_file")
         cls.add_arg("product-key", "product_key")
+        cls.add_arg("reg-login", "reg_login")
 
 
 def parse_unattended(optstr):

--- a/virtinst/install/unattended.py
+++ b/virtinst/install/unattended.py
@@ -119,6 +119,9 @@ def _make_installconfig(script, osobj, unattended_data, arch, hostname, url):
     if url:
         config.set_installation_url(url)  # pylint: disable=no-member
 
+    if unattended_data.reg_login:
+        config.set_reg_login(unattended_data.reg_login)
+
     if unattended_data.product_key:
         config.set_reg_product_key(unattended_data.product_key)
 
@@ -134,6 +137,7 @@ def _make_installconfig(script, osobj, unattended_data, arch, hostname, url):
     if hasattr(config, "get_installation_url"):
         log.debug("url: %s",
                 config.get_installation_url())  # pylint: disable=no-member
+    log.debug("reg-login %s", config.get_reg_login())
     log.debug("product-key: %s", config.get_reg_product_key())
 
     return config
@@ -274,6 +278,7 @@ class UnattendedData():
     user_login = None
     user_password_file = None
     product_key = None
+    reg_login = None
 
     def _get_password(self, pwdfile):
         with open(pwdfile, "r") as fobj:


### PR DESCRIPTION
As osinfo-db introduced the first usage of reg-login, let's also
add support for such option when using --unattended.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>

NOTE: This is the osinfo-db commit which adds the first usage of reg-login: https://gitlab.com/libosinfo/osinfo-db/merge_requests/87
The API has been there forever, but not being used.