### PR TITLE
Fix Send Key translation in pt_BR

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6900,7 +6900,7 @@ msgstr "B_arra de Ferramentas"
 
 #: ../ui/vmwindow.ui.h:21
 msgid "Send _Key"
-msgstr "Enviar _Chave"
+msgstr "Enviar _Tecla"
 
 #: ../ui/vmwindow.ui.h:22
 msgid "Show the graphical console"


### PR DESCRIPTION
This fixes a small mistake in the pt_BR translation. Currently it is translating "key" with the same word used for cryptographic keys instead of the word for keyboard keys.

Enviar Chave -> Enviar Tecla