### PR TITLE
cli: --cpu: implement missing options

### DIFF
--- a/tests/data/cli/compare/virt-install-cpu-host-model-no-fallback.xml
+++ b/tests/data/cli/compare/virt-install-cpu-host-model-no-fallback.xml
@@ -1,0 +1,81 @@
+<domain type="test">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <pae/>
+  </features>
+  <cpu mode="host-model">
+    <model fallback="forbid"/>
+  </cpu>
+  <clock offset="utc"/>
+  <on_reboot>destroy</on_reboot>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/test-hv</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <interface type="user">
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000"/>
+    </interface>
+    <console type="pty"/>
+  </devices>
+</domain>
+<domain type="test">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <pae/>
+  </features>
+  <cpu mode="host-model">
+    <model fallback="forbid"/>
+  </cpu>
+  <clock offset="utc"/>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/test-hv</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <interface type="user">
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000"/>
+    </interface>
+    <console type="pty"/>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-cpu-host-passthrough-migratable.xml
+++ b/tests/data/cli/compare/virt-install-cpu-host-passthrough-migratable.xml
@@ -1,0 +1,77 @@
+<domain type="test">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <pae/>
+  </features>
+  <cpu mode="host-passthrough" migratable="on"/>
+  <clock offset="utc"/>
+  <on_reboot>destroy</on_reboot>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/test-hv</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <interface type="user">
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000"/>
+    </interface>
+    <console type="pty"/>
+  </devices>
+</domain>
+<domain type="test">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <pae/>
+  </features>
+  <cpu mode="host-passthrough" migratable="on"/>
+  <clock offset="utc"/>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/test-hv</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <interface type="user">
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000"/>
+    </interface>
+    <console type="pty"/>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-cpu-model.xml
+++ b/tests/data/cli/compare/virt-install-cpu-model.xml
@@ -1,0 +1,81 @@
+<domain type="test">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <pae/>
+  </features>
+  <cpu mode="custom" match="exact">
+    <model fallback="allow" vendor_id="GenuineIntel">core2duo</model>
+  </cpu>
+  <clock offset="utc"/>
+  <on_reboot>destroy</on_reboot>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/test-hv</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <interface type="user">
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000"/>
+    </interface>
+    <console type="pty"/>
+  </devices>
+</domain>
+<domain type="test">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <pae/>
+  </features>
+  <cpu mode="custom" match="exact">
+    <model fallback="allow" vendor_id="GenuineIntel">core2duo</model>
+  </cpu>
+  <clock offset="utc"/>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/test-hv</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <interface type="user">
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000"/>
+    </interface>
+    <console type="pty"/>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -153,7 +153,12 @@
           <sibling id="1" value="10"/>
         </distances>
       </cell>
-      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no" unit="KiB"/>
+      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no" unit="KiB">
+        <cache level="1" associativity="direct" policy="writeback">
+          <size value="256" unit="KiB"/>
+          <line value="256" unit="KiB"/>
+        </cache>
+      </cell>
     </numa>
   </cpu>
   <clock offset="utc">
@@ -408,7 +413,12 @@
           <sibling id="1" value="10"/>
         </distances>
       </cell>
-      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no" unit="KiB"/>
+      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no" unit="KiB">
+        <cache level="1" associativity="direct" policy="writeback">
+          <size value="256" unit="KiB"/>
+          <line value="256" unit="KiB"/>
+        </cache>
+      </cell>
     </numa>
   </cpu>
   <clock offset="utc">

--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -139,8 +139,13 @@
     <feature policy="disable" name="distest"/>
     <feature policy="forbid" name="foo"/>
     <feature policy="forbid" name="bar"/>
-    <cache mode="emulate" level="3"/>
     <numa>
+      <interconnects>
+        <bandwidth initiator="0" target="0" type="access" value="204800"/>
+        <bandwidth initiator="0" target="2" cache="1" type="access" value="409600" unit="KiB"/>
+        <latency initiator="0" target="0" type="access" value="5"/>
+        <latency initiator="0" target="2" cache="1" type="access" value="10" unit="ns"/>
+      </interconnects>
       <cell id="0" cpus="1,2,3" memory="1024">
         <distances>
           <sibling id="0" value="10"/>
@@ -160,6 +165,7 @@
         </cache>
       </cell>
     </numa>
+    <cache mode="emulate" level="3"/>
   </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="merge"/>
@@ -399,8 +405,13 @@
     <feature policy="disable" name="distest"/>
     <feature policy="forbid" name="foo"/>
     <feature policy="forbid" name="bar"/>
-    <cache mode="emulate" level="3"/>
     <numa>
+      <interconnects>
+        <bandwidth initiator="0" target="0" type="access" value="204800"/>
+        <bandwidth initiator="0" target="2" cache="1" type="access" value="409600" unit="KiB"/>
+        <latency initiator="0" target="0" type="access" value="5"/>
+        <latency initiator="0" target="2" cache="1" type="access" value="10" unit="ns"/>
+      </interconnects>
       <cell id="0" cpus="1,2,3" memory="1024">
         <distances>
           <sibling id="0" value="10"/>
@@ -420,6 +431,7 @@
         </cache>
       </cell>
     </numa>
+    <cache mode="emulate" level="3"/>
   </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="merge"/>

--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -131,6 +131,7 @@
   <cpu mode="custom" match="strict" check="partial">
     <model>foobar</model>
     <vendor>meee</vendor>
+    <cache level="3" mode="emulate"/>
     <feature policy="force" name="x2apic"/>
     <feature policy="force" name="x2apicagain"/>
     <feature policy="require" name="reqtest"/>
@@ -140,12 +141,6 @@
     <feature policy="forbid" name="foo"/>
     <feature policy="forbid" name="bar"/>
     <numa>
-      <interconnects>
-        <bandwidth initiator="0" target="0" type="access" value="204800"/>
-        <bandwidth initiator="0" target="2" cache="1" type="access" value="409600" unit="KiB"/>
-        <latency initiator="0" target="0" type="access" value="5"/>
-        <latency initiator="0" target="2" cache="1" type="access" value="10" unit="ns"/>
-      </interconnects>
       <cell id="0" cpus="1,2,3" memory="1024">
         <distances>
           <sibling id="0" value="10"/>
@@ -158,14 +153,19 @@
           <sibling id="1" value="10"/>
         </distances>
       </cell>
-      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no" unit="KiB">
+      <cell id="2" cpus="4" memory="256" unit="KiB" memAccess="shared" discard="no">
         <cache level="1" associativity="direct" policy="writeback">
           <size value="256" unit="KiB"/>
           <line value="256" unit="KiB"/>
         </cache>
       </cell>
+      <interconnects>
+        <latency initiator="0" target="0" type="access" value="5"/>
+        <latency initiator="0" target="2" cache="1" type="access" value="10" unit="ns"/>
+        <bandwidth initiator="0" target="0" type="access" value="204800"/>
+        <bandwidth initiator="0" target="2" cache="1" type="access" value="409600" unit="KiB"/>
+      </interconnects>
     </numa>
-    <cache mode="emulate" level="3"/>
   </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="merge"/>
@@ -397,6 +397,7 @@
   <cpu mode="custom" match="strict" check="partial">
     <model>foobar</model>
     <vendor>meee</vendor>
+    <cache level="3" mode="emulate"/>
     <feature policy="force" name="x2apic"/>
     <feature policy="force" name="x2apicagain"/>
     <feature policy="require" name="reqtest"/>
@@ -406,12 +407,6 @@
     <feature policy="forbid" name="foo"/>
     <feature policy="forbid" name="bar"/>
     <numa>
-      <interconnects>
-        <bandwidth initiator="0" target="0" type="access" value="204800"/>
-        <bandwidth initiator="0" target="2" cache="1" type="access" value="409600" unit="KiB"/>
-        <latency initiator="0" target="0" type="access" value="5"/>
-        <latency initiator="0" target="2" cache="1" type="access" value="10" unit="ns"/>
-      </interconnects>
       <cell id="0" cpus="1,2,3" memory="1024">
         <distances>
           <sibling id="0" value="10"/>
@@ -424,14 +419,19 @@
           <sibling id="1" value="10"/>
         </distances>
       </cell>
-      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no" unit="KiB">
+      <cell id="2" cpus="4" memory="256" unit="KiB" memAccess="shared" discard="no">
         <cache level="1" associativity="direct" policy="writeback">
           <size value="256" unit="KiB"/>
           <line value="256" unit="KiB"/>
         </cache>
       </cell>
+      <interconnects>
+        <latency initiator="0" target="0" type="access" value="5"/>
+        <latency initiator="0" target="2" cache="1" type="access" value="10" unit="ns"/>
+        <bandwidth initiator="0" target="0" type="access" value="204800"/>
+        <bandwidth initiator="0" target="2" cache="1" type="access" value="409600" unit="KiB"/>
+      </interconnects>
     </numa>
-    <cache mode="emulate" level="3"/>
   </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="merge"/>

--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -128,7 +128,7 @@
     </kvm>
     <vmcoreinfo state="on"/>
   </features>
-  <cpu mode="custom" match="strict">
+  <cpu mode="custom" match="strict" check="partial">
     <model>foobar</model>
     <vendor>meee</vendor>
     <feature policy="force" name="x2apic"/>
@@ -383,7 +383,7 @@
     </kvm>
     <vmcoreinfo state="on"/>
   </features>
-  <cpu mode="custom" match="strict">
+  <cpu mode="custom" match="strict" check="partial">
     <model>foobar</model>
     <vendor>meee</vendor>
     <feature policy="force" name="x2apic"/>

--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -153,7 +153,7 @@
           <sibling id="1" value="10"/>
         </distances>
       </cell>
-      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no"/>
+      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no" unit="KiB"/>
     </numa>
   </cpu>
   <clock offset="utc">
@@ -408,7 +408,7 @@
           <sibling id="1" value="10"/>
         </distances>
       </cell>
-      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no"/>
+      <cell id="2" cpus="4" memory="256" memAccess="shared" discard="no" unit="KiB"/>
     </numa>
   </cpu>
   <clock offset="utc">

--- a/tests/data/cli/compare/virt-install-singleton-config-3.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-3.xml
@@ -76,7 +76,7 @@
     <vmcoreinfo state="on"/>
   </features>
   <cpu>
-    <topology sockets="1" cores="3" threads="2"/>
+    <topology sockets="1" dies="1" cores="3" threads="2"/>
     <numa>
       <cell cpus="0" memory="1048576"/>
     </numa>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -506,7 +506,7 @@ c.add_compare("""
 c.add_compare("""--pxe
 --memory 512,maxmemory=1024
 --vcpus 9
---cpu foobar,+x2apic,+x2apicagain,-distest,forbid=foo,forbid=bar,disable=distest2,optional=opttest,require=reqtest,match=strict,vendor=meee,mode=custom,\
+--cpu foobar,+x2apic,+x2apicagain,-distest,forbid=foo,forbid=bar,disable=distest2,optional=opttest,require=reqtest,match=strict,vendor=meee,mode=custom,check=partial,\
 cell.id=0,cell.cpus=1,2,3,cell.memory=1024,\
 cell1.id=1,cell1.memory=256,cell1.cpus=5-8,\
 numa.cell2.id=2,numa.cell2.memory=256,numa.cell2.cpus=4,numa.cell2.memAccess=shared,numa.cell2.discard=no,\
@@ -785,6 +785,7 @@ c.add_compare("--memory hotplugmemorymax=2048,hotplugmemoryslots=2 --cpu cell0.c
 c.add_compare("--memory currentMemory=100,memory=200,maxmemory=300,maxMemory=400,maxMemory.slots=1", "memory-option-backcompat", precompare_check="5.3.0")
 c.add_compare("--connect " + utils.URIs.kvm_q35 + " --cpu qemu64,secure=off", "cpu-disable-sec")  # disable security features that are added by default
 c.add_compare("--connect " + utils.URIs.kvm_rhel, "cpu-rhel7-default", precompare_check="5.1.0")  # default CPU for old QEMU where we cannot use host-model
+c.add_compare("--cpu host-passthrough,migratable=on", "cpu-host-passthrough-migratable")  # Passthrough with migratable attribute
 
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -516,6 +516,10 @@ numa.cell1.distances.sibling0.id=0,numa.cell1.distances.sibling0.value=21,\
 numa.cell2.cache0.level=1,numa.cell2.cache0.associativity=direct,numa.cell2.cache0.policy=writeback,\
 numa.cell2.cache0.size.value=256,numa.cell2.cache0.size.unit=KiB,numa.cell2.cache0.line.value=256,numa.cell2.cache0.line.unit=KiB,\
 cell1.distances.sibling1.id=1,cell1.distances.sibling1.value=10,\
+numa.interconnects.latency0.initiator=0,numa.interconnects.latency0.target=0,numa.interconnects.latency0.type=access,numa.interconnects.latency0.value=5,\
+numa.interconnects.latency1.initiator=0,numa.interconnects.latency1.target=2,numa.interconnects.latency1.cache=1,numa.interconnects.latency1.type=access,numa.interconnects.latency1.value=10,numa.interconnects.latency1.unit=ns,\
+numa.interconnects.bandwidth0.initiator=0,numa.interconnects.bandwidth0.target=0,numa.interconnects.bandwidth0.type=access,numa.interconnects.bandwidth0.value=204800,\
+numa.interconnects.bandwidth1.initiator=0,numa.interconnects.bandwidth1.target=2,numa.interconnects.bandwidth1.cache=1,numa.interconnects.bandwidth1.type=access,numa.interconnects.bandwidth1.value=409600,numa.interconnects.bandwidth1.unit=KiB,\
 cache.mode=emulate,cache.level=3
 --cputune vcpupin0.vcpu=0,vcpupin0.cpuset=0-3,emulatorpin.cpuset=1,7,iothreadpin0.iothread=1,iothreadpin0.cpuset=1,7,cachetune0.vcpus=0-3,cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60,vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95
 --iothreads iothreads=2,iothreadids.iothread1.id=1,iothreadids.iothread2.id=2
@@ -788,6 +792,8 @@ c.add_compare("--memory currentMemory=100,memory=200,maxmemory=300,maxMemory=400
 c.add_compare("--connect " + utils.URIs.kvm_q35 + " --cpu qemu64,secure=off", "cpu-disable-sec")  # disable security features that are added by default
 c.add_compare("--connect " + utils.URIs.kvm_rhel, "cpu-rhel7-default", precompare_check="5.1.0")  # default CPU for old QEMU where we cannot use host-model
 c.add_compare("--cpu host-passthrough,migratable=on", "cpu-host-passthrough-migratable")  # Passthrough with migratable attribute
+c.add_compare("--cpu host-model,model.fallback=forbid", "cpu-host-model-no-fallback")  # Host-Model with fallback disabled
+c.add_compare("--cpu model=core2duo,model.fallback=allow,model.vendor_id=GenuineIntel", "cpu-model")  # Specific CPU with fallback enabled
 
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -509,7 +509,7 @@ c.add_compare("""--pxe
 --cpu foobar,+x2apic,+x2apicagain,-distest,forbid=foo,forbid=bar,disable=distest2,optional=opttest,require=reqtest,match=strict,vendor=meee,mode=custom,check=partial,\
 cell.id=0,cell.cpus=1,2,3,cell.memory=1024,\
 cell1.id=1,cell1.memory=256,cell1.cpus=5-8,\
-numa.cell2.id=2,numa.cell2.memory=256,numa.cell2.cpus=4,numa.cell2.memAccess=shared,numa.cell2.discard=no,\
+numa.cell2.id=2,numa.cell2.memory=256,numa.cell2.unit=KiB,numa.cell2.cpus=4,numa.cell2.memAccess=shared,numa.cell2.discard=no,\
 cell0.distances.sibling0.id=0,cell0.distances.sibling0.value=10,\
 cell0.distances.sibling1.id=1,cell0.distances.sibling1.value=21,\
 numa.cell1.distances.sibling0.id=0,numa.cell1.distances.sibling0.value=21,\

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -568,7 +568,7 @@ c.add_compare("""
 --graphics spice,gl=yes
 --rng type=egd,backend.type=nmdm,backend.source.master=/dev/foo1,backend.source.slave=/dev/foo2
 --panic default,,address.type=isa,address.iobase=0x500,address.irq=5
---cpu topology.sockets=1,topology.cores=3,topology.threads=2,cell0.cpus=0,cell0.memory=1048576
+--cpu topology.sockets=1,topology.dies=1,topology.cores=3,topology.threads=2,cell0.cpus=0,cell0.memory=1048576
 --memdev dimm,access=private,target.size=512,target.node=0,source.pagesize=4,source.nodemask=1-2,discard=on
 --memdev nvdimm,source.path=/path/to/nvdimm,target.size=512,target.node=0,target.label_size=128,alias.name=mymemdev3,address.type=dimm,address.base=0x100000000,address.slot=1,source.pmem=on,source.alignsize=2048,target.readonly=on
 --vsock auto_cid=on

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -520,7 +520,7 @@ numa.interconnects.latency0.initiator=0,numa.interconnects.latency0.target=0,num
 numa.interconnects.latency1.initiator=0,numa.interconnects.latency1.target=2,numa.interconnects.latency1.cache=1,numa.interconnects.latency1.type=access,numa.interconnects.latency1.value=10,numa.interconnects.latency1.unit=ns,\
 numa.interconnects.bandwidth0.initiator=0,numa.interconnects.bandwidth0.target=0,numa.interconnects.bandwidth0.type=access,numa.interconnects.bandwidth0.value=204800,\
 numa.interconnects.bandwidth1.initiator=0,numa.interconnects.bandwidth1.target=2,numa.interconnects.bandwidth1.cache=1,numa.interconnects.bandwidth1.type=access,numa.interconnects.bandwidth1.value=409600,numa.interconnects.bandwidth1.unit=KiB,\
-cache.mode=emulate,cache.level=3
+cache.level=3,cache.mode=emulate
 --cputune vcpupin0.vcpu=0,vcpupin0.cpuset=0-3,emulatorpin.cpuset=1,7,iothreadpin0.iothread=1,iothreadpin0.cpuset=1,7,cachetune0.vcpus=0-3,cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60,vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95
 --iothreads iothreads=2,iothreadids.iothread1.id=1,iothreadids.iothread2.id=2
 --metadata title=my-title,description=my-description,uuid=00000000-1111-2222-3333-444444444444,genid=e9392370-2917-565e-692b-d057f46512d6

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -513,6 +513,8 @@ numa.cell2.id=2,numa.cell2.memory=256,numa.cell2.unit=KiB,numa.cell2.cpus=4,numa
 cell0.distances.sibling0.id=0,cell0.distances.sibling0.value=10,\
 cell0.distances.sibling1.id=1,cell0.distances.sibling1.value=21,\
 numa.cell1.distances.sibling0.id=0,numa.cell1.distances.sibling0.value=21,\
+numa.cell2.cache0.level=1,numa.cell2.cache0.associativity=direct,numa.cell2.cache0.policy=writeback,\
+numa.cell2.cache0.size.value=256,numa.cell2.cache0.size.unit=KiB,numa.cell2.cache0.line.value=256,numa.cell2.cache0.line.unit=KiB,\
 cell1.distances.sibling1.id=1,cell1.distances.sibling1.value=10,\
 cache.mode=emulate,cache.level=3
 --cputune vcpupin0.vcpu=0,vcpupin0.cpuset=0-3,emulatorpin.cpuset=1,7,iothreadpin0.iothread=1,iothreadpin0.cpuset=1,7,cachetune0.vcpus=0-3,cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60,vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2304,8 +2304,12 @@ class ParserCPU(VirtCLIParser):
         # 'secure' needs to be parsed before 'model'
         cls.add_arg("secure", "secure", is_onoff=True)
         cls.add_arg("model", "model", cb=cls.set_model_cb)
+
         cls.add_arg("mode", "mode")
         cls.add_arg("match", "match")
+        cls.add_arg("check", "check")
+        cls.add_arg("migratable", "migratable", is_onoff=True)
+
         cls.add_arg("vendor", "vendor")
         cls.add_arg("cache.mode", "cache.mode")
         cls.add_arg("cache.level", "cache.level")

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2263,12 +2263,21 @@ class ParserCPU(VirtCLIParser):
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(*args, **kwargs)
 
-    def sibling_find_inst_cb(self, inst, *args, **kwargs):
+    def cell_sibling_find_inst_cb(self, inst, *args, **kwargs):
         cell = self.cell_find_inst_cb(inst, *args, **kwargs)
         inst = cell
 
         cliarg = "sibling"  # cell[0-9]*.distances.sibling[0-9]*
         list_propname = "siblings"  # cell.siblings
+        cb = self._make_find_inst_cb(cliarg, list_propname)
+        return cb(inst, *args, **kwargs)
+
+    def cell_cache_find_inst_cb(self, inst, *args, **kwargs):
+        cell = self.cell_find_inst_cb(inst, *args, **kwargs)
+        inst = cell
+
+        cliarg = "cache"  # cell[0-9]*.cache[0-9]*
+        list_propname = "caches"  # cell.caches
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(inst, *args, **kwargs)
 
@@ -2341,9 +2350,24 @@ class ParserCPU(VirtCLIParser):
                     find_inst_cb=cls.cell_find_inst_cb)
 
         cls.add_arg("numa.cell[0-9]*.distances.sibling[0-9]*.id", "id",
-                    find_inst_cb=cls.sibling_find_inst_cb)
+                    find_inst_cb=cls.cell_sibling_find_inst_cb)
         cls.add_arg("numa.cell[0-9]*.distances.sibling[0-9]*.value", "value",
-                    find_inst_cb=cls.sibling_find_inst_cb)
+                    find_inst_cb=cls.cell_sibling_find_inst_cb)
+
+        cls.add_arg("numa.cell[0-9]*.cache[0-9]*.level", "level",
+                    find_inst_cb=cls.cell_cache_find_inst_cb)
+        cls.add_arg("numa.cell[0-9]*.cache[0-9]*.associativity", "associativity",
+                    find_inst_cb=cls.cell_cache_find_inst_cb)
+        cls.add_arg("numa.cell[0-9]*.cache[0-9]*.policy", "policy",
+                    find_inst_cb=cls.cell_cache_find_inst_cb)
+        cls.add_arg("numa.cell[0-9]*.cache[0-9]*.size.value", "size_value",
+                    find_inst_cb=cls.cell_cache_find_inst_cb)
+        cls.add_arg("numa.cell[0-9]*.cache[0-9]*.size.unit", "size_unit",
+                    find_inst_cb=cls.cell_cache_find_inst_cb)
+        cls.add_arg("numa.cell[0-9]*.cache[0-9]*.line.value", "line_value",
+                    find_inst_cb=cls.cell_cache_find_inst_cb)
+        cls.add_arg("numa.cell[0-9]*.cache[0-9]*.line.unit", "line_unit",
+                    find_inst_cb=cls.cell_cache_find_inst_cb)
 
 
 #####################

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2281,6 +2281,18 @@ class ParserCPU(VirtCLIParser):
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(inst, *args, **kwargs)
 
+    def latency_find_inst_cb(self, *args, **kwargs):
+        cliarg = "latency"  # latency[0-9]*
+        list_propname = "latencies"  # cpu.latencies
+        cb = self._make_find_inst_cb(cliarg, list_propname)
+        return cb(*args, **kwargs)
+
+    def bandwidth_find_inst_cb(self, *args, **kwargs):
+        cliarg = "bandwidth"  # bandwidth[0-9]*
+        list_propname = "bandwidths"  # cpu.bandwidths
+        cb = self._make_find_inst_cb(cliarg, list_propname)
+        return cb(*args, **kwargs)
+
     def set_model_cb(self, inst, val, virtarg):
         if val == "host":
             val = inst.SPECIAL_MODE_HOST_MODEL
@@ -2313,6 +2325,10 @@ class ParserCPU(VirtCLIParser):
         # 'secure' needs to be parsed before 'model'
         cls.add_arg("secure", "secure", is_onoff=True)
         cls.add_arg("model", "model", cb=cls.set_model_cb)
+        # 'model.fallback' must be parsed after 'model' as it may otherwise be
+        # overridden
+        cls.add_arg("model.fallback", "model_fallback")
+        cls.add_arg("model.vendor_id", "model_vendor_id")
 
         cls.add_arg("mode", "mode")
         cls.add_arg("match", "match")
@@ -2368,6 +2384,32 @@ class ParserCPU(VirtCLIParser):
                     find_inst_cb=cls.cell_cache_find_inst_cb)
         cls.add_arg("numa.cell[0-9]*.cache[0-9]*.line.unit", "line_unit",
                     find_inst_cb=cls.cell_cache_find_inst_cb)
+
+        cls.add_arg("numa.interconnects.latency[0-9]*.initiator", "initiator",
+                    find_inst_cb=cls.latency_find_inst_cb)
+        cls.add_arg("numa.interconnects.latency[0-9]*.target", "target",
+                    find_inst_cb=cls.latency_find_inst_cb)
+        cls.add_arg("numa.interconnects.latency[0-9]*.cache", "cache",
+                    find_inst_cb=cls.latency_find_inst_cb)
+        cls.add_arg("numa.interconnects.latency[0-9]*.type", "type",
+                    find_inst_cb=cls.latency_find_inst_cb)
+        cls.add_arg("numa.interconnects.latency[0-9]*.value", "value",
+                    find_inst_cb=cls.latency_find_inst_cb)
+        cls.add_arg("numa.interconnects.latency[0-9]*.unit", "unit",
+                    find_inst_cb=cls.latency_find_inst_cb)
+
+        cls.add_arg("numa.interconnects.bandwidth[0-9]*.initiator", "initiator",
+                    find_inst_cb=cls.bandwidth_find_inst_cb)
+        cls.add_arg("numa.interconnects.bandwidth[0-9]*.target", "target",
+                    find_inst_cb=cls.bandwidth_find_inst_cb)
+        cls.add_arg("numa.interconnects.bandwidth[0-9]*.type", "type",
+                    find_inst_cb=cls.bandwidth_find_inst_cb)
+        cls.add_arg("numa.interconnects.bandwidth[0-9]*.cache", "cache",
+                    find_inst_cb=cls.bandwidth_find_inst_cb)
+        cls.add_arg("numa.interconnects.bandwidth[0-9]*.value", "value",
+                    find_inst_cb=cls.bandwidth_find_inst_cb)
+        cls.add_arg("numa.interconnects.bandwidth[0-9]*.unit", "unit",
+                    find_inst_cb=cls.bandwidth_find_inst_cb)
 
 
 #####################

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2322,6 +2322,7 @@ class ParserCPU(VirtCLIParser):
         cls.add_arg("forbid", None, lookup_cb=None, cb=cls.set_feature_cb)
 
         cls.add_arg("topology.sockets", "topology.sockets")
+        cls.add_arg("topology.dies", "topology.dies")
         cls.add_arg("topology.cores", "topology.cores")
         cls.add_arg("topology.threads", "topology.threads")
 

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2337,6 +2337,9 @@ class ParserCPU(VirtCLIParser):
                     find_inst_cb=cls.cell_find_inst_cb)
         cls.add_arg("numa.cell[0-9]*.memory", "memory",
                     find_inst_cb=cls.cell_find_inst_cb)
+        cls.add_arg("numa.cell[0-9]*.unit", "unit",
+                    find_inst_cb=cls.cell_find_inst_cb)
+
         cls.add_arg("numa.cell[0-9]*.distances.sibling[0-9]*.id", "id",
                     find_inst_cb=cls.sibling_find_inst_cb)
         cls.add_arg("numa.cell[0-9]*.distances.sibling[0-9]*.value", "value",

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2334,7 +2334,7 @@ class ParserCPU(VirtCLIParser):
         cls.add_arg("numa.cell[0-9]*.memAccess", "memAccess",
                     find_inst_cb=cls.cell_find_inst_cb)
         cls.add_arg("numa.cell[0-9]*.discard", "discard",
-                    find_inst_cb=cls.cell_find_inst_cb)
+                    find_inst_cb=cls.cell_find_inst_cb, is_onoff=True)
         cls.add_arg("numa.cell[0-9]*.memory", "memory",
                     find_inst_cb=cls.cell_find_inst_cb)
         cls.add_arg("numa.cell[0-9]*.unit", "unit",

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -33,7 +33,7 @@ class _CPUCell(XMLBuilder):
     memory = XMLProperty("./@memory", is_int=True)
     unit = XMLProperty("./@unit")
     memAccess = XMLProperty("./@memAccess")
-    discard = XMLProperty("./@discard")
+    discard = XMLProperty("./@discard", is_yesno=True)
     siblings = XMLChildProperty(_CPUCellSibling, relative_xpath="./distances")
 
 

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -10,118 +10,13 @@ from ..xmlbuilder import XMLBuilder, XMLProperty, XMLChildProperty
 from .. import xmlutil
 
 
-class _NUMACellSibling(XMLBuilder):
-    """
-    Class for generating <cpu><numa><cell><distances> child nodes <sibling>,
-    describing the distances to other NUMA cells.
-    """
-    XML_NAME = "sibling"
-    _XML_PROP_ORDER = ["id", "value"]
-
-    id = XMLProperty("./@id", is_int=True)
-    value = XMLProperty("./@value", is_int=True)
-
-
-class _NUMACellCache(XMLBuilder):
-    """
-    Class for generating <cpu><numa><cell> child nodes <cache>, describing
-    caches for NUMA cells.
-    """
-    XML_NAME = "cache"
-    _XML_PROP_ORDER = ["level", "associativity", "policy",
-            "size_value", "size_unit", "line_value", "line_unit"]
-
-    level = XMLProperty("./@level", is_int=True)
-    associativity = XMLProperty("./@associativity")
-    policy = XMLProperty("./@policy")
-
-    size_value = XMLProperty("./size/@value", is_int=True)
-    size_unit = XMLProperty("./size/@unit")
-
-    line_value = XMLProperty("./line/@value", is_int=True)
-    line_unit = XMLProperty("./line/@unit")
-
-
-class _NUMACell(XMLBuilder):
-    """
-    Class for generating <cpu><numa> child nodes <cell> XML, describing NUMA
-    cells.
-    """
-    XML_NAME = "cell"
-    _XML_PROP_ORDER = ["id", "cpus", "memory", "memAccess", "discard"]
-
-    id = XMLProperty("./@id", is_int=True)
-    cpus = XMLProperty("./@cpus")
-    memory = XMLProperty("./@memory", is_int=True)
-    unit = XMLProperty("./@unit")
-    memAccess = XMLProperty("./@memAccess")
-    discard = XMLProperty("./@discard", is_yesno=True)
-    siblings = XMLChildProperty(_NUMACellSibling, relative_xpath="./distances")
-    caches = XMLChildProperty(_NUMACellCache)
-
-
-class _NUMALatency(XMLBuilder):
-    """
-    Class for generating <cpu><numa><cell><interconnects> child nodes
-    <latency>, describing latency between two NUMA memory nodes.
-    """
-    XML_NAME = "latency"
-    _XML_PROP_ORDER = ["initiator", "target", "cache", "type", "value", "unit"]
-
-    initiator = XMLProperty("./@initiator", is_int=True)
-    target = XMLProperty("./@target", is_int=True)
-    cache = XMLProperty("./@cache", is_int=True)
-    type = XMLProperty("./@type")
-    value = XMLProperty("./@value", is_int=True)
-    unit = XMLProperty("./@unit")
-
-
-class _NUMABandwidth(XMLBuilder):
-    """
-    Class for generating <cpu><numa><cell><interconnects> child nodes
-    <bandwidth>, describing bandwidth between two NUMA memory nodes.
-    """
-    XML_NAME = "bandwidth"
-    _XML_PROP_ORDER = ["initiator", "target", "cache", "type", "value", "unit"]
-
-    # Note: The documentation only mentions <latency> nodes havin a cache=
-    # attribute, but <bandwidth> and <latency> nodes are otherwise identical
-    # and libvirt will happily accept XML with a cache= attribute on
-    # <bandwidth> nodes as well, so let's leave it here for now.
-    initiator = XMLProperty("./@initiator", is_int=True)
-    target = XMLProperty("./@target", is_int=True)
-    cache = XMLProperty("./@cache", is_int=True)
-    type = XMLProperty("./@type")
-    value = XMLProperty("./@value", is_int=True)
-    unit = XMLProperty("./@unit")
-
-
-class _CPUCache(XMLBuilder):
-    """
-    Class for generating <cpu> child <cache> XML
-    """
-
-    XML_NAME = "cache"
-    _XML_PROP_ORDER = ["mode", "level"]
-
-    mode = XMLProperty("./@mode")
-    level = XMLProperty("./@level", is_int=True)
-
-
-class _CPUFeature(XMLBuilder):
-    """
-    Class for generating <cpu> child <feature> XML
-    """
-    XML_NAME = "feature"
-    _XML_PROP_ORDER = ["policy", "name"]
-
-    name = XMLProperty("./@name")
-    policy = XMLProperty("./@policy")
-
+###################################
+# Misc child nodes for CPU domain #
+###################################
 
 class _CPUTopology(XMLBuilder):
     """
-    Class for generating <cpu> <topology> XML
+    Class for generating XML for <cpu> child node <topology>.
     """
     XML_NAME = "topology"
     _XML_PROP_ORDER = ["sockets", "dies", "cores", "threads"]
@@ -152,15 +47,176 @@ class _CPUTopology(XMLBuilder):
         return
 
 
+# Note: CPU cache is weird. The documentation implies that multiples instances
+# can be declared, one for each cache level one wishes to define. However,
+# libvirt doesn't accept more than one <cache> element, so it's implemented
+# with `is_single=True` for now (see actual CPU Domain below).
+class _CPUCache(XMLBuilder):
+    """
+    Class for generating XML for <cpu> child node <cache>.
+    """
+    XML_NAME = "cache"
+    _XML_PROP_ORDER = ["level", "mode"]
+
+    level = XMLProperty("./@level", is_int=True)
+    mode = XMLProperty("./@mode")
+
+
+class _CPUFeature(XMLBuilder):
+    """
+    Class for generating XML for <cpu> child nodes <feature>.
+    """
+    XML_NAME = "feature"
+    _XML_PROP_ORDER = ["policy", "name"]
+
+    name = XMLProperty("./@name")
+    policy = XMLProperty("./@policy")
+
+
+##############
+# NUMA cells #
+##############
+
+class _NUMACellSibling(XMLBuilder):
+    """
+    Class for generating XML for <cpu><numa><cell><distances> child nodes
+    <sibling>, describing the distances to other NUMA cells.
+    """
+    XML_NAME = "sibling"
+    _XML_PROP_ORDER = ["id", "value"]
+
+    id = XMLProperty("./@id", is_int=True)
+    value = XMLProperty("./@value", is_int=True)
+
+
+class _NUMACellCache(XMLBuilder):
+    """
+    Class for generating XML for <cpu><numa><cell> child nodes <cache>,
+    describing caches for NUMA cells.
+    """
+    XML_NAME = "cache"
+    _XML_PROP_ORDER = ["level", "associativity", "policy",
+            "size_value", "size_unit", "line_value", "line_unit"]
+
+    level = XMLProperty("./@level", is_int=True)
+    associativity = XMLProperty("./@associativity")
+    policy = XMLProperty("./@policy")
+
+    size_value = XMLProperty("./size/@value", is_int=True)
+    size_unit = XMLProperty("./size/@unit")
+    line_value = XMLProperty("./line/@value", is_int=True)
+    line_unit = XMLProperty("./line/@unit")
+
+
+class _NUMACell(XMLBuilder):
+    """
+    Class for generating XML for <cpu><numa> child nodes <cell> XML, describing
+    NUMA cells.
+    """
+    XML_NAME = "cell"
+    _XML_PROP_ORDER = ["id", "cpus", "memory", "unit", "memAccess", "discard",
+            "siblings", "caches"]
+
+    id = XMLProperty("./@id", is_int=True)
+    cpus = XMLProperty("./@cpus")
+    memory = XMLProperty("./@memory", is_int=True)
+    unit = XMLProperty("./@unit")
+    memAccess = XMLProperty("./@memAccess")
+    discard = XMLProperty("./@discard", is_yesno=True)
+
+    siblings = XMLChildProperty(_NUMACellSibling, relative_xpath="./distances")
+    caches = XMLChildProperty(_NUMACellCache)
+
+
+#######################################
+# Interconnections between NUMA cells #
+#######################################
+
+class _NUMALatency(XMLBuilder):
+    """
+    Class for generating XML for <cpu><numa><cell><interconnects> child nodes
+    <latency>, describing latency between two NUMA memory nodes.
+    """
+    XML_NAME = "latency"
+    _XML_PROP_ORDER = ["initiator", "target", "cache", "type", "value", "unit"]
+
+    # Note: While libvirt happily accepts XML with a unit= property, it is
+    # currently ignored on <latency> nodes.
+    initiator = XMLProperty("./@initiator", is_int=True)
+    target = XMLProperty("./@target", is_int=True)
+    cache = XMLProperty("./@cache", is_int=True)
+    type = XMLProperty("./@type")
+    value = XMLProperty("./@value", is_int=True)
+    unit = XMLProperty("./@unit")
+
+
+class _NUMABandwidth(XMLBuilder):
+    """
+    Class for generating XML for <cpu><numa><cell><interconnects> child nodes
+    <bandwidth>, describing bandwidth between two NUMA memory nodes.
+    """
+    XML_NAME = "bandwidth"
+    _XML_PROP_ORDER = ["initiator", "target", "cache", "type", "value", "unit"]
+
+    # Note: The documentation only mentions <latency> nodes having a cache=
+    # attribute, but <bandwidth> and <latency> nodes are otherwise identical
+    # and libvirt will happily accept XML with a cache= attribute on
+    # <bandwidth> nodes as well, so let's leave it here for now.
+    initiator = XMLProperty("./@initiator", is_int=True)
+    target = XMLProperty("./@target", is_int=True)
+    cache = XMLProperty("./@cache", is_int=True)
+    type = XMLProperty("./@type")
+    value = XMLProperty("./@value", is_int=True)
+    unit = XMLProperty("./@unit")
+
+
+#####################
+# Actual CPU domain #
+#####################
+
 class DomainCpu(XMLBuilder):
     """
     Class for generating <cpu> XML
     """
     XML_NAME = "cpu"
     _XML_PROP_ORDER = ["mode", "match", "check", "migratable",
-            "model", "vendor", "topology", "features"]
+            "model", "model_fallback", "model_vendor_id", "vendor",
+            "topology", "cache", "features",
+            "cells", "latencies", "bandwidths"]
 
+
+    ##################
+    # XML properties #
+    ##################
+
+    # Note: This is not a libvirt property. This is specific to the virt-*
+    # tools and causes additional security features to be added to the VM.
+    # See the security mitigation related functions below for more details.
     secure = True
+
+    mode = XMLProperty("./@mode")
+    match = XMLProperty("./@match")
+    check = XMLProperty("./@check")
+    migratable = XMLProperty("./@migratable", is_onoff=True)
+
+    model = XMLProperty("./model")
+    model_fallback = XMLProperty("./model/@fallback")
+    model_vendor_id = XMLProperty("./model/@vendor_id")
+    vendor = XMLProperty("./vendor")
+
+    topology = XMLChildProperty(_CPUTopology, is_single=True)
+    cache = XMLChildProperty(_CPUCache, is_single=True)
+    features = XMLChildProperty(_CPUFeature)
+
+    # NUMA related properties
+    cells = XMLChildProperty(_NUMACell, relative_xpath="./numa")
+    latencies = XMLChildProperty(_NUMALatency, relative_xpath="./numa/interconnects")
+    bandwidths = XMLChildProperty(_NUMABandwidth, relative_xpath="./numa/interconnects")
+
+
+    #############################
+    # Special CPU mode handling #
+    #############################
 
     special_mode_was_set = False
     # These values are exposed on the command line, so are stable API
@@ -206,6 +262,42 @@ class DomainCpu(XMLBuilder):
 
         self.special_mode_was_set = True
 
+    def copy_host_cpu(self, guest):
+        """
+        Try to manually mimic host-model, copying all the info
+        preferably out of domcapabilities, but capabilities as fallback.
+        """
+        domcaps = guest.lookup_domcaps()
+        if domcaps.supports_safe_host_model():
+            log.debug("Using domcaps for host-copy")
+            cpu = domcaps.cpu.get_mode("host-model")
+            model = cpu.models[0].model
+            fallback = cpu.models[0].fallback
+        else:
+            cpu = self.conn.caps.host.cpu
+            model = cpu.model
+            fallback = None
+            if not model:  # pragma: no cover
+                raise ValueError(_("No host CPU reported in capabilities"))
+
+        self.mode = "custom"
+        self.match = "exact"
+        self.set_model(guest, model)
+        if fallback:
+            self.model_fallback = fallback
+        self.vendor = cpu.vendor
+
+        for feature in self.features:
+            self.remove_child(feature)
+        for feature in cpu.features:
+            policy = getattr(feature, "policy", "require")
+            self.add_feature(feature.name, policy)
+
+
+    ########################
+    # Security mitigations #
+    ########################
+
     def _add_security_features(self, guest):
         domcaps = guest.lookup_domcaps()
         for feature in domcaps.get_cpu_security_features():
@@ -245,6 +337,11 @@ class DomainCpu(XMLBuilder):
                     self.remove_child(f)
                     break
 
+
+    ###########
+    # Helpers #
+    ###########
+
     def set_model(self, guest, val):
         log.debug("setting cpu model %s", val)
         if val:
@@ -261,43 +358,6 @@ class DomainCpu(XMLBuilder):
         feature = self.features.add_new()
         feature.name = name
         feature.policy = policy
-    features = XMLChildProperty(_CPUFeature)
-
-    cells = XMLChildProperty(_NUMACell, relative_xpath="./numa")
-    latencies = XMLChildProperty(_NUMALatency, relative_xpath="./numa/interconnects")
-    bandwidths = XMLChildProperty(_NUMABandwidth, relative_xpath="./numa/interconnects")
-    cache = XMLChildProperty(_CPUCache, is_single=True)
-
-    def copy_host_cpu(self, guest):
-        """
-        Try to manually mimic host-model, copying all the info
-        preferably out of domcapabilities, but capabilities as fallback.
-        """
-        domcaps = guest.lookup_domcaps()
-        if domcaps.supports_safe_host_model():
-            log.debug("Using domcaps for host-copy")
-            cpu = domcaps.cpu.get_mode("host-model")
-            model = cpu.models[0].model
-            fallback = cpu.models[0].fallback
-        else:
-            cpu = self.conn.caps.host.cpu
-            model = cpu.model
-            fallback = None
-            if not model:  # pragma: no cover
-                raise ValueError(_("No host CPU reported in capabilities"))
-
-        self.mode = "custom"
-        self.match = "exact"
-        self.set_model(guest, model)
-        if fallback:
-            self.model_fallback = fallback
-        self.vendor = cpu.vendor
-
-        for feature in self.features:
-            self.remove_child(feature)
-        for feature in cpu.features:
-            policy = getattr(feature, "policy", "require")
-            self.add_feature(feature.name, policy)
 
     def vcpus_from_topology(self):
         """
@@ -323,23 +383,6 @@ class DomainCpu(XMLBuilder):
         if not self.has_topology():
             return
         self.topology.set_defaults_from_vcpus(vcpus)
-
-
-    ##################
-    # XML properties #
-    ##################
-
-    topology = XMLChildProperty(_CPUTopology, is_single=True)
-
-    model = XMLProperty("./model")
-    model_fallback = XMLProperty("./model/@fallback")
-    model_vendor_id = XMLProperty("./model/@vendor_id")
-
-    match = XMLProperty("./@match")
-    vendor = XMLProperty("./vendor")
-    mode = XMLProperty("./@mode")
-    check = XMLProperty("./@check")
-    migratable = XMLProperty("./@migratable", is_onoff=True)
 
 
     ##################

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -94,8 +94,8 @@ class DomainCpu(XMLBuilder):
     Class for generating <cpu> XML
     """
     XML_NAME = "cpu"
-    _XML_PROP_ORDER = ["mode", "match", "model", "vendor",
-            "topology", "features"]
+    _XML_PROP_ORDER = ["mode", "match", "check", "migratable",
+            "model", "vendor", "topology", "features"]
 
     secure = True
 
@@ -272,6 +272,8 @@ class DomainCpu(XMLBuilder):
     match = XMLProperty("./@match")
     vendor = XMLProperty("./vendor")
     mode = XMLProperty("./@mode")
+    check = XMLProperty("./@check")
+    migratable = XMLProperty("./@migratable", is_onoff=True)
 
 
     ##################

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -64,12 +64,15 @@ class _CPUTopology(XMLBuilder):
     Class for generating <cpu> <topology> XML
     """
     XML_NAME = "topology"
-    _XML_PROP_ORDER = ["sockets", "cores", "threads"]
+    _XML_PROP_ORDER = ["sockets", "dies", "cores", "threads"]
 
     sockets = XMLProperty("./@sockets", is_int=True)
+    dies = XMLProperty("./@dies", is_int=True)
     cores = XMLProperty("./@cores", is_int=True)
     threads = XMLProperty("./@threads", is_int=True)
 
+    # While `dies` is optional and defaults to 1 if omitted,
+    # `sockets`, `cores`, and `threads` are mandatory.
     def set_defaults_from_vcpus(self, vcpus):
         if not self.sockets:
             if not self.cores:

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -10,9 +10,10 @@ from ..xmlbuilder import XMLBuilder, XMLProperty, XMLChildProperty
 from .. import xmlutil
 
 
-class _CPUCellSibling(XMLBuilder):
+class _NUMACellSibling(XMLBuilder):
     """
-    Class for generating <distances> <sibling> nodes
+    Class for generating <cpu><numa><cell><distances> child nodes <sibling>,
+    describing the distances to other NUMA cells.
     """
     XML_NAME = "sibling"
     _XML_PROP_ORDER = ["id", "value"]
@@ -21,9 +22,30 @@ class _CPUCellSibling(XMLBuilder):
     value = XMLProperty("./@value", is_int=True)
 
 
-class _CPUCell(XMLBuilder):
+class _NUMACellCache(XMLBuilder):
     """
-    Class for generating <cpu><numa> child <cell> XML
+    Class for generating <cpu><numa><cell> child nodes <cache>, describing
+    caches for NUMA cells.
+    """
+    XML_NAME = "cache"
+    _XML_PROP_ORDER = ["level", "associativity", "policy",
+            "size_value", "size_unit", "line_value", "line_unit"]
+
+    level = XMLProperty("./@level", is_int=True)
+    associativity = XMLProperty("./@associativity")
+    policy = XMLProperty("./@policy")
+
+    size_value = XMLProperty("./size/@value", is_int=True)
+    size_unit = XMLProperty("./size/@unit")
+
+    line_value = XMLProperty("./line/@value", is_int=True)
+    line_unit = XMLProperty("./line/@unit")
+
+
+class _NUMACell(XMLBuilder):
+    """
+    Class for generating <cpu><numa> child nodes <cell> XML, describing NUMA
+    cells.
     """
     XML_NAME = "cell"
     _XML_PROP_ORDER = ["id", "cpus", "memory", "memAccess", "discard"]
@@ -34,7 +56,8 @@ class _CPUCell(XMLBuilder):
     unit = XMLProperty("./@unit")
     memAccess = XMLProperty("./@memAccess")
     discard = XMLProperty("./@discard", is_yesno=True)
-    siblings = XMLChildProperty(_CPUCellSibling, relative_xpath="./distances")
+    siblings = XMLChildProperty(_NUMACellSibling, relative_xpath="./distances")
+    caches = XMLChildProperty(_NUMACellCache)
 
 
 class _CPUCache(XMLBuilder):
@@ -204,7 +227,7 @@ class DomainCpu(XMLBuilder):
         feature.policy = policy
     features = XMLChildProperty(_CPUFeature)
 
-    cells = XMLChildProperty(_CPUCell, relative_xpath="./numa")
+    cells = XMLChildProperty(_NUMACell, relative_xpath="./numa")
     cache = XMLChildProperty(_CPUCache, is_single=True)
 
     def copy_host_cpu(self, guest):

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -60,6 +60,42 @@ class _NUMACell(XMLBuilder):
     caches = XMLChildProperty(_NUMACellCache)
 
 
+class _NUMALatency(XMLBuilder):
+    """
+    Class for generating <cpu><numa><cell><interconnects> child nodes
+    <latency>, describing latency between two NUMA memory nodes.
+    """
+    XML_NAME = "latency"
+    _XML_PROP_ORDER = ["initiator", "target", "cache", "type", "value", "unit"]
+
+    initiator = XMLProperty("./@initiator", is_int=True)
+    target = XMLProperty("./@target", is_int=True)
+    cache = XMLProperty("./@cache", is_int=True)
+    type = XMLProperty("./@type")
+    value = XMLProperty("./@value", is_int=True)
+    unit = XMLProperty("./@unit")
+
+
+class _NUMABandwidth(XMLBuilder):
+    """
+    Class for generating <cpu><numa><cell><interconnects> child nodes
+    <bandwidth>, describing bandwidth between two NUMA memory nodes.
+    """
+    XML_NAME = "bandwidth"
+    _XML_PROP_ORDER = ["initiator", "target", "cache", "type", "value", "unit"]
+
+    # Note: The documentation only mentions <latency> nodes havin a cache=
+    # attribute, but <bandwidth> and <latency> nodes are otherwise identical
+    # and libvirt will happily accept XML with a cache= attribute on
+    # <bandwidth> nodes as well, so let's leave it here for now.
+    initiator = XMLProperty("./@initiator", is_int=True)
+    target = XMLProperty("./@target", is_int=True)
+    cache = XMLProperty("./@cache", is_int=True)
+    type = XMLProperty("./@type")
+    value = XMLProperty("./@value", is_int=True)
+    unit = XMLProperty("./@unit")
+
+
 class _CPUCache(XMLBuilder):
     """
     Class for generating <cpu> child <cache> XML
@@ -228,6 +264,8 @@ class DomainCpu(XMLBuilder):
     features = XMLChildProperty(_CPUFeature)
 
     cells = XMLChildProperty(_NUMACell, relative_xpath="./numa")
+    latencies = XMLChildProperty(_NUMALatency, relative_xpath="./numa/interconnects")
+    bandwidths = XMLChildProperty(_NUMABandwidth, relative_xpath="./numa/interconnects")
     cache = XMLChildProperty(_CPUCache, is_single=True)
 
     def copy_host_cpu(self, guest):
@@ -295,6 +333,7 @@ class DomainCpu(XMLBuilder):
 
     model = XMLProperty("./model")
     model_fallback = XMLProperty("./model/@fallback")
+    model_vendor_id = XMLProperty("./model/@vendor_id")
 
     match = XMLProperty("./@match")
     vendor = XMLProperty("./vendor")

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -31,6 +31,7 @@ class _CPUCell(XMLBuilder):
     id = XMLProperty("./@id", is_int=True)
     cpus = XMLProperty("./@cpus")
     memory = XMLProperty("./@memory", is_int=True)
+    unit = XMLProperty("./@unit")
     memAccess = XMLProperty("./@memAccess")
     discard = XMLProperty("./@discard")
     siblings = XMLChildProperty(_CPUCellSibling, relative_xpath="./distances")


### PR DESCRIPTION
This should add all missing options to `--cpu` as of 7.5.0 and bring the ordering in the XML in line with libvirt's own output.