### PR TITLE
Fix problems with test suite in new libvirt

### DIFF
--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -571,15 +571,15 @@
     </hostdev>
     <hostdev mode="subsystem" type="usb" managed="yes">
       <source>
-        <vendor id="0x0781"/>
-        <product id="0x5151"/>
+        <vendor id="0x062a"/>
+        <product id="0x0001"/>
       </source>
       <driver name="vfio"/>
     </hostdev>
     <hostdev mode="subsystem" type="usb" managed="yes">
       <source>
-        <vendor id="0x04b3"/>
-        <product id="0x4485"/>
+        <vendor id="0x0483"/>
+        <product id="0x2016"/>
       </source>
     </hostdev>
     <hostdev mode="subsystem" type="scsi" managed="no">

--- a/tests/data/cli/compare/virt-xml-add-host-device.xml
+++ b/tests/data/cli/compare/virt-xml-add-host-device.xml
@@ -3,8 +3,8 @@
      </vsock>
 +    <hostdev mode="subsystem" type="usb" managed="yes">
 +      <source>
-+        <vendor id="0x04b3"/>
-+        <product id="0x4485"/>
++        <vendor id="0x0483"/>
++        <product id="0x2016"/>
 +      </source>
 +    </hostdev>
    </devices>

--- a/tests/data/testdriver/testsuite.xml
+++ b/tests/data/testdriver/testsuite.xml
@@ -744,6 +744,20 @@
 </device>
 
 <device>
+  <name>usb_device_483_2016_noserial</name>
+  <parent>usb_device_1d6b_1_0000_00_1a_0</parent>
+  <driver>
+    <name>usb</name>
+  </driver>
+  <capability type='usb_device'>
+    <bus>3</bus>
+    <device>2</device>
+    <product id='0x2016'>Fingerprint Reader</product>
+    <vendor id='0x0483'>SGS Thomson Microelectronics</vendor>
+  </capability>
+</device>
+
+<device>
   <name>mdev_8e37ee90_2b51_45e3_9b25_bf8283c03110</name>
   <path>/sys/devices/css0/0.0.0023/8e37ee90-2b51-45e3-9b25-bf8283c03110</path>
   <parent>css_0_0_0023</parent>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1350,7 +1350,7 @@ c = vixml.add_category("add/rm devices", "test-for-virtxml --print-diff --define
 c.add_valid("--add-device --security model=dac")  # --add-device works for seclabel
 c.add_invalid("--add-device --pm suspend_to_disk=yes")  # --add-device without a device
 c.add_invalid("--remove-device --clock utc")  # --remove-device without a dev
-c.add_compare("--add-device --host-device usb_device_4b3_4485_noserial", "add-host-device")
+c.add_compare("--add-device --host-device usb_device_483_2016_noserial", "add-host-device")
 c.add_compare("--add-device --sound pcspk", "add-sound")
 c.add_compare("--add-device --disk %(EXISTIMG1)s,bus=virtio,target=vdf", "add-disk-basic")
 c.add_compare("--add-device --disk %(EXISTIMG1)s", "add-disk-notarget")  # filling in acceptable target

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -695,8 +695,8 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --hostdev 15:0.1
 --host-device 2:15:0.2
 --hostdev 0:15:0.3,address.type=pci,address.zpci.uid=0xffff,address.zpci.fid=0xffffffff
---host-device 0x0781:0x5151,driver_name=vfio
---host-device 04b3:4485
+--host-device 0x062a:0x0001,driver_name=vfio
+--host-device 0483:2016
 --host-device pci_8086_2829_scsi_host_scsi_device_lun0,rom.bar=on
 --hostdev usb_5_20 --hostdev usb_5_21
 --hostdev wlan0,type=net


### PR DESCRIPTION
Libvirt > 7.6.0 introduced uniqueness checks for host devices in


```
commit 9c3b6b7a82373b680a0e4ba4f1baebcb430d45b2
Author: Shalini Chellathurai Saroja <shalini@linux.ibm.com>
Date:   Fri Jun 18 12:46:12 2021 +0200

    conf: verify for duplicate hostdevs
    
    It is possible to define/edit(in shut off state) a domain XML with
    same hostdev device repeated more than once, as shown below. This
    behavior is not expected. So, this patch fixes it.
```

The test suite was mistakenly relying on being able to add the same device twice, but is trivially fixed to use unique devices