### PR TITLE
notify keyboard (un)grabbed

### DIFF
--- a/virtManager/details/viewers.py
+++ b/virtManager/details/viewers.py
@@ -7,6 +7,7 @@
 
 from gi.repository import Gdk
 from gi.repository import GObject
+from gi.repository import Notify
 
 import gi
 gi.require_version('GtkVnc', '2.0')
@@ -59,6 +60,7 @@ class Viewer(vmmGObject):
         self._ginfo = ginfo
         self._tunnels = SSHTunnels(self._ginfo)
         self._keyboard_grab = False
+        Notify.init("virt-manager")
 
         self.add_gsettings_handle(
             self.config.on_keys_combination_changed(self._refresh_grab_keys))
@@ -504,8 +506,14 @@ class SpiceViewer(Viewer):
     def _keyboard_grab_cb(self, src, grab):
         self._keyboard_grab = grab
         if grab:
+            n = Notify.Notification.new("virt-manager", "keyboard grabbed")
+            n.set_timeout(2000)
+            n.show()
             self.emit("keyboard-grab")
         else:
+            n = Notify.Notification.new("virt-manager", "keyboard ungrabbed")
+            n.set_timeout(2000)
+            n.show()
             self.emit("keyboard-ungrab")
 
     def _init_widget(self):


### PR DESCRIPTION
There were no way to know if the keyboard is grabbed or not. It has leaded to many errors on my side.
Sending a notification is a way to know, another solution would be with an icon, or a different colour on the systray icon.

This PR is probably not production ready : strings are not in a .ui file and it is not editable in config. And maybe 2 seconds is too much.

Edit: I've tested 1 sec, it is a way better. I'm trying other values