### PR TITLE
Fix typo in virt-install man page

### DIFF
--- a/man/virt-install.pod
+++ b/man/virt-install.pod
@@ -341,7 +341,7 @@ Enable APIC PV EOI
 
 Enable hypver VAPIC, but disable spinlocks
 
-=item B<--features kvm.hidden.state==on>
+=item B<--features kvm.hidden.state=on>
 
 Allow the KVM hypervisor signature to be hidden from the guest
 


### PR DESCRIPTION
The flag for hiding the KVM hypervisor signature has too many "=" signs.