### PR TITLE
cli: --shmem: added support for shared memory devices

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -1886,6 +1886,19 @@ Complete details at https://libvirt.org/formatdomain.html#elementsPanic
 
 
 
+``--shmem``
+^^^^^^^^^^^
+
+**Syntax:** ``--shmem`` NAME[,OPTS]
+
+Attach a shared memory device to the guest. The name must not contain ``/`` and must
+not be directory-specific to ``.`` or ``..``
+
+Use --shmem=? to see a list of all available sub options.
+Complete details at https://libvirt.org/formatdomain.html#shared-memory-device
+
+
+
 ``--memdev``
 ^^^^^^^^^^^^
 

--- a/man/virt-xml.rst
+++ b/man/virt-xml.rst
@@ -243,6 +243,7 @@ XML OPTIONS
 * ``--tpm``
 * ``--rng``
 * ``--panic``
+* ``--shmem``
 * ``--memdev``
 
 These options alter the XML for a single class of XML elements. More complete documentation is found in virt-install(1).

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -647,6 +647,16 @@
     <panic model="isa">
       <address type="isa" iobase="507"/>
     </panic>
+    <shmem name="my_shmem0" role="peer">
+      <model type="ivshmem-plain"/>
+      <size unit="M">4</size>
+    </shmem>
+    <shmem name="shmem_server">
+      <model type="ivshmem-doorbell"/>
+      <size unit="M">2</size>
+      <server path="/tmp/socket-shmemm"/>
+      <msi vectors="32" ioeventfd="on"/>
+    </shmem>
     <vsock model="virtio">
       <cid address="17"/>
     </vsock>

--- a/tests/data/cli/compare/virt-install-singleton-config-1.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-1.xml
@@ -88,6 +88,7 @@
     <rng model="virtio">
       <backend model="random">/dev/random</backend>
     </rng>
+    <shmem name="shmem0"/>
     <vsock model="virtio">
       <cid auto="yes"/>
     </vsock>

--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -214,6 +214,10 @@
     <panic model="isa">
       <address type="isa" iobase="0x506"/>
     </panic>
+    <shmem name="shmem0" role="master">
+      <model type="ivshmem-plain"/>
+      <size unit="M">8</size>
+    </shmem>
     <iommu model="intel">
       <driver aw_bits="48" intremap="off" caching_mode="on" eim="off" iotlb="off"/>
     </iommu>
@@ -459,6 +463,10 @@
     <panic model="isa">
       <address type="isa" iobase="0x506"/>
     </panic>
+    <shmem name="shmem0" role="master">
+      <model type="ivshmem-plain"/>
+      <size unit="M">8</size>
+    </shmem>
     <iommu model="intel">
       <driver aw_bits="48" intremap="off" caching_mode="on" eim="off" iotlb="off"/>
     </iommu>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -498,6 +498,7 @@ c.add_compare("""
 --watchdog default
 --tpm /dev/tpm0
 --rng /dev/random
+--shmem shmem0
 --vsock default
 """, "singleton-config-1")
 
@@ -548,6 +549,7 @@ memnode0.cellid=1,memnode0.mode=strict,memnode0.nodeset=2
 --tpm passthrough,model=tpm-crb,path=/dev/tpm0,backend.encryption.secret=11111111-2222-3333-4444-5555555555,backend.persistent_state=yes
 --rng egd,backend_host=127.0.0.1,backend_service=8000,backend_type=udp,backend_mode=bind,backend_connect_host=foo,backend_connect_service=708,rate.bytes=1234,rate.period=1000,model=virtio
 --panic iobase=0x506
+--shmem shmem0,role=master,model.type=ivshmem-plain,size=8,size.unit=M
 --iommu model=intel,driver.aw_bits=48,driver.caching_mode=on,driver.eim=off,driver.intremap=off,driver.iotlb=off
 """, "singleton-config-2")
 
@@ -716,6 +718,9 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --rng device=/dev/urandom,backend.protocol.type=,backend.log.file=,backend.log.append=
 
 --panic iobase=507
+
+--shmem name=my_shmem0,role=peer,model.type=ivshmem-plain,size=4,size.unit=M
+--shmem name=shmem_server,model.type=ivshmem-doorbell,size=2,size.unit=M,server.path=/tmp/socket-shmemm,msi.vectors=32,msi.ioeventfd=on
 
 --vsock cid=17
 

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -796,6 +796,10 @@ def add_device_options(devg, sound_back_compat=False):
     devg.add_argument("--panic", action="append",
                     help=_("Configure a guest panic device. Ex:\n"
                            "--panic default"))
+    ParserShMem.register()
+    devg.add_argument("--shmem", action="append",
+                    help=_("Configure a guest shared memory device. Ex:\n"
+                           "--shmem name=shmem0"))
     ParserMemdev.register()
     devg.add_argument("--memdev", action="append",
                     help=_("Configure a guest memory device. Ex:\n"
@@ -4092,6 +4096,33 @@ class ParserPanic(VirtCLIParser):
         _add_common_device_args(cls)
 
         cls.add_arg("model", "model", ignore_default=True)
+
+
+###################
+# --shmem parsing #
+###################
+
+class ParserShMem(VirtCLIParser):
+    cli_arg_name = "shmem"
+    guest_propname = "devices.shmem"
+    remove_first = "name"
+
+    @classmethod
+    def _init_class(cls, **kwargs):
+        VirtCLIParser._init_class(**kwargs)
+        _add_common_device_args(cls)
+
+        cls.add_arg("name", "name")
+        cls.add_arg("role", "role")
+
+        cls.add_arg("model.type", "type")
+
+        cls.add_arg("size", "size")
+        cls.add_arg("size.unit", "size_unit")
+
+        cls.add_arg("server.path", "server_path")
+        cls.add_arg("msi.vectors", "msi_vectors")
+        cls.add_arg("msi.ioeventfd", "msi_ioeventfd")
 
 
 ###################

--- a/virtinst/devices/__init__.py
+++ b/virtinst/devices/__init__.py
@@ -17,10 +17,11 @@ from .iommu import DeviceIommu
 from .memballoon import DeviceMemballoon
 from .memory import DeviceMemory
 from .panic import DevicePanic
-from .smartcard import DeviceSmartcard
-from .sound import DeviceSound
 from .redirdev import DeviceRedirdev
 from .rng import DeviceRng
+from .shmem import DeviceShMem
+from .smartcard import DeviceSmartcard
+from .sound import DeviceSound
 from .tpm import DeviceTpm
 from .video import DeviceVideo
 from .vsock import DeviceVsock

--- a/virtinst/devices/device.py
+++ b/virtinst/devices/device.py
@@ -148,6 +148,7 @@ class Device(XMLBuilder):
             "tpm":           ["type", "xmlindex"],
             "rng":           ["backend_model", "xmlindex"],
             "panic":         ["model", "xmlindex"],
+            "shmem":         ["name", "xmlindex"],
             "vsock":         ["model", "xmlindex"],
             "memballoon":    ["model", "xmlindex"],
             "iommu":         ["model", "xmlindex"],

--- a/virtinst/devices/shmem.py
+++ b/virtinst/devices/shmem.py
@@ -1,0 +1,36 @@
+#
+# This work is licensed under the GNU GPLv2 or later.
+# See the COPYING file in the top-level directory.
+
+from .device import Device
+from ..xmlbuilder import XMLProperty
+
+
+class DeviceShMem(Device):
+    XML_NAME = "shmem"
+    _XML_PROP_ORDER = [
+        "name", "role",
+        "type", "size", "size_unit",
+        "server_path", "msi_vectors", "msi_ioeventfd",
+    ]
+
+    MODEL_IVSHMEM = "ivshmem"
+    MODEL_IVSHMEM_PLAIN = "ivshmem-plain"
+    MODEL_IVSHMEM_DOORBELL = "ivshmem-doorbell"
+    MODELS = [MODEL_IVSHMEM, MODEL_IVSHMEM_PLAIN, MODEL_IVSHMEM_DOORBELL]
+
+    ROLE_MASTER = "master"
+    ROLE_PEER = "peer"
+    ROLES = [ROLE_MASTER, ROLE_PEER]
+
+    name = XMLProperty("./@name")
+    role = XMLProperty("./@role")
+
+    type = XMLProperty("./model/@type")
+
+    size = XMLProperty("./size", is_int=True)
+    size_unit = XMLProperty("./size/@unit")
+
+    server_path = XMLProperty("./server/@path")
+    msi_vectors = XMLProperty("./msi/@vectors", is_int=True)
+    msi_ioeventfd = XMLProperty("./msi/@ioeventfd", is_onoff=True)

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -27,7 +27,7 @@ class _DomainDevices(XMLBuilder):
             'smartcard', 'serial', 'parallel', 'console', 'channel',
             'input', 'tpm', 'graphics', 'sound', 'video', 'hostdev',
             'redirdev', 'watchdog', 'memballoon', 'rng', 'panic',
-            'memory', 'vsock', 'iommu']
+            'shmem', 'memory', 'vsock', 'iommu']
 
 
     disk = XMLChildProperty(DeviceDisk)
@@ -50,6 +50,7 @@ class _DomainDevices(XMLBuilder):
     memballoon = XMLChildProperty(DeviceMemballoon)
     rng = XMLChildProperty(DeviceRng)
     panic = XMLChildProperty(DevicePanic)
+    shmem = XMLChildProperty(DeviceShMem)
     memory = XMLChildProperty(DeviceMemory)
     vsock = XMLChildProperty(DeviceVsock)
     iommu = XMLChildProperty(DeviceIommu)


### PR DESCRIPTION
This includes support for the following suboptions:
* `name`
* `role`
* `model.type`
* `size`
* `size.unit`
* `server.path`
* `msi.vectors`
* `msi.ioeventfd`

These should cover all possibilities as specified in the [Domain XML format](https://libvirt.org/formatdomain.html#shared-memory-device). 

Since the current stance on input checking seems to be to keep to a minimum and let libvirt complain about invalid configs, I haven't added any sanity checks beyond some really basic stuff. I have, however, included a list of acceptable values for `<shmem role=X>` and `<shmem><model type=X/>` in the Device class, though they're not enforced. This is analogous to how existing devices I've looked at handled this.

I don't provide any default values, as the specification doesn't either, but if we were to provide any, I'd suggest `size.unit=M` and `size=1` (smallest allowed size), as well as `model.type=ivshmem-plain` (`ivshmem` is deprecated and `ivshmem-doorbell` requires a server, whereas `ivshmem-plain` is stand-alone).