### PR TITLE
use default cloud user for SSH key

### DIFF
--- a/virtinst/install/cloudinit.py
+++ b/virtinst/install/cloudinit.py
@@ -76,11 +76,9 @@ def _create_userdata_content(cloudinit_data):
         content += "  expire: False\n"
 
     if cloudinit_data.ssh_key:
-        rootpass = cloudinit_data.get_ssh_key()
+        sshkey = cloudinit_data.get_ssh_key()
         content += "users:\n"
-        content += "  - name: root\n"
-        content += "    ssh-authorized-keys:\n"
-        content += "      - %s\n" % rootpass
+        content += "  - ssh-authorized-keys: %s\n" % sshkey
 
     if cloudinit_data.disable:
         content += "runcmd:\n"


### PR DESCRIPTION
current `--cloud-init` implementation to `virt-install` uses the
`root` user the provision the SSH key. This patch uses the default
user account as defined in `cloud.cfg` of cloud-init. This matches
behavior of other cloud deployment platforms like e.g. OpenStack.

Possible fix for #307 