### PR TITLE
installerinject: Use root:root instead of +0:+0 as owner

### DIFF
--- a/virtinst/install/installerinject.py
+++ b/virtinst/install/installerinject.py
@@ -20,7 +20,7 @@ def _run_initrd_commands(initrd, tempdir):
                                  stderr=subprocess.PIPE,
                                  cwd=tempdir)
     cpio_proc = subprocess.Popen(['cpio', '--create', '--null', '--quiet',
-                                  '--format=newc', '--owner=+0:+0'],
+                                  '--format=newc', '--owner=root:root'],
                                  stdin=find_proc.stdout,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE,


### PR DESCRIPTION
Commit c6b5f22fa61d started passing the --owner argument to cpio when injecting files into the initrd to comply with the more strict requirements introduced by systemd starting with Fedora 30.

However, cpio only started accepting the +uid:+gid syntax in version 2.12, which means that the fix actually broke the
initrd inject functionality completely in RHEL 7 and other distros that don't include a recent enough cpio.

Use the user:group syntax instead, which is understood by all versions of cpio, including non-GNU ones.