### PR TITLE
Fix duplicate machine type entry in aarch64 when creating new VM

### DIFF
--- a/virtinst/capabilities.py
+++ b/virtinst/capabilities.py
@@ -138,13 +138,13 @@ class _CapsGuest(XMLBuilder):
     def all_machine_names(self, domain):
         """
         Return all machine string names, including canonical aliases for
-        the guest+domain combo
+        the guest+domain combo but avoiding duplicates
         """
         mobjs = (domain and domain.machines) or self.machines
         ret = []
         for m in mobjs:
             ret.append(m.name)
-            if m.canonical:
+            if m.canonical and m.canonical not in ret:
                 ret.append(m.canonical)
         return ret
 


### PR DESCRIPTION
Hello

Just noticed that when creating new aarch64 machine, "virt-5.0" entry appeared twice.
This PR tries to fix this problem by avoiding the same alias name.

before patch:
<img src="https://user-images.githubusercontent.com/34906001/88414460-dae17600-ce17-11ea-93d6-9c255a1ec5e9.png" width="320px">

after patch:
<img src="https://user-images.githubusercontent.com/34906001/88414481-e339b100-ce17-11ea-8b52-eb8fafddb92e.png" width="320px">
