### PR TITLE
installerinject: Add error detection for initrd injection

### DIFF
--- a/virtinst/install/installerinject.py
+++ b/virtinst/install/installerinject.py
@@ -43,6 +43,11 @@ def _run_initrd_commands(initrd, tempdir):
     if gziperr:  # pragma: no cover
         log.debug("gzip stderr=%s", gziperr)
 
+    if (cpio_proc.returncode != 0 or
+        find_proc.returncode != 0 or
+        gzip_proc.returncode != 0):  # pragma: no cover
+        raise RuntimeError("Failed to inject files into initrd")
+
 
 def _run_iso_commands(iso, tempdir, cloudinit=False):
     # These three programs all behave similarly for our needs, and


### PR DESCRIPTION
Any of the commands involved in injecting files into an initrd could fail, and if that happens we should interrupt the installation instead of proceeding as if nothing had happened.