### PR TITLE
Undecorated window

### DIFF
--- a/ui/vmwindow.ui
+++ b/ui/vmwindow.ui
@@ -183,6 +183,21 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkCheckMenuItem" id="details-menu-view-undecorated-window">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Display in _Undecorated Window</property>
+                        <property name="use_underline">True</property>
+                        <signal name="activate" handler="on_details_menu_view_undecorated_window_activate" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkMenuItem" id="detains-menu-view-size-to-vm">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -556,12 +556,10 @@ class vmmConsolePages(vmmGObjectUI):
     def _change_fullscreen(self, do_fullscreen):
         if do_fullscreen:
             self._in_fullscreen = True
-            self.topwin.fullscreen()
             self._overlay_toolbar_fullscreen.timed_revealer.force_reveal(True)
         else:
             self._in_fullscreen = False
             self._overlay_toolbar_fullscreen.timed_revealer.force_reveal(False)
-            self.topwin.unfullscreen()
 
         self._sync_scaling_with_display()
 

--- a/virtManager/vmwindow.py
+++ b/virtManager/vmwindow.py
@@ -650,6 +650,12 @@ class vmmVMWindow(vmmGObjectUI):
     def _fullscreen_changed_cb(self, src):
         do_fullscreen = src.get_active()
         self.widget("control-fullscreen").set_active(do_fullscreen)
+
+        if do_fullscreen:
+            self.topwin.fullscreen()
+        else:
+            self.topwin.unfullscreen()
+
         self._console.vmwindow_set_fullscreen(do_fullscreen)
 
         self.widget("details-menubar").set_visible(not do_fullscreen)


### PR DESCRIPTION

    virt-manager: implement undecorated window mode
    
    I have a 4k monitor and I have a VM that uses 1920x1080 resolution, which
    I would like to lay out in the top-right corner of my monitor.
    
    The problem is that as long as the window decoration, menubar and toolbar
    is visible, 1920x1080 does not fit in the 1/4th of my monitor.
    
    Also, the current virtual VGA driver for Windows does not support
    non-standard resolutions like VirtualBox, thus I am either seeing a lot of
    "black" space around my virtual desktop, or I would have to increase
    the size of my virt-manager window.
    
    None of this is appealing, so this patch implements a "windowed" full screen
    mode, which is basically an undecorated window, without a menu or toolbar.
    
    The same overlay is available at the top of the window than what is available
    in full screen.
