### PR TITLE
virtinst: add support for configuring the VNC WebSocket port

### DIFF
--- a/man/virt-install.pod
+++ b/man/virt-install.pod
@@ -1212,6 +1212,14 @@ console. This is used by 'vnc' and 'spice'
 
 Specify the spice tlsport.
 
+=item B<websocket>
+
+Request a VNC WebSocket port for the guest console.
+
+If -1 is specified, the WebSocket port is auto-allocated.
+
+This is used by 'vnc' and 'spice'
+
 =item B<listen>
 
 Address to listen on for VNC/Spice connections. Default is typically 127.0.0.1

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -386,6 +386,8 @@
       <image compression="off"/>
     </graphics>
     <graphics type="vnc" port="5950" keymap="ja" listen="1.2.3.4" passwd="foo"/>
+    <graphics type="vnc" port="5950" websocket="15950" keymap="ja" listen="1.2.3.4" passwd="foo"/>
+    <graphics type="vnc" port="5950" websocket="-1" keymap="ja" listen="1.2.3.4" passwd="foo"/>
     <graphics type="spice" port="5950" tlsPort="5950" keymap="ja" listen="1.2.3.4">
       <image compression="off"/>
     </graphics>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -630,6 +630,8 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --graphics sdl
 --graphics spice,keymap=none
 --graphics vnc,port=5950,listen=1.2.3.4,keymap=ja,password=foo
+--graphics vnc,port=5950,listen=1.2.3.4,keymap=ja,password=foo,websocket=15950
+--graphics vnc,port=5950,listen=1.2.3.4,keymap=ja,password=foo,websocket=-1
 --graphics spice,port=5950,tlsport=5950,listen=1.2.3.4,keymap=ja
 --graphics spice,image_compression=glz,streaming_mode=filter,clipboard_copypaste=yes,mouse_mode=client,filetransfer_enable=on,zlib.compression=always
 --graphics spice,gl=yes,listen=socket,image.compression=glz,streaming.mode=filter,clipboard.copypaste=yes,mouse.mode=client,filetransfer.enable=on,tlsPort=6000,passwd=testpass,passwdValidTo=2010-04-09T15:51:00,passwordValidTo=2010-04-09T15:51:01,defaultMode=insecure

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3531,6 +3531,7 @@ class ParserGraphics(VirtCLIParser):
         cls.add_arg("type", "type", cb=cls.set_type_cb)
         cls.add_arg("port", "port")
         cls.add_arg("tlsPort", "tlsPort")
+        cls.add_arg("websocket", "websocket")
         cls.add_arg("listen", "listen")
         cls.add_arg("keymap", "keymap", cb=cls.set_keymap_cb)
         cls.add_arg("password", "passwd")

--- a/virtinst/devices/graphics.py
+++ b/virtinst/devices/graphics.py
@@ -51,7 +51,7 @@ class DeviceGraphics(Device):
     CHANNEL_TYPE_PLAYBACK = "playback"
     CHANNEL_TYPE_RECORD   = "record"
 
-    _XML_PROP_ORDER = ["type", "gl", "_port", "_tlsPort", "autoport",
+    _XML_PROP_ORDER = ["type", "gl", "_port", "_tlsPort", "autoport", "websocket",
                        "keymap", "_listen",
                        "passwd", "display", "xauth"]
 
@@ -76,6 +76,7 @@ class DeviceGraphics(Device):
     tlsPort = property(_get_tlsport, _set_tlsport)
 
     autoport = XMLProperty("./@autoport", is_yesno=True)
+    websocket = XMLProperty("./@websocket", is_int=True)
 
     channel_main_mode = _get_mode_prop(CHANNEL_TYPE_MAIN)
     channel_display_mode = _get_mode_prop(CHANNEL_TYPE_DISPLAY)


### PR DESCRIPTION
Add a --websocket option to configure VNC WebSocket port as described in https://libvirt.org/formatdomain.html#elementsGraphics

Closes #107