### PR TITLE
dont_mess_with_console_background_color

### DIFF
--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -332,11 +332,6 @@ class vmmConsolePages(vmmGObjectUI):
         self.widget("console-overlay").add_overlay(
                 self._overlay_toolbar_fullscreen.timed_revealer.get_overlay_widget())
 
-        # Make viewer widget background always be black
-        black = Gdk.Color(0, 0, 0)
-        self.widget("console-gfx-viewport").modify_bg(Gtk.StateType.NORMAL,
-                                                      black)
-
         self.widget("console-pages").set_show_tabs(False)
         self.widget("serial-pages").set_show_tabs(False)
         self.widget("console-gfx-pages").set_show_tabs(False)


### PR DESCRIPTION
Do not impose random aesthetic preferences, users already have a GTK theme for that. This is a usability problem at least for those of us who invert our screens at night. 