### PR TITLE
Disk pool volumes should be always attached as 'raw' disks

### DIFF
--- a/tests/data/cli/compare/virt-xml-build-disk-pool-disk.xml
+++ b/tests/data/cli/compare/virt-xml-build-disk-pool-disk.xml
@@ -1,0 +1,5 @@
+<disk type="volume" device="disk">
+  <driver name="qemu" type="raw"/>
+  <source volume="sdfg1" pool="pool-disk"/>
+  <target dev="vdag" bus="virtio"/>
+</disk>

--- a/tests/data/testdriver/testdriver.xml
+++ b/tests/data/testdriver/testdriver.xml
@@ -2017,6 +2017,45 @@ ba</description>
   </volume>
 </pool>
 
+<pool type='disk'>
+  <name>pool-disk</name>
+  <uuid>f426a5fe-d5b7-4086-a30d-95e32731cbb7</uuid>
+  <capacity unit='bytes'>2088960</capacity>
+  <allocation unit='bytes'>1304576</allocation>
+  <available unit='bytes'>783360</available>
+  <source>
+    <device path='/dev/sdfg'>
+      <freeExtent start='1305600' end='2088960'/>
+    </device>
+    <format type='dos'/>
+  </source>
+  <target>
+    <path>/dev/pool-disk</path>
+  </target>
+
+  <volume type='block'>
+    <name>sdfg1</name>
+    <key>/dev/sdfg1</key>
+    <source>
+      <device path='/dev/sdfg'>
+        <extent start='1024' end='1305600'/>
+      </device>
+    </source>
+    <capacity unit='bytes'>1304576</capacity>
+    <allocation unit='bytes'>1304576</allocation>
+    <physical unit='bytes'>1304576</physical>
+    <target>
+      <path>/dev/sda1</path>
+      <format type='none'/>
+      <permissions>
+        <mode>0660</mode>
+        <owner>0</owner>
+        <group>6</group>
+        <label>system_u:object_r:fixed_disk_device_t:s0</label>
+      </permissions>
+    </target>
+  </volume>
+</pool>
 
 <pool type='logical'>
   <name>disk-pool</name>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1267,6 +1267,7 @@ c.add_compare("--edit --print-diff --qemu-commandline clearxml=yes", "edit-clear
 c.add_compare("--print-diff --remove-device --serial 1", "remove-console-dup", input_file=(_VIRTXMLDIR + "virtxml-console-dup.xml"))
 c.add_compare("--connect %(URI-KVM)s test-hyperv-uefi --edit --boot uefi", "hyperv-uefi-collision")
 c.add_compare("--connect %(URI-KVM)s test-many-devices --edit --cpu host-copy", "edit-cpu-host-copy")
+c.add_compare("--connect %(URI-KVM)s test-many-devices --build-xml --disk source.pool=pool-disk,source.volume=sdfg1", "build-disk-pool-disk")
 c.add_compare("test --add-device --network default --update --confirm", "update-succeed", env={"VIRTXML_TESTSUITE_UPDATE_IGNORE_FAIL": "1", "VIRTINST_TEST_SUITE_INCREMENT_MACADDR": "1"}, input_text="yes\nyes\n")  # test hotplug success
 c.add_compare("test --add-device --network default --update --confirm --no-define", "update-nodefine-succeed", env={"VIRTXML_TESTSUITE_UPDATE_IGNORE_FAIL": "1"}, input_text="yes\n")  # test hotplug success without define
 

--- a/virtinst/diskbackend.py
+++ b/virtinst/diskbackend.py
@@ -787,9 +787,12 @@ class StorageBackend(_StorageBase):
 
     def get_driver_type(self):
         if self._vol_object:
-            ret = self.get_vol_xml().format
-            if ret != "unknown":
-                return ret
+            if self.get_parent_pool_xml().type != "disk":
+                ret = self.get_vol_xml().format
+                if ret != "unknown":
+                    return ret
+            else:
+                return "raw"
         return None
 
     def validate(self):


### PR DESCRIPTION
Usually, when storage volume is attached as a disk and disk xml is filled with
default values, the `<driver type=...>` value is copied from volume's
`<format type=...>`.  This makes sense for volumes of storage pool of type
"dir", where format types include `raw, qcow2...`.

However, the same approach cannot be used for the storage pool of type "disk".
In that case, format types include `none, linux, fat16, fat32...`. Such formats
cannot be used for disk's `<driver type=...>`.

Therefore, when generating disk XML for volume of storage pool type "disk",
driver type should always be "raw".

Documentation: https://libvirt.org/storage.html#StorageBackendDisk