### PR TITLE
cli: --cputune: add iothreadpin[0-9]* config

### DIFF
--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -232,6 +232,7 @@
   <cputune>
     <vcpupin vcpu="0" cpuset="0-3"/>
     <emulatorpin cpuset="1,7"/>
+    <iothreadpin iothread="1" cpuset="1,7"/>
     <cachetune vcpus="0-3">
       <cache level="3" id="0" type="both" size="3" unit="MiB"/>
     </cachetune>
@@ -478,6 +479,7 @@
   <cputune>
     <vcpupin vcpu="0" cpuset="0-3"/>
     <emulatorpin cpuset="1,7"/>
+    <iothreadpin iothread="1" cpuset="1,7"/>
     <cachetune vcpus="0-3">
       <cache level="3" id="0" type="both" size="3" unit="MiB"/>
     </cachetune>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -514,7 +514,7 @@ cell0.distances.sibling1.id=1,cell0.distances.sibling1.value=21,\
 numa.cell1.distances.sibling0.id=0,numa.cell1.distances.sibling0.value=21,\
 cell1.distances.sibling1.id=1,cell1.distances.sibling1.value=10,\
 cache.mode=emulate,cache.level=3
---cputune vcpupin0.vcpu=0,vcpupin0.cpuset=0-3,emulatorpin.cpuset=1,7,cachetune0.vcpus=0-3,cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60,vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95
+--cputune vcpupin0.vcpu=0,vcpupin0.cpuset=0-3,emulatorpin.cpuset=1,7,iothreadpin0.iothread=1,iothreadpin0.cpuset=1,7,cachetune0.vcpus=0-3,cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60,vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95
 --iothreads iothreads=2,iothreadids.iothread1.id=1,iothreadids.iothread2.id=2
 --metadata title=my-title,description=my-description,uuid=00000000-1111-2222-3333-444444444444,genid=e9392370-2917-565e-692b-d057f46512d6
 --boot cdrom,fd,hd,network,menu=off,loader=/foo/bar,emulator=/new/emu,bootloader=/new/bootld,rebootTimeout=3,initargs="foo=bar baz=woo",initdir=/my/custom/cwd,inituser=tester,initgroup=1000,firmware=efi

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2350,6 +2350,12 @@ class ParserCputune(VirtCLIParser):
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(*args, **kwargs)
 
+    def iothreadpin_find_inst_cb(self, *args, **kwargs):
+        cliarg = "iothreadpin"  # iothreadpin[0-9]*
+        list_propname = "iothreadpin"
+        cb = self._make_find_inst_cb(cliarg, list_propname)
+        return cb(*args, **kwargs)
+
     def vcpusched_find_inst_cb(self, *args, **kwargs):
         cliarg = "vcpusched"  # vcpusched[0-9]*
         list_propname = "vcpusched"
@@ -2395,6 +2401,10 @@ class ParserCputune(VirtCLIParser):
         cls.add_arg("vcpupin[0-9]*.cpuset", "cpuset", can_comma=True,
                     find_inst_cb=cls.vcpu_find_inst_cb)
         cls.add_arg("emulatorpin.cpuset", "emulatorpin_cpuset", can_comma=True)
+        cls.add_arg("iothreadpin[0-9]*.iothread", "iothread",
+                    find_inst_cb=cls.iothreadpin_find_inst_cb)
+        cls.add_arg("iothreadpin[0-9]*.cpuset", "cpuset", can_comma=True,
+                    find_inst_cb=cls.iothreadpin_find_inst_cb)
         cls.add_arg("vcpusched[0-9]*.vcpus", "vcpus", can_comma=True,
                     find_inst_cb=cls.vcpusched_find_inst_cb)
         cls.add_arg("vcpusched[0-9]*.scheduler", "scheduler",

--- a/virtinst/domain/cputune.py
+++ b/virtinst/domain/cputune.py
@@ -17,6 +17,17 @@ class _VCPUPin(XMLBuilder):
     cpuset = XMLProperty("./@cpuset")
 
 
+class _IOThreadPin(XMLBuilder):
+    """
+    Class for generating <cputune> child <iothreadpin> XML
+    """
+    XML_NAME = "iothreadpin"
+    _XML_PROP_ORDER = ["iothread", "cpuset"]
+
+    iothread = XMLProperty("./@iothread", is_int=True)
+    cpuset = XMLProperty("./@cpuset")
+
+
 class _CacheCPU(XMLBuilder):
     """
     Class for generating <cachetune> child <cache> XML
@@ -80,10 +91,11 @@ class DomainCputune(XMLBuilder):
     Class for generating <cpu> XML
     """
     XML_NAME = "cputune"
-    _XML_PROP_ORDER = ["vcpus", "emulatorpin_cpuset", "cachetune",
-            "memorytune", "vcpusched"]
+    _XML_PROP_ORDER = ["vcpus", "emulatorpin_cpuset", "iothreadpin",
+             "cachetune", "memorytune", "vcpusched"]
 
     vcpus = XMLChildProperty(_VCPUPin)
+    iothreadpin = XMLChildProperty(_IOThreadPin)
     cachetune = XMLChildProperty(_CacheTuneCPU)
     memorytune = XMLChildProperty(_MemoryTuneCPU)
     vcpusched = XMLChildProperty(_VCPUSched)


### PR DESCRIPTION
This adds the following suboptions to configure the
\<domain\>\<cputune\>\<iothreadpin\> list:

* iothreadpin[0-9]*.iothread
* iothreadpin[0-9]*.cpuset

\<iothreadpin\> only has two suboptions, but due to its `[0-9]*` nature, I don't think it can be simplified from an XMLChildProperty to an XMLProperty. Feel free to correct me on this if I misunderstood how that mechanism works.