### PR TITLE
Explicitly set CPU topology for new VMs and use cores by default

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -293,7 +293,8 @@ CPU topology can additionally be specified with sockets, dies, cores, and thread
 If values are omitted, the rest will be autofilled preferring cores over sockets
 over threads. Cores are preferred because this matches the characteristics of
 modern real world silicon and thus a better fit for what guest OS will be
-expecting to deal with.
+expecting to deal with. If all values are omitted, then a default topology
+will be created for fully virtualized machines.
 
 'cpuset' sets which physical cpus the guest can use. ``CPUSET`` is a comma
 separated list of numbers, which can also be specified in ranges or cpus

--- a/tests/data/cli/compare/virt-install-aarch64-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-cdrom.xml
@@ -11,6 +11,9 @@
     <boot dev="cdrom"/>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_poweroff>restart</on_poweroff>
   <on_reboot>destroy</on_reboot>
@@ -66,6 +69,9 @@
     <nvram template="VARS.fd"/>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_poweroff>restart</on_poweroff>
   <on_reboot>destroy</on_reboot>

--- a/tests/data/cli/compare/virt-install-aarch64-firmware-no-override.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-firmware-no-override.xml
@@ -8,7 +8,9 @@
     <type arch="aarch64" machine="virt">hvm</type>
     <boot dev="network"/>
   </os>
-  <cpu mode="host-passthrough"/>
+  <cpu mode="host-passthrough">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <devices>
@@ -42,7 +44,9 @@
     <type arch="aarch64" machine="virt">hvm</type>
     <boot dev="network"/>
   </os>
-  <cpu mode="host-passthrough"/>
+  <cpu mode="host-passthrough">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-aarch64</emulator>

--- a/tests/data/cli/compare/virt-install-aarch64-graphics.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-graphics.xml
@@ -14,7 +14,9 @@
     <loader readonly="yes" type="pflash">/usr/share/AAVMF/AAVMF_CODE.fd</loader>
     <boot dev="hd"/>
   </os>
-  <cpu mode="host-passthrough"/>
+  <cpu mode="host-passthrough">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-aarch64</emulator>

--- a/tests/data/cli/compare/virt-install-aarch64-headless.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-headless.xml
@@ -14,7 +14,9 @@
     <loader readonly="yes" type="pflash">/usr/share/AAVMF/AAVMF_CODE.fd</loader>
     <boot dev="hd"/>
   </os>
-  <cpu mode="host-passthrough"/>
+  <cpu mode="host-passthrough">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-aarch64</emulator>

--- a/tests/data/cli/compare/virt-install-aarch64-kvm-gic.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-kvm-gic.xml
@@ -17,7 +17,9 @@
   <features>
     <gic version="host"/>
   </features>
-  <cpu mode="host-passthrough"/>
+  <cpu mode="host-passthrough">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-aarch64</emulator>

--- a/tests/data/cli/compare/virt-install-aarch64-kvm-import.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-kvm-import.xml
@@ -14,7 +14,9 @@
     <loader readonly="yes" type="pflash">/usr/share/AAVMF/AAVMF_CODE.fd</loader>
     <boot dev="hd"/>
   </os>
-  <cpu mode="host-passthrough"/>
+  <cpu mode="host-passthrough">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-aarch64</emulator>

--- a/tests/data/cli/compare/virt-install-aarch64-machdefault.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-machdefault.xml
@@ -12,6 +12,7 @@
   </os>
   <cpu mode="custom" match="exact">
     <model>cortex-a57</model>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
   </cpu>
   <clock offset="utc"/>
   <devices>

--- a/tests/data/cli/compare/virt-install-aarch64-machvirt.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-machvirt.xml
@@ -12,6 +12,7 @@
   </os>
   <cpu mode="custom" match="exact">
     <model>cortex-a57</model>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
   </cpu>
   <clock offset="utc"/>
   <devices>

--- a/tests/data/cli/compare/virt-install-arm-defaultmach-f20.xml
+++ b/tests/data/cli/compare/virt-install-arm-defaultmach-f20.xml
@@ -15,6 +15,9 @@
     <initrd>/f19-arm.initrd</initrd>
     <cmdline>foo</cmdline>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-arm</emulator>

--- a/tests/data/cli/compare/virt-install-arm-kvm-import.xml
+++ b/tests/data/cli/compare/virt-install-arm-kvm-import.xml
@@ -14,7 +14,9 @@
     <loader readonly="yes" type="pflash">/usr/share/edk2/arm/QEMU_EFI.fd</loader>
     <boot dev="hd"/>
   </os>
-  <cpu mode="host-passthrough"/>
+  <cpu mode="host-passthrough">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-arm</emulator>

--- a/tests/data/cli/compare/virt-install-arm-vexpress-plain.xml
+++ b/tests/data/cli/compare/virt-install-arm-vexpress-plain.xml
@@ -11,6 +11,9 @@
     <cmdline>console=ttyAMA0 rw root=/dev/mmcblk0p3</cmdline>
     <dtb>/f19-arm.dtb</dtb>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-arm</emulator>

--- a/tests/data/cli/compare/virt-install-arm-virt-f20.xml
+++ b/tests/data/cli/compare/virt-install-arm-virt-f20.xml
@@ -15,6 +15,9 @@
     <initrd>/f19-arm.initrd</initrd>
     <cmdline>console=ttyAMA0,1234 rw root=/dev/vda3</cmdline>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-arm</emulator>

--- a/tests/data/cli/compare/virt-install-bhyve-default-f27.xml
+++ b/tests/data/cli/compare/virt-install-bhyve-default-f27.xml
@@ -14,6 +14,9 @@
     <loader readonly="yes" type="pflash">/usr/local/share/uefi-firmware/BHYVE_UEFI.fd</loader>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>bhyve</emulator>

--- a/tests/data/cli/compare/virt-install-bhyve-uefi.xml
+++ b/tests/data/cli/compare/virt-install-bhyve-uefi.xml
@@ -9,6 +9,9 @@
     <loader readonly="yes" type="pflash">/usr/local/share/uefi-firmware/BHYVE_UEFI.fd</loader>
     <boot dev="network"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <devices>
@@ -39,6 +42,9 @@
     <loader readonly="yes" type="pflash">/usr/local/share/uefi-firmware/BHYVE_UEFI.fd</loader>
     <boot dev="network"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>bhyve</emulator>

--- a/tests/data/cli/compare/virt-install-boot-container.xml
+++ b/tests/data/cli/compare/virt-install-boot-container.xml
@@ -19,6 +19,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-boot-direct-kernel.xml
+++ b/tests/data/cli/compare/virt-install-boot-direct-kernel.xml
@@ -17,6 +17,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-boot-guest-loader-bios.xml
+++ b/tests/data/cli/compare/virt-install-boot-guest-loader-bios.xml
@@ -14,6 +14,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-boot-guest-loader-efi.xml
+++ b/tests/data/cli/compare/virt-install-boot-guest-loader-efi.xml
@@ -14,6 +14,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-boot-host-loader.xml
+++ b/tests/data/cli/compare/virt-install-boot-host-loader.xml
@@ -13,6 +13,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-boot-loader-secure.xml
+++ b/tests/data/cli/compare/virt-install-boot-loader-secure.xml
@@ -12,6 +12,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-boot-uefi.xml
+++ b/tests/data/cli/compare/virt-install-boot-uefi.xml
@@ -15,7 +15,9 @@
     <smm state="on"/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-cdrom-centos-label.xml
+++ b/tests/data/cli/compare/virt-install-cdrom-centos-label.xml
@@ -19,7 +19,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -98,7 +100,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-cdrom-double.xml
+++ b/tests/data/cli/compare/virt-install-cdrom-double.xml
@@ -12,6 +12,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -64,6 +67,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-cdrom-url.xml
+++ b/tests/data/cli/compare/virt-install-cdrom-url.xml
@@ -11,6 +11,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -56,6 +59,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-cloud-init-default.xml
+++ b/tests/data/cli/compare/virt-install-cloud-init-default.xml
@@ -15,6 +15,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -67,6 +70,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-cloud-init-options.xml
+++ b/tests/data/cli/compare/virt-install-cloud-init-options.xml
@@ -15,6 +15,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -67,6 +70,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-cpu-disable-sec.xml
+++ b/tests/data/cli/compare/virt-install-cpu-disable-sec.xml
@@ -14,6 +14,7 @@
   </features>
   <cpu mode="custom" match="exact">
     <model>qemu64</model>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
   </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
@@ -61,6 +62,7 @@
   </features>
   <cpu mode="custom" match="exact">
     <model>qemu64</model>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
   </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>

--- a/tests/data/cli/compare/virt-install-cpu-host-model-no-fallback.xml
+++ b/tests/data/cli/compare/virt-install-cpu-host-model-no-fallback.xml
@@ -13,6 +13,7 @@
   </features>
   <cpu mode="host-model">
     <model fallback="forbid"/>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
   </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
@@ -54,6 +55,7 @@
   </features>
   <cpu mode="host-model">
     <model fallback="forbid"/>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
   </cpu>
   <clock offset="utc"/>
   <pm>

--- a/tests/data/cli/compare/virt-install-cpu-host-passthrough-migratable.xml
+++ b/tests/data/cli/compare/virt-install-cpu-host-passthrough-migratable.xml
@@ -11,7 +11,9 @@
   <features>
     <pae/>
   </features>
-  <cpu mode="host-passthrough" migratable="on"/>
+  <cpu mode="host-passthrough" migratable="on">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -50,7 +52,9 @@
   <features>
     <pae/>
   </features>
-  <cpu mode="host-passthrough" migratable="on"/>
+  <cpu mode="host-passthrough" migratable="on">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-cpu-model.xml
+++ b/tests/data/cli/compare/virt-install-cpu-model.xml
@@ -13,6 +13,7 @@
   </features>
   <cpu mode="custom" match="exact">
     <model fallback="allow" vendor_id="GenuineIntel">core2duo</model>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
   </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
@@ -54,6 +55,7 @@
   </features>
   <cpu mode="custom" match="exact">
     <model fallback="allow" vendor_id="GenuineIntel">core2duo</model>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
   </cpu>
   <clock offset="utc"/>
   <pm>

--- a/tests/data/cli/compare/virt-install-cpu-rhel7-default.xml
+++ b/tests/data/cli/compare/virt-install-cpu-rhel7-default.xml
@@ -14,6 +14,7 @@
   </features>
   <cpu mode="custom" match="exact">
     <model>Skylake-Client-IBRS</model>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
     <feature policy="require" name="spec-ctrl"/>
     <feature policy="require" name="ssbd"/>
   </cpu>
@@ -63,6 +64,7 @@
   </features>
   <cpu mode="custom" match="exact">
     <model>Skylake-Client-IBRS</model>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
     <feature policy="require" name="spec-ctrl"/>
     <feature policy="require" name="ssbd"/>
   </cpu>

--- a/tests/data/cli/compare/virt-install-cpuset-auto.xml
+++ b/tests/data/cli/compare/virt-install-cpuset-auto.xml
@@ -11,6 +11,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -49,6 +52,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-f21-kvm-remote.xml
+++ b/tests/data/cli/compare/virt-install-f21-kvm-remote.xml
@@ -18,7 +18,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-fake-ftp.xml
+++ b/tests/data/cli/compare/virt-install-fake-ftp.xml
@@ -18,6 +18,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -61,6 +64,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-fake-http.xml
+++ b/tests/data/cli/compare/virt-install-fake-http.xml
@@ -13,6 +13,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -51,6 +54,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-graphics-usb-disable.xml
+++ b/tests/data/cli/compare/virt-install-graphics-usb-disable.xml
@@ -18,7 +18,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-kvm-centos7.xml
+++ b/tests/data/cli/compare/virt-install-kvm-centos7.xml
@@ -19,7 +19,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -87,7 +89,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-kvm-cpu-default-fallback.xml
+++ b/tests/data/cli/compare/virt-install-kvm-cpu-default-fallback.xml
@@ -21,6 +21,7 @@
   </features>
   <cpu mode="custom" match="exact">
     <model>Opteron_G4</model>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
   </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
@@ -90,6 +91,7 @@
   </features>
   <cpu mode="custom" match="exact">
     <model>Opteron_G4</model>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
   </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>

--- a/tests/data/cli/compare/virt-install-kvm-fedoralatest-url.xml
+++ b/tests/data/cli/compare/virt-install-kvm-fedoralatest-url.xml
@@ -20,7 +20,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -78,7 +80,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-kvm-hostcopy-fallback.xml
+++ b/tests/data/cli/compare/virt-install-kvm-hostcopy-fallback.xml
@@ -16,6 +16,7 @@
   <cpu mode="custom" match="exact">
     <model>Opteron_G4</model>
     <vendor>AMD</vendor>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
     <feature name="invtsc"/>
     <feature name="perfctr_nb"/>
     <feature name="perfctr_core"/>
@@ -97,6 +98,7 @@
   <cpu mode="custom" match="exact">
     <model>Opteron_G4</model>
     <vendor>AMD</vendor>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
     <feature name="invtsc"/>
     <feature name="perfctr_nb"/>
     <feature name="perfctr_core"/>

--- a/tests/data/cli/compare/virt-install-kvm-i686-uefi.xml
+++ b/tests/data/cli/compare/virt-install-kvm-i686-uefi.xml
@@ -16,6 +16,9 @@
     <pae/>
     <vmport state="off"/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -76,6 +79,9 @@
     <pae/>
     <vmport state="off"/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-kvm-rhel5.xml
+++ b/tests/data/cli/compare/virt-install-kvm-rhel5.xml
@@ -19,7 +19,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -87,7 +89,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-kvm-rhel6.xml
+++ b/tests/data/cli/compare/virt-install-kvm-rhel6.xml
@@ -20,7 +20,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -93,7 +95,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-kvm-rhel7.xml
+++ b/tests/data/cli/compare/virt-install-kvm-rhel7.xml
@@ -20,7 +20,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -87,7 +89,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-kvm-session-defaults.xml
+++ b/tests/data/cli/compare/virt-install-kvm-session-defaults.xml
@@ -19,7 +19,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -92,7 +94,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-kvm-win10.xml
+++ b/tests/data/cli/compare/virt-install-kvm-win10.xml
@@ -24,7 +24,9 @@
     </hyperv>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -96,7 +98,9 @@
     </hyperv>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-kvm-win2k3-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-kvm-win2k3-cdrom.xml
@@ -24,7 +24,9 @@
     </hyperv>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -96,7 +98,9 @@
     </hyperv>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-location-iso.xml
+++ b/tests/data/cli/compare/virt-install-location-iso.xml
@@ -19,7 +19,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -97,7 +99,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-location-manual-kernel.xml
+++ b/tests/data/cli/compare/virt-install-location-manual-kernel.xml
@@ -14,7 +14,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -79,7 +81,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-memory-hotplug.xml
+++ b/tests/data/cli/compare/virt-install-memory-hotplug.xml
@@ -11,6 +11,7 @@
     <pae/>
   </features>
   <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
     <numa>
       <cell cpus="0" memory="1048576"/>
     </numa>
@@ -76,6 +77,7 @@
     <pae/>
   </features>
   <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
     <numa>
       <cell cpus="0" memory="1048576"/>
     </numa>

--- a/tests/data/cli/compare/virt-install-memory-option-backcompat.xml
+++ b/tests/data/cli/compare/virt-install-memory-option-backcompat.xml
@@ -12,6 +12,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -51,6 +54,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-network-install-resources.xml
+++ b/tests/data/cli/compare/virt-install-network-install-resources.xml
@@ -19,7 +19,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -68,7 +70,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-openbsd-defaults.xml
+++ b/tests/data/cli/compare/virt-install-openbsd-defaults.xml
@@ -18,7 +18,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-os-detect-fail-fallback.xml
+++ b/tests/data/cli/compare/virt-install-os-detect-fail-fallback.xml
@@ -21,6 +21,9 @@
       <spinlocks state="on" retries="8191"/>
     </hyperv>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -69,6 +72,9 @@
       <spinlocks state="on" retries="8191"/>
     </hyperv>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-os-detect-success-fallback.xml
+++ b/tests/data/cli/compare/virt-install-os-detect-success-fallback.xml
@@ -18,6 +18,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -61,6 +64,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-osinfo-multiple-short-id.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-multiple-short-id.xml
@@ -18,7 +18,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -72,7 +74,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-osinfo-netinst-unattended.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-netinst-unattended.xml
@@ -19,7 +19,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -74,7 +76,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-osinfo-unattended-treeapis.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-unattended-treeapis.xml
@@ -19,7 +19,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -77,7 +79,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-osinfo-url-unattended.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-url-unattended.xml
@@ -19,7 +19,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -68,7 +70,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-osinfo-url-with-disk.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-url-with-disk.xml
@@ -19,7 +19,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -78,7 +80,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-osinfo-url.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-url.xml
@@ -19,7 +19,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -68,7 +70,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-osinfo-win7-unattended.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-win7-unattended.xml
@@ -22,7 +22,9 @@
       <spinlocks state="on" retries="8191"/>
     </hyperv>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -98,7 +100,9 @@
       <spinlocks state="on" retries="8191"/>
     </hyperv>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-osvariant-defaults-pxe.xml
+++ b/tests/data/cli/compare/virt-install-osvariant-defaults-pxe.xml
@@ -18,6 +18,9 @@
     <pae/>
     <vmport state="off"/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -79,6 +82,9 @@
     <pae/>
     <vmport state="off"/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-ppc64-graphics.xml
+++ b/tests/data/cli/compare/virt-install-ppc64-graphics.xml
@@ -13,6 +13,9 @@
     <type arch="ppc64le" machine="pseries">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/libexec/qemu-kvm</emulator>

--- a/tests/data/cli/compare/virt-install-ppc64-headless.xml
+++ b/tests/data/cli/compare/virt-install-ppc64-headless.xml
@@ -13,6 +13,9 @@
     <type arch="ppc64le" machine="pseries">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/libexec/qemu-kvm</emulator>

--- a/tests/data/cli/compare/virt-install-ppc64-machdefault-f20.xml
+++ b/tests/data/cli/compare/virt-install-ppc64-machdefault-f20.xml
@@ -13,6 +13,9 @@
     <type arch="ppc64" machine="pseries">hvm</type>
     <boot dev="network"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-ppc64</emulator>

--- a/tests/data/cli/compare/virt-install-ppc64-pseries-f20.xml
+++ b/tests/data/cli/compare/virt-install-ppc64-pseries-f20.xml
@@ -13,6 +13,9 @@
     <type arch="ppc64" machine="pseries">hvm</type>
     <boot dev="network"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-ppc64</emulator>

--- a/tests/data/cli/compare/virt-install-ppc64-pseries-tpm.xml
+++ b/tests/data/cli/compare/virt-install-ppc64-pseries-tpm.xml
@@ -8,6 +8,9 @@
     <type arch="ppc64" machine="pseries">hvm</type>
     <boot dev="network"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-ppc64</emulator>

--- a/tests/data/cli/compare/virt-install-ppc64le-kvm-import.xml
+++ b/tests/data/cli/compare/virt-install-ppc64le-kvm-import.xml
@@ -13,6 +13,9 @@
     <type arch="ppc64le" machine="pseries">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/libexec/qemu-kvm</emulator>

--- a/tests/data/cli/compare/virt-install-q35-defaults.xml
+++ b/tests/data/cli/compare/virt-install-q35-defaults.xml
@@ -14,7 +14,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -84,7 +86,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-qemu-32-on-64.xml
+++ b/tests/data/cli/compare/virt-install-qemu-32-on-64.xml
@@ -19,6 +19,9 @@
     <pae/>
     <vmport state="off"/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-qemu-plain.xml
+++ b/tests/data/cli/compare/virt-install-qemu-plain.xml
@@ -20,6 +20,7 @@
   </features>
   <cpu mode="custom" match="exact">
     <model>Penryn</model>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
   </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>

--- a/tests/data/cli/compare/virt-install-remote-storage.xml
+++ b/tests/data/cli/compare/virt-install-remote-storage.xml
@@ -12,6 +12,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -58,6 +61,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-riscv64-graphics.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-graphics.xml
@@ -13,6 +13,9 @@
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>

--- a/tests/data/cli/compare/virt-install-riscv64-headless.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-headless.xml
@@ -13,6 +13,9 @@
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>

--- a/tests/data/cli/compare/virt-install-s390x-cdrom-KVMIBM.xml
+++ b/tests/data/cli/compare/virt-install-s390x-cdrom-KVMIBM.xml
@@ -14,6 +14,9 @@
     <kernel>/kernel.img</kernel>
     <initrd>/initrd.img</initrd>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-kvm</emulator>

--- a/tests/data/cli/compare/virt-install-s390x-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-s390x-cdrom.xml
@@ -14,6 +14,9 @@
     <kernel>/kernel.img</kernel>
     <initrd>/initrd.img</initrd>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-s390x</emulator>

--- a/tests/data/cli/compare/virt-install-s390x-graphics.xml
+++ b/tests/data/cli/compare/virt-install-s390x-graphics.xml
@@ -13,6 +13,9 @@
     <type arch="s390x" machine="s390-ccw-virtio">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-s390x</emulator>

--- a/tests/data/cli/compare/virt-install-s390x-headless.xml
+++ b/tests/data/cli/compare/virt-install-s390x-headless.xml
@@ -13,6 +13,9 @@
     <type arch="s390x" machine="s390-ccw-virtio">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-s390x</emulator>

--- a/tests/data/cli/compare/virt-install-simple-pxe.xml
+++ b/tests/data/cli/compare/virt-install-simple-pxe.xml
@@ -11,6 +11,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -49,6 +52,9 @@
   <features>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-singleton-config-2.xml
+++ b/tests/data/cli/compare/virt-install-singleton-config-2.xml
@@ -131,6 +131,7 @@
   <cpu mode="custom" match="strict" check="partial">
     <model>foobar</model>
     <vendor>meee</vendor>
+    <topology sockets="1" dies="1" cores="9" threads="1"/>
     <cache level="3" mode="emulate"/>
     <feature policy="force" name="x2apic"/>
     <feature policy="force" name="x2apicagain"/>
@@ -415,6 +416,7 @@
   <cpu mode="custom" match="strict" check="partial">
     <model>foobar</model>
     <vendor>meee</vendor>
+    <topology sockets="1" dies="1" cores="9" threads="1"/>
     <cache level="3" mode="emulate"/>
     <feature policy="force" name="x2apic"/>
     <feature policy="force" name="x2apicagain"/>

--- a/tests/data/cli/compare/virt-install-unattended-remote-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-unattended-remote-cdrom.xml
@@ -21,6 +21,9 @@
       <spinlocks state="on" retries="8191"/>
     </hyperv>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime"/>
   <on_reboot>destroy</on_reboot>
   <pm>
@@ -79,6 +82,9 @@
       <spinlocks state="on" retries="8191"/>
     </hyperv>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/cli/compare/virt-install-win7-uefi.xml
+++ b/tests/data/cli/compare/virt-install-win7-uefi.xml
@@ -21,7 +21,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -98,7 +100,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="localtime">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-x86_64-graphics.xml
+++ b/tests/data/cli/compare/virt-install-x86_64-graphics.xml
@@ -17,7 +17,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-x86_64-headless.xml
+++ b/tests/data/cli/compare/virt-install-x86_64-headless.xml
@@ -17,7 +17,9 @@
     <acpi/>
     <apic/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="2" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-x86_64-launch-security-sev-full.xml
+++ b/tests/data/cli/compare/virt-install-x86_64-launch-security-sev-full.xml
@@ -14,7 +14,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-x86_64-launch-security-sev.xml
+++ b/tests/data/cli/compare/virt-install-x86_64-launch-security-sev.xml
@@ -14,7 +14,9 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-model"/>
+  <cpu mode="host-model">
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-xen-hvm.xml
+++ b/tests/data/cli/compare/virt-install-xen-hvm.xml
@@ -15,6 +15,9 @@
     <apic/>
     <pae/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/lib64/xen/bin/qemu-dm</emulator>

--- a/tests/data/xmlparse/replace-child-build.xml
+++ b/tests/data/xmlparse/replace-child-build.xml
@@ -8,6 +8,9 @@
     <pae/>
     <vmport state="off"/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/tests/data/xmlparse/replace-child-parse.xml
+++ b/tests/data/xmlparse/replace-child-parse.xml
@@ -8,6 +8,9 @@
     <pae/>
     <vmport state="off"/>
   </features>
+  <cpu>
+    <topology sockets="1" dies="1" cores="1" threads="1"/>
+  </cpu>
   <clock offset="utc"/>
   <pm>
     <suspend-to-mem enabled="no"/>

--- a/ui/details.ui
+++ b/ui/details.ui
@@ -61,6 +61,13 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment6">
+    <property name="lower">1</property>
+    <property name="upper">256</property>
+    <property name="value">1</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment7">
     <property name="lower">1</property>
     <property name="upper">1024</property>
@@ -1504,7 +1511,7 @@
                                       </object>
                                       <packing>
                                         <property name="left_attach">0</property>
-                                        <property name="top_attach">2</property>
+                                        <property name="top_attach">3</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1515,6 +1522,20 @@
                                         <property name="label" translatable="yes">Cor_es:</property>
                                         <property name="use_underline">True</property>
                                         <property name="mnemonic_widget">cpu-cores</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label65">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">_Dies:</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="mnemonic_widget">cpu-sockets</property>
                                       </object>
                                       <packing>
                                         <property name="left_attach">0</property>
@@ -1553,6 +1574,24 @@
                                       </packing>
                                     </child>
                                     <child>
+                                      <object class="GtkSpinButton" id="cpu-dies">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="halign">start</property>
+                                        <property name="hexpand">False</property>
+                                        <property name="vexpand">True</property>
+                                        <property name="invisible_char">●</property>
+                                        <property name="text" translatable="yes">1</property>
+                                        <property name="adjustment">adjustment6</property>
+                                        <property name="value">1</property>
+                                        <signal name="changed" handler="on_cpu_dies_changed" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <object class="GtkSpinButton" id="cpu-cores">
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
@@ -1567,7 +1606,7 @@
                                       </object>
                                       <packing>
                                         <property name="left_attach">1</property>
-                                        <property name="top_attach">1</property>
+                                        <property name="top_attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1585,7 +1624,7 @@
                                       </object>
                                       <packing>
                                         <property name="left_attach">1</property>
-                                        <property name="top_attach">2</property>
+                                        <property name="top_attach">3</property>
                                       </packing>
                                     </child>
                                   </object>

--- a/virtManager/details/details.py
+++ b/virtManager/details/details.py
@@ -1170,8 +1170,8 @@ class vmmDetails(vmmGObjectUI):
             self.widget("cpu-vcpus").set_value(total)
         else:
             vcpus = uiutil.spin_get_helper(self.widget("cpu-vcpus"))
-            self.widget("cpu-sockets").set_value(vcpus or 1)
-            self.widget("cpu-cores").set_value(1)
+            self.widget("cpu-sockets").set_value(1)
+            self.widget("cpu-cores").set_value(vcpus or 1)
             self.widget("cpu-threads").set_value(1)
 
         self._enable_apply(EDIT_TOPOLOGY)

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -625,7 +625,7 @@ class vmmDomain(vmmLibvirtObject):
     ##########################
 
     def define_cpu(self, vcpus=_SENTINEL,
-            model=_SENTINEL, secure=_SENTINEL, sockets=_SENTINEL,
+            model=_SENTINEL, secure=_SENTINEL, sockets=_SENTINEL, dies=_SENTINEL,
             cores=_SENTINEL, threads=_SENTINEL, clear_topology=_SENTINEL):
         guest = self._make_xmlobj_to_define()
 
@@ -637,6 +637,7 @@ class vmmDomain(vmmLibvirtObject):
             guest.cpu.topology.clear()
         elif sockets != _SENTINEL:
             guest.cpu.topology.sockets = sockets
+            guest.cpu.topology.dies = dies
             guest.cpu.topology.cores = cores
             guest.cpu.topology.threads = threads
 

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -705,6 +705,16 @@ class Guest(XMLBuilder):
                 self.vcpus = defCPUs
         self.cpu.set_topology_defaults(self.vcpus)
 
+    def create_vcpus_topology(self):
+        """
+        If the user didn't specify any topology then populate a
+        default for fully virtualized machines
+        """
+        createTopology = False
+        if self.os.is_hvm():
+            createTopology = True
+        self.cpu.set_topology_defaults(self.vcpus, createTopology)
+
     def set_defaults(self, _guest):
         self.set_capabilities_defaults()
 
@@ -727,6 +737,7 @@ class Guest(XMLBuilder):
 
         self.clock.set_defaults(self)
         self.cpu.set_defaults(self)
+        self.create_vcpus_topology()
         self.features.set_defaults(self)
         for seclabel in self.seclabels:
             seclabel.set_defaults(self)


### PR DESCRIPTION
This changes the code to always set CPU topology for hvm guests and prefer cores over sockets when doing so. As a side effect of this, we fix many gaps related to CPU dies support.
