### PR TITLE
details: enable resizing of displays with new GtkVnc

### DIFF
--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -5,8 +5,11 @@
 # This work is licensed under the GNU GPLv2 or later.
 # See the COPYING file in the top-level directory.
 
+import gi
+gi.require_version('GtkVnc', '2.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import GtkVnc
 
 from virtinst import log
 
@@ -487,12 +490,12 @@ class vmmConsolePages(vmmGObjectUI):
     def _viewer_get_resizeguest_tooltip(self):
         tooltip = ""
         if self._viewer:
-            if self._viewer.viewer_type != "spice":
-                tooltip = (
-                    _("Graphics type '%s' does not support auto resize.") %
-                    self._viewer.viewer_type)
-            elif not self._viewer.console_has_agent():
-                tooltip = _("Guest agent is not available.")
+            if self._viewer.viewer_type == "spice":
+                if not self._viewer.has_agent():
+                    tooltip = _("Guest agent is not available.")
+            elif self._viewer.viewer_type == "vnc":
+                if not hasattr(GtkVnc.Display, "set_allow_resize"):
+                    tooltip = _("GTK-VNC viewer is too old")
         return tooltip
 
     def _sync_resizeguest_with_display(self):

--- a/virtManager/details/viewers.py
+++ b/virtManager/details/viewers.py
@@ -408,8 +408,11 @@ class VNCViewer(Viewer):
         self._display.set_credential(GtkVnc.DisplayCredential.PASSWORD, cred)
 
     def _set_resizeguest(self, val):
-        ignore = val
+        if hasattr(self._display, "set_allow_resize"):
+            self._display.set_allow_resize(val)
     def _get_resizeguest(self):
+        if hasattr(self._display, "set_allow_resize"):
+            return self._display.get_allow_resize()
         return False
 
     def _get_usb_widget(self):


### PR DESCRIPTION
The (forthcoming) 1.2.0 release of GtkVnc introduces support for remote desktop
resize. This is also supported in QEMU >= 6.0.0 when using virtio-gpu.

This introduces support for resize without forcing a new min version of
GtkVnc by just checking for existance of the new API. We don't attempt
to check if the current QEMU instance supports resize, as we gracefully
degrade - the guest simply won't resize and will be rendered as before.

Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>