### PR TITLE
tpm: add SPAPR (ppc64) device model

### DIFF
--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -196,6 +196,9 @@
         <encryption secret="11111111-2222-3333-4444-5555555555"/>
       </backend>
     </tpm>
+    <tpm model="tpm-spapr">
+      <backend type="emulator" version="2.0"/>
+    </tpm>
     <graphics type="vnc" port="-1"/>
     <video>
       <model type="bochs"/>
@@ -436,6 +439,9 @@
         <device path="/dev/tpm0"/>
         <encryption secret="11111111-2222-3333-4444-5555555555"/>
       </backend>
+    </tpm>
+    <tpm model="tpm-spapr">
+      <backend type="emulator" version="2.0"/>
     </tpm>
     <graphics type="vnc" port="-1"/>
     <video>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -707,6 +707,7 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --vsock cid=17
 
 --tpm emulator,model=tpm-crb,version=2.0
+--tpm emulator,model=tpm-spapr,version=2.0
 
 --qemu-commandline env=DISPLAY=:0.1
 --qemu-commandline="-display gtk,gl=on"

--- a/virtManager/addhardware.py
+++ b/virtManager/addhardware.py
@@ -207,7 +207,7 @@ class vmmAddHardware(vmmGObjectUI):
         self.build_watchdogaction_combo(self.vm, self.widget("watchdog-action"))
         self.build_smartcard_mode_combo(self.vm, self.widget("smartcard-mode"))
         self._build_redir_type_combo()
-        self._build_tpm_type_combo()
+        self._build_tpm_type_combo(self.vm)
         self._build_panic_model_combo()
         _build_combo(self.widget("controller-model"), [])
         self._build_controller_type_combo()
@@ -551,6 +551,8 @@ class vmmAddHardware(vmmGObjectUI):
             return _("TIS")
         if tpm_model == DeviceTpm.MODEL_CRB:
             return _("CRB")
+        if tpm_model == DeviceTpm.MODEL_SPAPR:
+            return _("SPAPR")
         return tpm_model
 
     @staticmethod
@@ -901,13 +903,13 @@ class vmmAddHardware(vmmGObjectUI):
         _build_combo(self.widget("usbredir-list"), values)
 
 
-    def _build_tpm_type_combo(self):
+    def _build_tpm_type_combo(self, vm):
         values = []
         for t in DeviceTpm.TYPES:
             values.append([t, vmmAddHardware.tpm_pretty_type(t)])
         _build_combo(self.widget("tpm-type"), values)
         values = []
-        for t in DeviceTpm.MODELS:
+        for t in vmmAddHardware._get_tpm_model_list(vm, None):
             values.append([t, vmmAddHardware.tpm_pretty_model(t)])
         _build_combo(self.widget("tpm-model"), values)
         values = []
@@ -920,9 +922,12 @@ class vmmAddHardware(vmmGObjectUI):
     def _get_tpm_model_list(vm, tpmversion):
         mod_list = []
         if vm.is_hvm():
-            mod_list.append("tpm-tis")
-            if tpmversion != '1.2':
-                mod_list.append("tpm-crb")
+            if vm.xmlobj.os.is_pseries():
+                mod_list.append("tpm-spapr")
+            else:
+                mod_list.append("tpm-tis")
+                if tpmversion == None or tpmversion != '1.2':
+                    mod_list.append("tpm-crb")
             mod_list.sort()
         return mod_list
 

--- a/virtinst/devices/tpm.py
+++ b/virtinst/devices/tpm.py
@@ -22,7 +22,8 @@ class DeviceTpm(Device):
 
     MODEL_TIS = "tpm-tis"
     MODEL_CRB = "tpm-crb"
-    MODELS = [MODEL_TIS, MODEL_CRB]
+    MODEL_SPAPR = "tpm-spapr"
+    MODELS = [MODEL_TIS, MODEL_CRB, MODEL_SPAPR]
 
     type = XMLProperty("./backend/@type")
     version = XMLProperty("./backend/@version")


### PR DESCRIPTION
Add support for the tpm-spapr device model for pSeries VMs.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>