### PR TITLE
urldetect: Deal with ubuntu 20.04 legacy installer

### DIFF
--- a/tests/data/test_urls.ini
+++ b/tests/data/test_urls.ini
@@ -177,12 +177,17 @@ testshortcircuit = 1
 [ubuntu16.04]
 url = http://us.archive.ubuntu.com/ubuntu/dists/xenial/main/installer-amd64
 distro = ubuntu16.04
-# Latest release.
 # Check for xen for full coverage
 [ubuntu19.04]
 url = http://us.archive.ubuntu.com/ubuntu/dists/disco/main/installer-amd64
 testxen = 1
 distro = ubuntu19.04
+# Latest release.
+# Check for legacy-images for full coverage
+[ubuntu20.04]
+url = http://archive.ubuntu.com/ubuntu/dists/focal/main/installer-amd64
+kernelregex = current/legacy-images/netboot/ubuntu-installer/.*
+distro = ubuntu20.04
 
 
 

--- a/virtinst/install/urldetect.py
+++ b/virtinst/install/urldetect.py
@@ -648,6 +648,8 @@ class _DebianDistro(_DistroTree):
         media_type = None
         if check_manifest("current/images/MANIFEST"):
             media_type = "url"
+        elif check_manifest("current/legacy-images/MANIFEST"):
+            media_type = "legacy_url"
         elif check_manifest("daily/MANIFEST"):
             media_type = "daily"
         elif cache.content_regex(".disk/info",
@@ -705,6 +707,8 @@ class _DebianDistro(_DistroTree):
             url_prefix = "daily"
         elif self.cache.debian_media_type == "mounted_iso_url":
             url_prefix = "install"
+        elif self.cache.debian_media_type == "legacy_url":
+            url_prefix = "current/legacy-images"
 
         tree_arch = self._find_treearch()
         hvmroot = "%s/netboot/%s-installer/%s/" % (url_prefix,


### PR DESCRIPTION
Ubuntu 20.04 has a new installer, which is yet not supported by
virt-install / osinfo-db, and this made then switch their URLs
for the old installer to current/legacy-images/... instead of
current/images/...

Let's adapt URL detect so it can deal with thsi new "legacy"
style.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>