### PR TITLE
urlfetcher: Make `check_output` call compatible with Python 3.6

### DIFF
--- a/virtinst/install/urlfetcher.py
+++ b/virtinst/install/urlfetcher.py
@@ -33,7 +33,7 @@ class _XorrisoReader():
 
         log.debug("Generating iso filelist: %s", cmd)
         output = subprocess.check_output(cmd,
-                stderr=subprocess.DEVNULL, text=True)
+                stderr=subprocess.DEVNULL, universal_newlines=True)
         return output.split(delim, 1)[1].strip().splitlines()
 
     def grabFile(self, url, scratchdir):


### PR DESCRIPTION
Fixes: #291

The `text=` keyword was added in Python 3.7 "as a more readable
alias for `universal_newlines=`". This commit switches to the
old form of the name, for backwards compatibility with Python 3.6,
the default Python3 version on Ubuntu 18.04 and RHEL 8.

When support for Python 3.6 is no longer needed, this change can
be reverted.