### PR TITLE
cli: --boot: add support of firmware features

### DIFF
--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -101,6 +101,10 @@
     <smbios mode="sysinfo"/>
     <bootmenu enable="no"/>
     <bios rebootTimeout="3"/>
+    <firmware>
+      <feature enabled="yes" name="secure-boot"/>
+      <feature enabled="no" name="enrolled-keys"/>
+    </firmware>
     <initarg>foo=bar</initarg>
     <initarg>baz=woo</initarg>
   </os>
@@ -352,6 +356,10 @@
     <smbios mode="sysinfo"/>
     <bootmenu enable="no"/>
     <bios rebootTimeout="3"/>
+    <firmware>
+      <feature enabled="yes" name="secure-boot"/>
+      <feature enabled="no" name="enrolled-keys"/>
+    </firmware>
     <initarg>foo=bar</initarg>
     <initarg>baz=woo</initarg>
   </os>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -519,6 +519,8 @@ cache.mode=emulate,cache.level=3
 --iothreads iothreads=2,iothreadids.iothread1.id=1,iothreadids.iothread2.id=2
 --metadata title=my-title,description=my-description,uuid=00000000-1111-2222-3333-444444444444,genid=e9392370-2917-565e-692b-d057f46512d6
 --boot cdrom,fd,hd,network,menu=off,loader=/foo/bar,emulator=/new/emu,bootloader=/new/bootld,rebootTimeout=3,initargs="foo=bar baz=woo",initdir=/my/custom/cwd,inituser=tester,initgroup=1000,firmware=efi
+--boot firmware.feature0.enabled=true,firmware.feature0.name=secure-boot
+--boot firmware.feature1.enabled=off,firmware.feature1.name=enrolled-keys
 --idmap uid_start=0,uid_target=1000,uid_count=10,gid_start=0,gid_target=1000,gid_count=10
 --seclabel type=static,label='system_u:object_r:svirt_image_t:s0:c100,c200',relabel=yes,baselabel=baselabel
 --seclabel type=dynamic,label=012:345
@@ -551,7 +553,7 @@ memnode0.cellid=1,memnode0.mode=strict,memnode0.nodeset=2
 --panic iobase=0x506
 --shmem shmem0,role=master,model.type=ivshmem-plain,size=8,size.unit=M
 --iommu model=intel,driver.aw_bits=48,driver.caching_mode=on,driver.eim=off,driver.intremap=off,driver.iotlb=off
-""", "singleton-config-2")
+""", "singleton-config-2", predefine_check="7.2.0")
 
 
 # Test the implied defaults for gl=yes setting virgl=on

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2632,6 +2632,12 @@ class ParserBoot(VirtCLIParser):
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(*args, **kwargs)
 
+    def feature_find_inst_cb(self, *args, **kwargs):
+        cliarg = "feature"  # firmware.feature[0-9]*
+        list_propname = "firmware_features"  # os.firmware_features
+        cb = self._make_find_inst_cb(cliarg, list_propname)
+        return cb(*args, **kwargs)
+
     @classmethod
     def _init_class(cls, **kwargs):
         VirtCLIParser._init_class(**kwargs)
@@ -2662,6 +2668,10 @@ class ParserBoot(VirtCLIParser):
         cls.add_arg("cmdline", "kernel_args", can_comma=True)
 
         cls.add_arg("firmware", "firmware")
+        cls.add_arg("firmware.feature[0-9]*.enabled", "enabled",
+                    find_inst_cb=cls.feature_find_inst_cb, is_onoff=True)
+        cls.add_arg("firmware.feature[0-9]*.name", "name",
+                    find_inst_cb=cls.feature_find_inst_cb)
         cls.add_arg("boot[0-9]*.dev", "dev",
                     find_inst_cb=cls.boot_find_inst_cb)
         cls.add_arg("bootmenu.enable", "enable_bootmenu", is_onoff=True)

--- a/virtinst/domain/os.py
+++ b/virtinst/domain/os.py
@@ -17,6 +17,14 @@ class _BootDevice(XMLBuilder):
     dev = XMLProperty("./@dev")
 
 
+class _FirmwareFeature(XMLBuilder):
+    XML_NAME = "feature"
+    _XML_PROP_ORDER = ["enabled", "name"]
+
+    enabled = XMLProperty("./@enabled", is_yesno=True)
+    name = XMLProperty("./@name")
+
+
 class DomainOs(XMLBuilder):
     """
     Class for generating boot device related XML
@@ -115,6 +123,7 @@ class DomainOs(XMLBuilder):
     machine = XMLProperty("./type/@machine")
     os_type = XMLProperty("./type")
     firmware = XMLProperty("./@firmware")
+    firmware_features = XMLChildProperty(_FirmwareFeature, relative_xpath="./firmware")
 
 
     ##################


### PR DESCRIPTION
libvirt 7.2.0 introduced support for a list of firmware features
that should or should not be present. Libvirt takes these into
account when auto-selecting a firmware. Currently supported
features are `enrolled-keys` and `secure-boot`.

This also bumps the minimum version for the `singleton-config-2`
test to 7.2.0.

---
Keeping from creating way to many XMLChildProperty with this one caused me some headache until I notice how `<cpu><numa><cell>` is handled using `relative_xpath=""`. Much neater like this!