### PR TITLE
cli: --input: add support for evdev inputs

### DIFF
--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -448,6 +448,13 @@
     <input type="keyboard" bus="usb"/>
     <input type="tablet" bus="usb"/>
     <input type="mouse" bus="ps2"/>
+    <input type="mouse" bus="virtio" model="virtio-non-transitional"/>
+    <input type="passthrough" bus="virtio">
+      <source evdev="/dev/input/event1"/>
+    </input>
+    <input type="evdev">
+      <source dev="/dev/input/event1234" repeat="on" grab="all" grabToggle="ctrl-ctrl"/>
+    </input>
     <tpm model="tpm-crb">
       <backend type="emulator" version="2.0"/>
     </tpm>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -652,6 +652,9 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --input type=keyboard,bus=usb
 --input tablet
 --input mouse
+--input mouse,bus=virtio,model=virtio-non-transitional
+--input passthrough,source.evdev=/dev/input/event1,bus=virtio
+--input evdev,source.dev=/dev/input/event1234,source.repeat=on,source.grab=all,source.grabToggle=ctrl-ctrl
 
 --serial char_type=tcp,host=:2222,mode=bind,protocol=telnet,log.file=/tmp/foo.log,log.append=yes,,target.model.name=pci-serial
 --serial nmdm,source.master=/dev/foo1,source.slave=/dev/foo2,alias.name=testalias7

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3814,6 +3814,13 @@ class ParserInput(VirtCLIParser):
 
         cls.add_arg("type", "type", ignore_default=True)
         cls.add_arg("bus", "bus", ignore_default=True)
+        cls.add_arg("model", "model")
+
+        cls.add_arg("source.evdev", "source_evdev")
+        cls.add_arg("source.dev", "source_dev")
+        cls.add_arg("source.repeat", "source_repeat")
+        cls.add_arg("source.grab", "source_grab")
+        cls.add_arg("source.grabToggle", "source_grabToggle")
 
 
 ###################

--- a/virtinst/devices/input.py
+++ b/virtinst/devices/input.py
@@ -14,6 +14,7 @@ class DeviceInput(Device):
     TYPE_MOUSE = "mouse"
     TYPE_TABLET = "tablet"
     TYPE_KEYBOARD = "keyboard"
+    TYPE_EVDEV = "evdev"
 
     BUS_PS2 = "ps2"
     BUS_USB = "usb"
@@ -23,6 +24,13 @@ class DeviceInput(Device):
 
     type = XMLProperty("./@type")
     bus = XMLProperty("./@bus")
+    model = XMLProperty("./@model")
+
+    source_evdev = XMLProperty("./source/@evdev")
+    source_dev = XMLProperty("./source/@dev")
+    source_repeat = XMLProperty("./source/@repeat", is_onoff=True)
+    source_grab = XMLProperty("./source/@grab")
+    source_grabToggle = XMLProperty("./source/@grabToggle")
 
 
     ##################
@@ -32,6 +40,11 @@ class DeviceInput(Device):
     def _default_bus(self, _guest):
         if self.type == self.TYPE_TABLET:
             return self.BUS_USB
+        # This is not explicitly stated in the docs, but the example provided
+        # for evdev inputs does not have a bus type set and libvirt won't
+        # accept such XML either.
+        if self.type == self.TYPE_EVDEV:
+            return None
         if self.conn.is_xen():
             return self.BUS_XEN
         return self.BUS_PS2


### PR DESCRIPTION
This adds support for evdev inputs which were introduced in libvirt 7.4.0,
as well as passthrough inputs and some other misc options to complete
the --input command.

New suboptions:
* source.evdev
* source.dev
* source.repeat
* source.grab
* source.grabToggle
* model