### PR TITLE
virtinst: Fix TOCTOU race in user scratch dir creation

### DIFF
--- a/virtinst/install/installertreemedia.py
+++ b/virtinst/install/installertreemedia.py
@@ -94,8 +94,7 @@ class InstallerTreeMedia(object):
         if (guest.conn.is_unprivileged() or
             not os.path.exists(system_scratchdir) or
             not os.access(system_scratchdir, os.W_OK)):
-            if not os.path.exists(user_scratchdir):
-                os.makedirs(user_scratchdir, 0o751)  # pragma: no cover
+            os.makedirs(user_scratchdir, 0o751, exist_ok=True)
             return user_scratchdir
 
         return system_scratchdir  # pragma: no cover


### PR DESCRIPTION
When starting many virt-install processes in parallel, some often crash
with

    ERROR    [Errno 17] File exists: '/home/kstest/.cache/virt-manager/boot'

Fix that by ignoring existing directories instead of explicitly testing
for existence.

The `exist_ok` parameter exists since Python 3.2, and the minimum
supported version is 3.4 now.