### PR TITLE
Add toggle menu to enable/disable SPICE clipboard sync

### DIFF
--- a/data/org.virt-manager.virt-manager.gschema.xml
+++ b/data/org.virt-manager.virt-manager.gschema.xml
@@ -31,6 +31,12 @@
       <summary>Autoconnect to the default VM console when the VM window is opened</summary>
       <description>Autoconnect to the default VM console when the VM window is opened. Users may want to turn this off if they prefer to use another viewer app for their VMs, and don't want virt-manager to interfere, but they still want to use virt-manager's details. -1 = global default, 0 = off, 1 = on</description>
     </key>
+
+    <key name="auto-clipboard" type="i">
+      <default>-1</default>
+      <summary>Enable SPICE clipboard sync by default in the console window</summary>
+      <description>Whether to enable SPICE clipboard sync by default while connected to the guest console.</description>
+    </key>
   </schema>
 
 
@@ -227,6 +233,12 @@
       <default>true</default>
       <summary>Enable SPICE Auto USB redirection in console window</summary>
       <description>Whether to enable SPICE Auto USB redirection while connected to the guest console.</description>
+    </key>
+
+    <key name="auto-clipboard" type="b">
+      <default>true</default>
+      <summary>Enable SPICE clipboard sync by default in the console window</summary>
+      <description>Whether to enable SPICE clipboard sync by default while connected to the guest console.</description>
     </key>
 
     <key name="autoconnect" type="b">

--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -688,6 +688,32 @@ identical CPUs in order to migrate the VM.</property>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="tooltip_text" translatable="yes">If disabled, the VM window will not automatically enabled clipboard sync with the running VM.</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">SPICE _clipboard sync:</property>
+                            <property name="use_underline">True</property>
+                            <property name="mnemonic_widget">prefs-console-autoclipboard</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBox" id="prefs-console-autoclipboard">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <signal name="changed" handler="on_prefs_console_autoclipboard_changed" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
                             <property name="tooltip_text" translatable="yes">If disabled, the VM window will not automatically connect to the running VM graphical console.</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Console autoconnec_t:</property>
@@ -696,7 +722,7 @@ identical CPUs in order to migrate the VM.</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">4</property>
+                            <property name="top_attach">5</property>
                           </packing>
                         </child>
                         <child>
@@ -709,7 +735,7 @@ identical CPUs in order to migrate the VM.</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">4</property>
+                            <property name="top_attach">5</property>
                           </packing>
                         </child>
                       </object>

--- a/ui/vmwindow.ui
+++ b/ui/vmwindow.ui
@@ -121,6 +121,16 @@
                         <signal name="activate" handler="on_details_menu_usb_redirection" swapped="no"/>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkCheckMenuItem" id="details-menu-auto-clipboard">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="tooltip_text" translatable="yes">Enable or disable clipboard sync with the virtual machine running a SPICE agent.</property>
+                        <property name="label" translatable="yes">Sync _clipboard</property>
+                        <property name="use_underline">True</property>
+                        <signal name="toggled" handler="on_details_menu_autoclipboard_toggled" swapped="no"/>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/virtManager/config.py
+++ b/virtManager/config.py
@@ -488,6 +488,11 @@ class vmmConfig(object):
     def set_auto_usbredir(self, state):
         self.conf.set("/console/auto-redirect", state)
 
+    def get_auto_clipboard(self):
+        return bool(self.conf.get("/console/auto-clipboard"))
+    def set_auto_clipboard(self, state):
+        self.conf.set("/console/auto-clipboard", state)
+
     def get_console_autoconnect(self):
         return bool(self.conf.get("/console/autoconnect"))
     def set_console_autoconnect(self, val):

--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -667,6 +667,11 @@ class vmmConsolePages(vmmGObjectUI):
             gpage == _GFX_PAGE_VIEWER and
             self._viewer and self._viewer.console_is_open())
 
+    def _viewer_can_auto_clipboard(self):
+        return (self._viewer_is_visible() and
+                self._viewer.console_has_auto_clipboard() and
+                self.vm.has_spicevmc_type_channel())
+
     def _viewer_can_usb_redirect(self):
         return (self._viewer_is_visible() and
                 self._viewer.console_has_usb_redirection() and
@@ -732,6 +737,7 @@ class vmmConsolePages(vmmGObjectUI):
             self._connect_viewer_signals()
 
             self._viewer.console_open()
+            self._viewer.console_set_auto_clipboard(self.vm.get_console_auto_clipboard())
         except Exception as e:
             log.exception("Error connecting to graphical console")
             self._activate_gfx_unavailable_page(
@@ -955,6 +961,11 @@ class vmmConsolePages(vmmGObjectUI):
     ###########################
     # API used by vmmVMWindow #
     ###########################
+
+    def vmwindow_get_can_auto_clipboard(self):
+        return self._viewer_can_auto_clipboard()
+    def vmwindow_viewer_set_auto_clipboard(self, enabled):
+        self._viewer.console_set_auto_clipboard(enabled)
 
     def vmwindow_viewer_has_usb_redirection(self):
         return bool(self._viewer and

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -427,6 +427,13 @@ class vmmDomain(vmmLibvirtObject):
     def get_install_abort(self):
         return bool(self._install_abort)
 
+    def has_spicevmc_type_channel(self):
+        devs = self.xmlobj.devices.channel
+        for dev in devs:
+            if dev.type == "spicevmc":
+                return True
+        return False
+
     def has_spicevmc_type_redirdev(self):
         devs = self.xmlobj.devices.redirdev
         for dev in devs:
@@ -1579,6 +1586,17 @@ class vmmDomain(vmmLibvirtObject):
         ret = self.config.get_pervm(self.get_uuid(), "/resize-guest")
         if ret == -1:
             return self.config.get_console_resizeguest()
+        return ret
+
+    def on_console_auto_clipboard_changed(self, *args, **kwargs):
+        return self.config.listen_pervm(self.get_uuid(), "/auto-clipboard",
+                                        *args, **kwargs)
+    def set_console_auto_clipboard(self, value):
+        self.config.set_pervm(self.get_uuid(), "/auto-clipboard", value)
+    def get_console_auto_clipboard(self):
+        ret = self.config.get_pervm(self.get_uuid(), "/auto-clipboard")
+        if ret == -1:
+            return self.config.get_auto_clipboard()
         return ret
 
     def on_console_autoconnect_changed(self, *args, **kwargs):

--- a/virtManager/preferences.py
+++ b/virtManager/preferences.py
@@ -42,6 +42,7 @@ class vmmPreferences(vmmGObjectUI):
         self.refresh_console_scaling()
         self.refresh_console_resizeguest()
         self.refresh_console_autoredir()
+        self.refresh_console_autoclipboard()
         self.refresh_console_autoconnect()
         self.refresh_graphics_type()
         self.refresh_storage_format()
@@ -69,6 +70,7 @@ class vmmPreferences(vmmGObjectUI):
             "on_prefs_console_scaling_changed": self.change_console_scaling,
             "on_prefs_console_resizeguest_changed": self.change_console_resizeguest,
             "on_prefs_console_autoredir_changed": self.change_console_autoredir,
+            "on_prefs_console_autoclipboard_changed": self.change_console_autoclipboard,
             "on_prefs_console_autoconnect_toggled": self.change_console_autoconnect,
             "on_prefs_graphics_type_changed": self.change_graphics_type,
             "on_prefs_storage_format_changed": self.change_storage_format,
@@ -134,6 +136,18 @@ class vmmPreferences(vmmGObjectUI):
         vals = {
             False: _("Manual redirect only"),
             True: _("Auto redirect on USB attach"),
+        }
+        for key, val in vals.items():
+            model.append([key, val])
+        combo.set_model(model)
+        uiutil.init_combo_text_column(combo, 1)
+
+        combo = self.widget("prefs-console-autoclipboard")
+        # [gsettings value, string]
+        model = Gtk.ListStore(bool, str)
+        vals = {
+            False: _("Disabled by default"),
+            True: _("Enabled by default"),
         }
         for key, val in vals.items():
             model.append([key, val])
@@ -217,6 +231,10 @@ class vmmPreferences(vmmGObjectUI):
     def refresh_console_autoredir(self):
         combo = self.widget("prefs-console-autoredir")
         val = self.config.get_auto_usbredir()
+        uiutil.set_list_selection(combo, val)
+    def refresh_console_autoclipboard(self):
+        combo = self.widget("prefs-console-autoclipboard")
+        val = self.config.get_auto_clipboard()
         uiutil.set_list_selection(combo, val)
     def refresh_console_autoconnect(self):
         val = self.config.get_console_autoconnect()
@@ -362,6 +380,9 @@ class vmmPreferences(vmmGObjectUI):
     def change_console_autoredir(self, box):
         val = uiutil.get_list_selection(box)
         self.config.set_auto_usbredir(val)
+    def change_console_autoclipboard(self, box):
+        val = uiutil.get_list_selection(box)
+        self.config.set_auto_clipboard(val)
     def change_console_autoconnect(self, src):
         self.config.set_console_autoconnect(bool(src.get_active()))
 


### PR DESCRIPTION
While it's a nice feature, it bothered me a bit that clipboard sync is automatically enabled (unless explicitly disabled in the XML), and there is no way to toggle it while the VM is running.

This pull request adds a toggle menu to the VM window (the setting is saved per VM), and adds a global setting of the default state.

![screen-vmwindow](https://user-images.githubusercontent.com/2717179/96036158-5de8fa00-0e64-11eb-9e43-d81ac825116c.png)

![screen-prefs](https://user-images.githubusercontent.com/2717179/96036151-5b86a000-0e64-11eb-9b41-a6a01d482534.png)

I built this for myself, and figured I'd try to upstream this. I've seen `DESIGN.md`, so I suspect it's a bit out of scope, but I'll let you be the judge of that.