### PR TITLE
urldetect: warn about legacy Ubuntu installer deprecation

### DIFF
--- a/virtinst/install/urldetect.py
+++ b/virtinst/install/urldetect.py
@@ -709,6 +709,9 @@ class _DebianDistro(_DistroTree):
             url_prefix = "install"
         elif self.cache.debian_media_type == "legacy_url":
             url_prefix = "current/legacy-images"
+            log.warning(("Using legacy d-i based installer, that has been"
+                         " deprecated and will be removed in the future."
+                         " https://discourse.ubuntu.com/c/server"))
 
         tree_arch = self._find_treearch()
         hvmroot = "%s/netboot/%s-installer/%s/" % (url_prefix,


### PR DESCRIPTION
The classic d-i based Ubuntu installer was deprecated. There was a last
minute fix in Ubuntu 20.04 [1]. I have found that recently a
functionally similar change made it upstream [2].

In addition to [2] the change in [1] included a warning about these
images being deprecated to raise awareness [3].

This change keeps [2] as is, but adds that message of [3].

[1]: https://git.launchpad.net/ubuntu/+source/virt-manager/tree/debian/patches/legacy-images.patch?h=ubuntu/focal-devel
[2]: https://github.com/virt-manager/virt-manager/commit/b55b7e94622dd039d00b6e21b5d28d44ab944693
[3]: https://git.launchpad.net/ubuntu/+source/virt-manager/tree/virtinst/install/urldetect.py?h=applied/ubuntu/focal-devel#n700

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>