### PR TITLE
display, graphics: Add default graphics & allow using SPICE on aarch64

### DIFF
--- a/tests/data/cli/compare/virt-install-aarch64-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-cdrom.xml
@@ -40,6 +40,18 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich6"/>
+    <video>
+      <model type="virtio"/>
+    </video>
   </devices>
 </domain>
 <domain type="qemu">
@@ -81,5 +93,17 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich6"/>
+    <video>
+      <model type="virtio"/>
+    </video>
   </devices>
 </domain>

--- a/tests/data/cli/compare/virt-install-aarch64-firmware-no-override.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-firmware-no-override.xml
@@ -24,9 +24,15 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
     <input type="tablet" bus="usb"/>
     <input type="keyboard" bus="usb"/>
-    <graphics type="vnc" port="-1"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich6"/>
     <video>
       <model type="virtio"/>
     </video>
@@ -57,9 +63,15 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
     <input type="tablet" bus="usb"/>
     <input type="keyboard" bus="usb"/>
-    <graphics type="vnc" port="-1"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich6"/>
     <video>
       <model type="virtio"/>
     </video>

--- a/tests/data/cli/compare/virt-install-aarch64-firmware-no-override.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-firmware-no-override.xml
@@ -24,6 +24,12 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <graphics type="vnc" port="-1"/>
+    <video>
+      <model type="virtio"/>
+    </video>
   </devices>
 </domain>
 <domain type="kvm">
@@ -51,5 +57,11 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <graphics type="vnc" port="-1"/>
+    <video>
+      <model type="virtio"/>
+    </video>
   </devices>
 </domain>

--- a/tests/data/cli/compare/virt-install-aarch64-kvm-gic.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-kvm-gic.xml
@@ -41,6 +41,12 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <graphics type="vnc" port="-1"/>
+    <video>
+      <model type="virtio"/>
+    </video>
     <memballoon model="virtio"/>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>

--- a/tests/data/cli/compare/virt-install-aarch64-kvm-gic.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-kvm-gic.xml
@@ -41,9 +41,15 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
     <input type="tablet" bus="usb"/>
     <input type="keyboard" bus="usb"/>
-    <graphics type="vnc" port="-1"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich6"/>
     <video>
       <model type="virtio"/>
     </video>

--- a/tests/data/cli/compare/virt-install-aarch64-kvm-import.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-kvm-import.xml
@@ -34,6 +34,12 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <graphics type="vnc" port="-1"/>
+    <video>
+      <model type="virtio"/>
+    </video>
     <memballoon model="virtio"/>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>

--- a/tests/data/cli/compare/virt-install-aarch64-kvm-import.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-kvm-import.xml
@@ -34,9 +34,15 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
     <input type="tablet" bus="usb"/>
     <input type="keyboard" bus="usb"/>
-    <graphics type="vnc" port="-1"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich6"/>
     <video>
       <model type="virtio"/>
     </video>

--- a/tests/data/cli/compare/virt-install-aarch64-machdefault.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-machdefault.xml
@@ -32,5 +32,17 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich6"/>
+    <video>
+      <model type="virtio"/>
+    </video>
   </devices>
 </domain>

--- a/tests/data/cli/compare/virt-install-aarch64-machvirt.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-machvirt.xml
@@ -32,5 +32,17 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich6"/>
+    <video>
+      <model type="virtio"/>
+    </video>
   </devices>
 </domain>

--- a/virtinst/devices/graphics.py
+++ b/virtinst/devices/graphics.py
@@ -133,7 +133,7 @@ class DeviceGraphics(Device):
         if not self.conn.is_qemu() and not self.conn.is_test():
             return False
         # Spice has issues on some host arches, like ppc, so allow it
-        if self.conn.caps.host.cpu.arch not in ["i686", "x86_64"]:
+        if self.conn.caps.host.cpu.arch not in ["i686", "x86_64", "aarch64"]:
             return False
         return True
 

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -924,7 +924,7 @@ class Guest(XMLBuilder):
             return
         if self.os.is_container() and not self.conn.is_vz():
             return
-        if self.os.arch not in ["x86_64", "i686", "ppc64", "ppc64le"]:
+        if self.os.arch not in ["x86_64", "i686", "ppc64", "ppc64le", "aarch64"]:
             return
         self.add_device(DeviceGraphics(self.conn))
 


### PR DESCRIPTION
This series consists in two simple patches, the first adding default graphics for aarch64, and the second allowing to use SPICE with aarch64.

With this, we have unattended installations working on aarch64 in the exactly the same way it works on x86_64.

This work has has been tested on a NVIDIA Jetson Xavier NX SBC.