### PR TITLE
osinfo: use the OS kernel-url-argument if available

### DIFF
--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -593,6 +593,12 @@ class _OsVariant(object):
         Kernel argument name the distro's installer uses to reference
         a network source, possibly bypassing some installer prompts
         """
+        # Let's ask the OS for its kernel argument for the source
+        if hasattr(self._os, "get_kernel_url_argument"):
+            osarg = self._os.get_kernel_url_argument()
+            if osarg is not None:
+                return osarg
+
         # SUSE distros
         if self.distro in ["caasp", "sle", "sled", "sles", "opensuse"]:
             return "install"


### PR DESCRIPTION
Each OS may specify which kernel argument is needed to specify the
installation source; use it as primary source, falling back to the
current logic. This should help supporting new OSes OOTB.

Signed-off-by: Pino Toscano <ptoscano@redhat.com>