### PR TITLE
cli: --cputune: implement missing options

### DIFF
--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -254,7 +254,14 @@
     <vcpusched vcpus="0-3,^2" scheduler="fifo" priority="95"/>
     <iothreadsched iothreads="1,2" scheduler="fifo" priority="90"/>
     <cachetune vcpus="0-3">
-      <cache level="3" id="0" type="both" size="3" unit="MiB"/>
+      <cache id="0" level="3" type="both" size="3" unit="MiB"/>
+      <cache id="1" level="3" type="both" size="3" unit="MiB"/>
+      <monitor level="3" vcpus="2"/>
+      <monitor level="3" vcpus="0-3,^2"/>
+    </cachetune>
+    <cachetune vcpus="4-5">
+      <monitor level="3" vcpus="4"/>
+      <monitor level="3" vcpus="5"/>
     </cachetune>
     <memorytune vcpus="0-3">
       <node id="0" bandwidth="60"/>
@@ -520,7 +527,14 @@
     <vcpusched vcpus="0-3,^2" scheduler="fifo" priority="95"/>
     <iothreadsched iothreads="1,2" scheduler="fifo" priority="90"/>
     <cachetune vcpus="0-3">
-      <cache level="3" id="0" type="both" size="3" unit="MiB"/>
+      <cache id="0" level="3" type="both" size="3" unit="MiB"/>
+      <cache id="1" level="3" type="both" size="3" unit="MiB"/>
+      <monitor level="3" vcpus="2"/>
+      <monitor level="3" vcpus="0-3,^2"/>
+    </cachetune>
+    <cachetune vcpus="4-5">
+      <monitor level="3" vcpus="4"/>
+      <monitor level="3" vcpus="5"/>
     </cachetune>
     <memorytune vcpus="0-3">
       <node id="0" bandwidth="60"/>

--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -238,6 +238,15 @@
   </keywrap>
   <on_lockfailure>ignore</on_lockfailure>
   <cputune>
+    <shares>2048</shares>
+    <period>1000000</period>
+    <quota>-1</quota>
+    <global_period>1000000</global_period>
+    <global_quota>-1</global_quota>
+    <emulator_period>1000000</emulator_period>
+    <emulator_quota>-1</emulator_quota>
+    <iothread_period>1000000</iothread_period>
+    <iothread_quota>-1</iothread_quota>
     <vcpupin vcpu="0" cpuset="0-3"/>
     <emulatorpin cpuset="1,7"/>
     <iothreadpin iothread="1" cpuset="1,7"/>
@@ -493,6 +502,15 @@
   </keywrap>
   <on_lockfailure>ignore</on_lockfailure>
   <cputune>
+    <shares>2048</shares>
+    <period>1000000</period>
+    <quota>-1</quota>
+    <global_period>1000000</global_period>
+    <global_quota>-1</global_quota>
+    <emulator_period>1000000</emulator_period>
+    <emulator_quota>-1</emulator_quota>
+    <iothread_period>1000000</iothread_period>
+    <iothread_quota>-1</iothread_quota>
     <vcpupin vcpu="0" cpuset="0-3"/>
     <emulatorpin cpuset="1,7"/>
     <iothreadpin iothread="1" cpuset="1,7"/>

--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -250,13 +250,15 @@
     <vcpupin vcpu="0" cpuset="0-3"/>
     <emulatorpin cpuset="1,7"/>
     <iothreadpin iothread="1" cpuset="1,7"/>
+    <emulatorsched scheduler="rr" priority="99"/>
+    <vcpusched vcpus="0-3,^2" scheduler="fifo" priority="95"/>
+    <iothreadsched iothreads="1,2" scheduler="fifo" priority="90"/>
     <cachetune vcpus="0-3">
       <cache level="3" id="0" type="both" size="3" unit="MiB"/>
     </cachetune>
     <memorytune vcpus="0-3">
       <node id="0" bandwidth="60"/>
     </memorytune>
-    <vcpusched vcpus="0-3,^2" scheduler="fifo" priority="95"/>
   </cputune>
 </domain>
 <domain type="kvm">
@@ -514,12 +516,14 @@
     <vcpupin vcpu="0" cpuset="0-3"/>
     <emulatorpin cpuset="1,7"/>
     <iothreadpin iothread="1" cpuset="1,7"/>
+    <emulatorsched scheduler="rr" priority="99"/>
+    <vcpusched vcpus="0-3,^2" scheduler="fifo" priority="95"/>
+    <iothreadsched iothreads="1,2" scheduler="fifo" priority="90"/>
     <cachetune vcpus="0-3">
       <cache level="3" id="0" type="both" size="3" unit="MiB"/>
     </cachetune>
     <memorytune vcpus="0-3">
       <node id="0" bandwidth="60"/>
     </memorytune>
-    <vcpusched vcpus="0-3,^2" scheduler="fifo" priority="95"/>
   </cputune>
 </domain>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -515,7 +515,11 @@ cell0.distances.sibling1.id=1,cell0.distances.sibling1.value=21,\
 numa.cell1.distances.sibling0.id=0,numa.cell1.distances.sibling0.value=21,\
 cell1.distances.sibling1.id=1,cell1.distances.sibling1.value=10,\
 cache.mode=emulate,cache.level=3
---cputune vcpupin0.vcpu=0,vcpupin0.cpuset=0-3,emulatorpin.cpuset=1,7,iothreadpin0.iothread=1,iothreadpin0.cpuset=1,7,cachetune0.vcpus=0-3,cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60,vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95
+--cputune shares=2048,period=1000000,quota=-1,global_period=1000000,global_quota=-1,emulator_period=1000000,emulator_quota=-1,iothread_period=1000000,iothread_quota=-1,\
+vcpupin0.vcpu=0,vcpupin0.cpuset=0-3,emulatorpin.cpuset=1,7,iothreadpin0.iothread=1,iothreadpin0.cpuset=1,7,\
+cachetune0.vcpus=0-3,cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,\
+memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60,\
+vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95
 --iothreads iothreads=2,iothreadids.iothread1.id=1,iothreadids.iothread2.id=2
 --metadata title=my-title,description=my-description,uuid=00000000-1111-2222-3333-444444444444,genid=e9392370-2917-565e-692b-d057f46512d6
 --boot cdrom,fd,hd,network,menu=off,loader=/foo/bar,emulator=/new/emu,bootloader=/new/bootld,rebootTimeout=3,initargs="foo=bar baz=woo",initdir=/my/custom/cwd,inituser=tester,initgroup=1000,firmware=efi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -518,7 +518,14 @@ cache.mode=emulate,cache.level=3
 --cputune shares=2048,period=1000000,quota=-1,global_period=1000000,global_quota=-1,emulator_period=1000000,emulator_quota=-1,iothread_period=1000000,iothread_quota=-1,\
 vcpupin0.vcpu=0,vcpupin0.cpuset=0-3,emulatorpin.cpuset=1,7,iothreadpin0.iothread=1,iothreadpin0.cpuset=1,7,\
 emulatorsched.scheduler=rr,emulatorsched.priority=99,vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95,iothreadsched0.iothreads=1,2,iothreadsched0.scheduler=fifo,iothreadsched0.priority=90,\
-cachetune0.vcpus=0-3,cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,\
+cachetune0.vcpus=0-3,\
+cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,\
+cachetune0.cache1.level=3,cachetune0.cache1.id=1,cachetune0.cache1.type=both,cachetune0.cache1.size=3,cachetune0.cache1.unit=MiB,\
+cachetune0.monitor0.level=3,cachetune0.monitor0.vcpus=2,\
+cachetune0.monitor1.level=3,cachetune0.monitor1.vcpus=0-3,^2,\
+cachetune1.vcpus=4-5,\
+cachetune1.monitor0.level=3,cachetune1.monitor0.vcpus=4,\
+cachetune1.monitor1.level=3,cachetune1.monitor1.vcpus=5,\
 memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60
 --iothreads iothreads=2,iothreadids.iothread1.id=1,iothreadids.iothread2.id=2
 --metadata title=my-title,description=my-description,uuid=00000000-1111-2222-3333-444444444444,genid=e9392370-2917-565e-692b-d057f46512d6

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -517,9 +517,9 @@ cell1.distances.sibling1.id=1,cell1.distances.sibling1.value=10,\
 cache.mode=emulate,cache.level=3
 --cputune shares=2048,period=1000000,quota=-1,global_period=1000000,global_quota=-1,emulator_period=1000000,emulator_quota=-1,iothread_period=1000000,iothread_quota=-1,\
 vcpupin0.vcpu=0,vcpupin0.cpuset=0-3,emulatorpin.cpuset=1,7,iothreadpin0.iothread=1,iothreadpin0.cpuset=1,7,\
+emulatorsched.scheduler=rr,emulatorsched.priority=99,vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95,iothreadsched0.iothreads=1,2,iothreadsched0.scheduler=fifo,iothreadsched0.priority=90,\
 cachetune0.vcpus=0-3,cachetune0.cache0.level=3,cachetune0.cache0.id=0,cachetune0.cache0.type=both,cachetune0.cache0.size=3,cachetune0.cache0.unit=MiB,\
-memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60,\
-vcpusched0.vcpus=0-3,^2,vcpusched0.scheduler=fifo,vcpusched0.priority=95
+memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60
 --iothreads iothreads=2,iothreadids.iothread1.id=1,iothreadids.iothread2.id=2
 --metadata title=my-title,description=my-description,uuid=00000000-1111-2222-3333-444444444444,genid=e9392370-2917-565e-692b-d057f46512d6
 --boot cdrom,fd,hd,network,menu=off,loader=/foo/bar,emulator=/new/emu,bootloader=/new/bootld,rebootTimeout=3,initargs="foo=bar baz=woo",initdir=/my/custom/cwd,inituser=tester,initgroup=1000,firmware=efi

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2366,6 +2366,12 @@ class ParserCputune(VirtCLIParser):
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(*args, **kwargs)
 
+    def iothreadsched_find_inst_cb(self, *args, **kwargs):
+        cliarg = "iothreadsched"  # iothreadsched[0-9]*
+        list_propname = "iothreadscheds"  # cputune.iothreadscheds
+        cb = self._make_find_inst_cb(cliarg, list_propname)
+        return cb(*args, **kwargs)
+
     def cachetune_find_inst_cb(self, *args, **kwargs):
         cliarg = "cachetune"  # cachetune[0-9]*
         list_propname = "cachetunes"  # cputune.cachetunes
@@ -2420,12 +2426,23 @@ class ParserCputune(VirtCLIParser):
                     find_inst_cb=cls.iothreadpin_find_inst_cb)
         cls.add_arg("iothreadpin[0-9]*.cpuset", "cpuset", can_comma=True,
                     find_inst_cb=cls.iothreadpin_find_inst_cb)
+
+        # Scheduling
+        cls.add_arg("emulatorsched.scheduler", "emulatorsched_scheduler")
+        cls.add_arg("emulatorsched.priority", "emulatorsched_priority")
         cls.add_arg("vcpusched[0-9]*.vcpus", "vcpus", can_comma=True,
                     find_inst_cb=cls.vcpusched_find_inst_cb)
         cls.add_arg("vcpusched[0-9]*.scheduler", "scheduler",
                     find_inst_cb=cls.vcpusched_find_inst_cb)
         cls.add_arg("vcpusched[0-9]*.priority", "priority",
                     find_inst_cb=cls.vcpusched_find_inst_cb)
+        cls.add_arg("iothreadsched[0-9]*.iothreads", "iothreads", can_comma=True,
+                    find_inst_cb=cls.iothreadsched_find_inst_cb)
+        cls.add_arg("iothreadsched[0-9]*.scheduler", "scheduler",
+                    find_inst_cb=cls.iothreadsched_find_inst_cb)
+        cls.add_arg("iothreadsched[0-9]*.priority", "priority",
+                    find_inst_cb=cls.iothreadsched_find_inst_cb)
+
         cls.add_arg("cachetune[0-9]*.vcpus", "vcpus",
                     find_inst_cb=cls.cachetune_find_inst_cb)
         cls.add_arg("cachetune[0-9]*.cache[0-9]*.level", "level",

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2399,6 +2399,17 @@ class ParserCputune(VirtCLIParser):
     @classmethod
     def _init_class(cls, **kwargs):
         VirtCLIParser._init_class(**kwargs)
+        # Resource quotas
+        cls.add_arg("shares", "shares")
+        cls.add_arg("period", "period")
+        cls.add_arg("quota", "quota")
+        cls.add_arg("global_period", "global_period")
+        cls.add_arg("global_quota", "global_quota")
+        cls.add_arg("emulator_period", "emulator_period")
+        cls.add_arg("emulator_quota", "emulator_quota")
+        cls.add_arg("iothread_period", "iothread_period")
+        cls.add_arg("iothread_quota", "iothread_quota")
+
         # Options for CPU.vcpus config
         cls.add_arg("vcpupin[0-9]*.vcpu", "vcpu",
                     find_inst_cb=cls.vcpu_find_inst_cb)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2387,6 +2387,15 @@ class ParserCputune(VirtCLIParser):
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(inst, *args, **kwargs)
 
+    def monitor_find_inst_cb(self, inst, *args, **kwargs):
+        cachetune = self.cachetune_find_inst_cb(inst, *args, **kwargs)
+        inst = cachetune
+
+        cliarg = "monitor"  # cachetune[0-9]*.monitor[0-9]*
+        list_propname = "monitors"  # cachetune.monitors
+        cb = self._make_find_inst_cb(cliarg, list_propname)
+        return cb(inst, *args, **kwargs)
+
     def memorytune_find_inst_cb(self, *args, **kwargs):
         cliarg = "memorytune"  # memorytune[0-9]*
         list_propname = "memorytunes"  # cputune.memorytunes
@@ -2443,11 +2452,12 @@ class ParserCputune(VirtCLIParser):
         cls.add_arg("iothreadsched[0-9]*.priority", "priority",
                     find_inst_cb=cls.iothreadsched_find_inst_cb)
 
+        # CPU Cache & Memory Tunables
         cls.add_arg("cachetune[0-9]*.vcpus", "vcpus",
-                    find_inst_cb=cls.cachetune_find_inst_cb)
-        cls.add_arg("cachetune[0-9]*.cache[0-9]*.level", "level",
-                    find_inst_cb=cls.cache_find_inst_cb)
+                    find_inst_cb=cls.cachetune_find_inst_cb, can_comma=True)
         cls.add_arg("cachetune[0-9]*.cache[0-9]*.id", "id",
+                    find_inst_cb=cls.cache_find_inst_cb)
+        cls.add_arg("cachetune[0-9]*.cache[0-9]*.level", "level",
                     find_inst_cb=cls.cache_find_inst_cb)
         cls.add_arg("cachetune[0-9]*.cache[0-9]*.type", "type",
                     find_inst_cb=cls.cache_find_inst_cb)
@@ -2455,8 +2465,12 @@ class ParserCputune(VirtCLIParser):
                     find_inst_cb=cls.cache_find_inst_cb)
         cls.add_arg("cachetune[0-9]*.cache[0-9]*.unit", "unit",
                     find_inst_cb=cls.cache_find_inst_cb)
+        cls.add_arg("cachetune[0-9]*.monitor[0-9]*.level", "level",
+                    find_inst_cb=cls.monitor_find_inst_cb)
+        cls.add_arg("cachetune[0-9]*.monitor[0-9]*.vcpus", "vcpus",
+                    find_inst_cb=cls.monitor_find_inst_cb, can_comma=True)
         cls.add_arg("memorytune[0-9]*.vcpus", "vcpus",
-                    find_inst_cb=cls.memorytune_find_inst_cb)
+                    find_inst_cb=cls.memorytune_find_inst_cb, can_comma=True)
         cls.add_arg("memorytune[0-9]*.node[0-9]*.id", "id",
                     find_inst_cb=cls.node_find_inst_cb)
         cls.add_arg("memorytune[0-9]*.node[0-9]*.bandwidth", "bandwidth",

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2348,27 +2348,27 @@ class ParserCputune(VirtCLIParser):
     remove_first = "model"
     stub_none = False
 
-    def vcpu_find_inst_cb(self, *args, **kwargs):
+    def vcpupin_find_inst_cb(self, *args, **kwargs):
         cliarg = "vcpupin"  # vcpupin[0-9]*
-        list_propname = "vcpus"
+        list_propname = "vcpupins"  # cputune.vcpupins
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(*args, **kwargs)
 
     def iothreadpin_find_inst_cb(self, *args, **kwargs):
         cliarg = "iothreadpin"  # iothreadpin[0-9]*
-        list_propname = "iothreadpin"
+        list_propname = "iothreadpins"  # cputune.iothreadpins
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(*args, **kwargs)
 
     def vcpusched_find_inst_cb(self, *args, **kwargs):
         cliarg = "vcpusched"  # vcpusched[0-9]*
-        list_propname = "vcpusched"
+        list_propname = "vcpuscheds"  # cputune.vcpuscheds
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(*args, **kwargs)
 
     def cachetune_find_inst_cb(self, *args, **kwargs):
         cliarg = "cachetune"  # cachetune[0-9]*
-        list_propname = "cachetune"
+        list_propname = "cachetunes"  # cputune.cachetunes
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(*args, **kwargs)
 
@@ -2383,7 +2383,7 @@ class ParserCputune(VirtCLIParser):
 
     def memorytune_find_inst_cb(self, *args, **kwargs):
         cliarg = "memorytune"  # memorytune[0-9]*
-        list_propname = "memorytune"
+        list_propname = "memorytunes"  # cputune.memorytunes
         cb = self._make_find_inst_cb(cliarg, list_propname)
         return cb(*args, **kwargs)
 
@@ -2412,9 +2412,9 @@ class ParserCputune(VirtCLIParser):
 
         # Options for CPU.vcpus config
         cls.add_arg("vcpupin[0-9]*.vcpu", "vcpu",
-                    find_inst_cb=cls.vcpu_find_inst_cb)
+                    find_inst_cb=cls.vcpupin_find_inst_cb)
         cls.add_arg("vcpupin[0-9]*.cpuset", "cpuset", can_comma=True,
-                    find_inst_cb=cls.vcpu_find_inst_cb)
+                    find_inst_cb=cls.vcpupin_find_inst_cb)
         cls.add_arg("emulatorpin.cpuset", "emulatorpin_cpuset", can_comma=True)
         cls.add_arg("iothreadpin[0-9]*.iothread", "iothread",
                     find_inst_cb=cls.iothreadpin_find_inst_cb)

--- a/virtinst/domain/cputune.py
+++ b/virtinst/domain/cputune.py
@@ -91,8 +91,23 @@ class DomainCputune(XMLBuilder):
     Class for generating <cpu> XML
     """
     XML_NAME = "cputune"
-    _XML_PROP_ORDER = ["vcpus", "emulatorpin_cpuset", "iothreadpin",
+    _XML_PROP_ORDER = ["shares", "period", "quota",
+            "global_period", "global_quota",
+            "emulator_period", "emulator_quota",
+            "iothread_period", "iothread_quota",
+            "vcpus", "emulatorpin_cpuset", "iothreadpin",
              "cachetune", "memorytune", "vcpusched"]
+
+    # Resource quotas
+    shares = XMLProperty("./shares", is_int=True)
+    period = XMLProperty("./period", is_int=True)
+    quota = XMLProperty("./quota", is_int=True)
+    global_period = XMLProperty("./global_period", is_int=True)
+    global_quota = XMLProperty("./global_quota", is_int=True)
+    emulator_period = XMLProperty("./emulator_period", is_int=True)
+    emulator_quota = XMLProperty("./emulator_quota", is_int=True)
+    iothread_period = XMLProperty("./iothread_period", is_int=True)
+    iothread_quota = XMLProperty("./iothread_quota", is_int=True)
 
     vcpus = XMLChildProperty(_VCPUPin)
     iothreadpin = XMLChildProperty(_IOThreadPin)

--- a/virtinst/domain/cputune.py
+++ b/virtinst/domain/cputune.py
@@ -32,6 +32,34 @@ class _IOThreadPin(XMLBuilder):
     cpuset = XMLProperty("./@cpuset")
 
 
+##############
+# Scheduling #
+##############
+
+class _VCPUSched(XMLBuilder):
+    """
+    Class for generating <cputune> child <vcpusched> XML
+    """
+    XML_NAME = "vcpusched"
+    _XML_PROP_ORDER = ["vcpus", "scheduler", "priority"]
+
+    vcpus = XMLProperty("./@vcpus")
+    scheduler = XMLProperty("./@scheduler")
+    priority = XMLProperty("./@priority", is_int=True)
+
+
+class _IOThreadSched(XMLBuilder):
+    """
+    Class for generating <cputune> child <iothreadsched> XML
+    """
+    XML_NAME = "iothreadsched"
+    _XML_PROP_ORDER = ["iothreads", "scheduler", "priority"]
+
+    iothreads = XMLProperty("./@iothreads")
+    scheduler = XMLProperty("./@scheduler")
+    priority = XMLProperty("./@priority", is_int=True)
+
+
 class _CacheCPU(XMLBuilder):
     """
     Class for generating <cachetune> child <cache> XML
@@ -78,18 +106,6 @@ class _MemoryTuneCPU(XMLBuilder):
     nodes = XMLChildProperty(_NodeCPU)
 
 
-class _VCPUSched(XMLBuilder):
-    """
-    Class for generating <cputune> child <vcpusched> XML
-    """
-    XML_NAME = "vcpusched"
-    _XML_PROP_ORDER = ["vcpus", "scheduler", "priority"]
-
-    vcpus = XMLProperty("./@vcpus")
-    scheduler = XMLProperty("./@scheduler")
-    priority = XMLProperty("./@priority", is_int=True)
-
-
 class DomainCputune(XMLBuilder):
     """
     Class for generating <cpu> XML
@@ -98,7 +114,8 @@ class DomainCputune(XMLBuilder):
     _XML_PROP_ORDER = ["shares", "period", "quota", "global_period", "global_quota",
             "emulator_period", "emulator_quota", "iothread_period", "iothread_quota",
             "vcpupins", "emulatorpin_cpuset", "iothreadpins",
-            "cachetunes", "memorytunes", "vcpuscheds"]
+            "emulatorsched_scheduler", "emulatorsched_priority", "vcpuscheds", "iothreadscheds",
+            "cachetunes", "memorytunes"]
 
     # Resource quotas
     shares = XMLProperty("./shares", is_int=True)
@@ -115,6 +132,12 @@ class DomainCputune(XMLBuilder):
     vcpupins = XMLChildProperty(_VCPUPin)
     emulatorpin_cpuset = XMLProperty("./emulatorpin/@cpuset")
     iothreadpins = XMLChildProperty(_IOThreadPin)
+
+    # Scheduling
+    emulatorsched_scheduler = XMLProperty("./emulatorsched/@scheduler")
+    emulatorsched_priority = XMLProperty("./emulatorsched/@priority", is_int=True)
+    vcpuscheds = XMLChildProperty(_VCPUSched)
+    iothreadscheds = XMLChildProperty(_IOThreadSched)
+
     cachetunes = XMLChildProperty(_CacheTuneCPU)
     memorytunes = XMLChildProperty(_MemoryTuneCPU)
-    vcpuscheds = XMLChildProperty(_VCPUSched)

--- a/virtinst/domain/cputune.py
+++ b/virtinst/domain/cputune.py
@@ -6,6 +6,10 @@
 from ..xmlbuilder import XMLBuilder, XMLProperty, XMLChildProperty
 
 
+###############
+# CPU Pinning #
+###############
+
 class _VCPUPin(XMLBuilder):
     """
     Class for generating <cputune> child <vcpupin> XML
@@ -91,12 +95,10 @@ class DomainCputune(XMLBuilder):
     Class for generating <cpu> XML
     """
     XML_NAME = "cputune"
-    _XML_PROP_ORDER = ["shares", "period", "quota",
-            "global_period", "global_quota",
-            "emulator_period", "emulator_quota",
-            "iothread_period", "iothread_quota",
-            "vcpus", "emulatorpin_cpuset", "iothreadpin",
-             "cachetune", "memorytune", "vcpusched"]
+    _XML_PROP_ORDER = ["shares", "period", "quota", "global_period", "global_quota",
+            "emulator_period", "emulator_quota", "iothread_period", "iothread_quota",
+            "vcpupins", "emulatorpin_cpuset", "iothreadpins",
+            "cachetunes", "memorytunes", "vcpuscheds"]
 
     # Resource quotas
     shares = XMLProperty("./shares", is_int=True)
@@ -109,10 +111,10 @@ class DomainCputune(XMLBuilder):
     iothread_period = XMLProperty("./iothread_period", is_int=True)
     iothread_quota = XMLProperty("./iothread_quota", is_int=True)
 
-    vcpus = XMLChildProperty(_VCPUPin)
-    iothreadpin = XMLChildProperty(_IOThreadPin)
-    cachetune = XMLChildProperty(_CacheTuneCPU)
-    memorytune = XMLChildProperty(_MemoryTuneCPU)
-    vcpusched = XMLChildProperty(_VCPUSched)
-
+    # CPU Pinning
+    vcpupins = XMLChildProperty(_VCPUPin)
     emulatorpin_cpuset = XMLProperty("./emulatorpin/@cpuset")
+    iothreadpins = XMLChildProperty(_IOThreadPin)
+    cachetunes = XMLChildProperty(_CacheTuneCPU)
+    memorytunes = XMLChildProperty(_MemoryTuneCPU)
+    vcpuscheds = XMLChildProperty(_VCPUSched)

--- a/virtinst/domain/cputune.py
+++ b/virtinst/domain/cputune.py
@@ -60,21 +60,36 @@ class _IOThreadSched(XMLBuilder):
     priority = XMLProperty("./@priority", is_int=True)
 
 
-class _CacheCPU(XMLBuilder):
+###########################
+# Cache & Memory Tunables #
+###########################
+
+class _CacheTuneCache(XMLBuilder):
     """
     Class for generating <cachetune> child <cache> XML
     """
     XML_NAME = "cache"
-    _XML_PROP_ORDER = ["level", "id", "type", "size", "unit"]
+    _XML_PROP_ORDER = ["id", "level", "type", "size", "unit"]
 
-    level = XMLProperty("./@level", is_int=True)
     id = XMLProperty("./@id", is_int=True)
+    level = XMLProperty("./@level", is_int=True)
     type = XMLProperty("./@type")
     size = XMLProperty("./@size", is_int=True)
     unit = XMLProperty("./@unit")
 
 
-class _CacheTuneCPU(XMLBuilder):
+class _CacheTuneMonitor(XMLBuilder):
+    """
+    Class for generating <cachetune> child <monitor> XML
+    """
+    XML_NAME = "monitor"
+    _XML_PROP_ORDER = ["level", "vcpus"]
+
+    level = XMLProperty("./@level", is_int=True)
+    vcpus = XMLProperty("./@vcpus")
+
+
+class _CacheTune(XMLBuilder):
     """
     Class for generating <cputune> child <cachetune> XML
     """
@@ -82,10 +97,11 @@ class _CacheTuneCPU(XMLBuilder):
     _XML_PROP_ORDER = ["vcpus", "caches"]
 
     vcpus = XMLProperty("./@vcpus")
-    caches = XMLChildProperty(_CacheCPU)
+    caches = XMLChildProperty(_CacheTuneCache)
+    monitors = XMLChildProperty(_CacheTuneMonitor)
 
 
-class _NodeCPU(XMLBuilder):
+class _MemoryTuneNode(XMLBuilder):
     """
     Class for generating <memorytune> child <node> XML
     """
@@ -96,19 +112,24 @@ class _NodeCPU(XMLBuilder):
     bandwidth = XMLProperty("./@bandwidth", is_int=True)
 
 
-class _MemoryTuneCPU(XMLBuilder):
+class _MemoryTune(XMLBuilder):
     """
     Class for generating <cputune> child <memorytune> XML
     """
     XML_NAME = "memorytune"
+    _XML_PROP_ORDER = ["vcpus", "nodes"]
 
     vcpus = XMLProperty("./@vcpus")
-    nodes = XMLChildProperty(_NodeCPU)
+    nodes = XMLChildProperty(_MemoryTuneNode)
 
+
+#########################
+# Actual CPUTune domain #
+#########################
 
 class DomainCputune(XMLBuilder):
     """
-    Class for generating <cpu> XML
+    Class for generating <cputune> XML
     """
     XML_NAME = "cputune"
     _XML_PROP_ORDER = ["shares", "period", "quota", "global_period", "global_quota",
@@ -139,5 +160,6 @@ class DomainCputune(XMLBuilder):
     vcpuscheds = XMLChildProperty(_VCPUSched)
     iothreadscheds = XMLChildProperty(_IOThreadSched)
 
-    cachetunes = XMLChildProperty(_CacheTuneCPU)
-    memorytunes = XMLChildProperty(_MemoryTuneCPU)
+    # Cache & Memory Tunables
+    cachetunes = XMLChildProperty(_CacheTune)
+    memorytunes = XMLChildProperty(_MemoryTune)


### PR DESCRIPTION
This should add all missing options to --cputune as of 7.6.0 and bring the ordering in the XML in line with libvirt's own output.