### PR TITLE
Default to UEFI if BIOS is not supported and add a TPM whenever using UEFI

### DIFF
--- a/tests/data/capabilities/kvm-x86_64-domcaps-q35.xml
+++ b/tests/data/capabilities/kvm-x86_64-domcaps-q35.xml
@@ -118,6 +118,16 @@
         <value>vfio</value>
       </enum>
     </hostdev>
+    <tpm supported='yes'>
+      <enum name='model'>
+        <value>tpm-tis</value>
+        <value>tpm-crb</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>passthrough</value>
+        <value>emulator</value>
+      </enum>
+    </tpm>
   </devices>
   <features>
     <gic supported='no'/>

--- a/tests/data/cli/compare/virt-install-boot-uefi.xml
+++ b/tests/data/cli/compare/virt-install-boot-uefi.xml
@@ -47,6 +47,9 @@
       <target type="virtio" name="com.redhat.spice.0"/>
     </channel>
     <input type="tablet" bus="usb"/>
+    <tpm model="tpm-tis">
+      <backend type="emulator"/>
+    </tpm>
     <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
       <image compression="off"/>
     </graphics>

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -4086,6 +4086,10 @@ class ParserTPM(VirtCLIParser):
     }
 
     def _parse(self, inst):
+        if self.optstr == "none":
+            self.guest.skip_default_tpm = True
+            return
+
         if (self.optdict.get("type", "").startswith("/")):
             self.optdict["path"] = self.optdict.pop("type")
         return super()._parse(inst)

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -101,6 +101,7 @@ class _Devices(_CapsBlock):
     disk = XMLChildProperty(_make_capsblock("disk"), is_single=True)
     video = XMLChildProperty(_make_capsblock("video"), is_single=True)
     graphics = XMLChildProperty(_make_capsblock("graphics"), is_single=True)
+    tpm = XMLChildProperty(_make_capsblock("tpm"), is_single=True)
 
 
 class _Features(_CapsBlock):
@@ -350,6 +351,15 @@ class DomainCapabilities(XMLBuilder):
         """
         models = self.devices.video.get_enum("modelType").get_values()
         return bool("bochs" in models)
+
+    def supports_tpm_emulator(self):
+        """
+        Returns False if either libvirt or qemu do not have support for
+        emulating a TPM.
+        """
+        models = self.devices.tpm.get_enum("model").get_values()
+        backends = self.devices.tpm.get_enum("backendModel").get_values()
+        return len(models) > 0 and bool("emulator" in backends)
 
     def supports_graphics_spice(self):
         if not self.devices.graphics.supported:

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -516,7 +516,21 @@ class Guest(XMLBuilder):
         arm+machvirt prefers UEFI since it's required for traditional
         install methods
         """
-        return self.os.is_arm_machvirt() or self.conn.is_bhyve()
+        if self.os.is_x86() and self.conn.is_qemu():
+            # If OS has dropped support for 'bios', we have no
+            # choice but to use EFI.
+            # For other OS still prefer BIOS since it is faster
+            # and doesn't break QEMU internal snapshots
+            has_efi = self.osinfo.supports_firmware_efi(self.os.arch)
+            has_bios = self.osinfo.supports_firmware_bios(self.os.arch)
+            log.debug("Guest osinfo firmware has_efi=%d has_bios=%d",
+                      has_efi, has_bios)
+            prefer_efi = has_efi and not has_bios
+        else:
+            prefer_efi = self.os.is_arm_machvirt() or self.conn.is_bhyve()
+
+        log.debug("Prefer EFI => %s", prefer_efi)
+        return prefer_efi
 
     def get_uefi_path(self):
         """

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -513,6 +513,28 @@ class _OsVariant(object):
         devids = ["http://qemu.org/chipset/x86/q35"]
         return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
+    def _get_firmware_list(self):
+        if hasattr(self._os, "get_complete_firmware_list"):
+            return self._os.get_complete_firmware_list().get_elements()
+        return []
+
+    def _supports_firmware_type(self, name, arch, default):
+        firmwares = self._get_firmware_list()
+
+        for firmware in firmwares:
+            if firmware.get_architecture() != arch:
+                continue
+            if firmware.get_firmware_type() == name:
+                return firmware.is_supported()
+
+        return default
+
+    def supports_firmware_efi(self, arch):
+        return self._supports_firmware_type("efi", arch, False)
+
+    def supports_firmware_bios(self, arch):
+        return self._supports_firmware_type("bios", arch, True)
+
     def get_recommended_resources(self):
         minimum = self._os.get_minimum_resources()
         recommended = self._os.get_recommended_resources()


### PR DESCRIPTION
Some modern OS will now only support use of UEFI, not legacy BIOS. At the same time they will also generally expect a TPM to be present.

These changes will default to using UEFI if libosinfo declares BIOS is not supported. This relies on a new  API in libosinfo 1.10, so existing installs won't see the new behaviour. It of course also depends on the osinfo-db metadata declaring this fact.

Since use of UEFI generally indicates a desire for a fairly modern platform, it is considered appropriate that the platform should include a TPM by default too. Increasingly OS expect a TPM as a standard, even mandatory, piece of infrastructure. While libvirt has supported swtpm for a while, apps couldn't rely on it being installed by default. So latest libvirt now reports whether tpm is available in domcapabilities, which this code looks for.

The basic point of this is that when selecting a  Windows 11 OS to install, virt-manager/virt-install will now do the right thing to provide a platform that can actually pass the installer's minimum hardware requirements.