### PR TITLE
fix some pylint

### DIFF
--- a/tests/uitests/lib/app.py
+++ b/tests/uitests/lib/app.py
@@ -7,9 +7,9 @@ import subprocess
 import sys
 import time
 
+from gi.repository import Gio
 import dogtail.rawinput
 import dogtail.tree
-from gi.repository import Gio
 
 from virtinst import log
 import tests.utils

--- a/virtManager/createvm.py
+++ b/virtManager/createvm.py
@@ -979,7 +979,7 @@ class vmmCreateVM(vmmGObjectUI):
         self.widget("summary-cpu").set_text(cpu)
         self._populate_summary_storage()
 
-        ignore, nsource, ignore = self._netlist.get_network_selection()
+        ignore0, nsource, ignore1 = self._netlist.get_network_selection()
         expand = not nsource
         if expand:
             self.widget("advanced-expander").set_expanded(True)


### PR DESCRIPTION
virtManager/createvm.py:982:8: W0128: Redeclared variable 'ignore' in assignment (redeclared-assigned-name)

tests/uitests/lib/app.py:12:0: C0411: third party import "from gi.repository import Gio" should be placed before "import dogtail.rawinput" (wrong-import-order)

Signed-off-by: Chen Hanxiao <chenhx.fnst@cn.fujitsu.com>