### PR TITLE
Add USB cdrom and ramfb video

### DIFF
--- a/virtManager/addhardware.py
+++ b/virtManager/addhardware.py
@@ -522,7 +522,7 @@ class vmmAddHardware(vmmGObjectUI):
         bus_map = {
             "disk": ["ide", "sata", "scsi", "sd", "usb", "virtio", "xen"],
             "floppy": ["fdc"],
-            "cdrom": ["ide", "sata", "scsi"],
+            "cdrom": ["ide", "sata", "scsi", "usb"],
             "lun": ["scsi"],
         }
         return [bus for bus in buses if bus in bus_map.get(devtype, [])]
@@ -682,7 +682,7 @@ class vmmAddHardware(vmmGObjectUI):
         if guest.conn.is_xen():
             return ["xen", "vga"]
         if guest.conn.is_qemu() or guest.conn.is_test():
-            return ["vga", "bochs", "qxl", "virtio"]
+            return ["vga", "bochs", "qxl", "virtio", "ramfb"]
         return []
 
     @staticmethod


### PR DESCRIPTION
Both are needed to install Windows 10 Arm64 from ISO.

Just FYI, if you want to test this: libvirt currently doesn't create correct USB cdrom devices, which breaks the installer. More info is available in the pending merge request for it: https://gitlab.com/libvirt/libvirt/-/merge_requests/19