### PR TITLE
tests: force an English UTF-8 locale

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,6 +10,10 @@ import os
 os.environ["VIRTINST_TEST_SUITE"] = "1"
 # Need to do this before we import argcomplete
 os.environ.pop("_ARC_DEBUG", None)
+# Make sure the test suite uses an English locale, as we need to match
+# error/status messages
+os.environ["LANG"] = "en_US.UTF-8"
+os.environ.pop("LANGUAGE", None)
 
 # pylint: disable=wrong-import-position
 from virtinst import buildconfig


### PR DESCRIPTION
Various checks in the test suite try to match for error/status messages, so using a localized libvirt (or even using translations of an installed version of virt-manager in the system) makes those check fail. Hence, force (using `$LANG`, and unsetting `$LANGUAGE`) an English UTF-8 locale.

Thanks Cole Robinson for spotting the right place where to inject the locale settings.

Fixes: #199

Signed-off-by: Pino Toscano <ptoscano@redhat.com>