### PR TITLE
installertreemedia: Support for AlmaLinux OS 8

### DIFF
--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -597,7 +597,7 @@ class _OsVariant(object):
         if self.distro in ["caasp", "sle", "sled", "sles", "opensuse"]:
             return "install"
 
-        if self.distro not in ["centos", "rhel", "fedora"]:
+        if self.distro not in ["centos", "rhel", "fedora", "almalinux"]:
             return None
 
         # Red Hat distros


### PR DESCRIPTION
AlmaLinux OS 8 has kernel argument in its Osinfo database of
information. Considering kernel arguments are hardcoded instead of using
the libosinfo's kernel-url-argument API, which queries the Osinfo
database, this adds the required kernel argument to boot OS
successfully.
Fixes: https://bugs.almalinux.org/view.php?id=127

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>