### PR TITLE
This removes a bit of legacy cruft around handling osinfo DB

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -961,7 +961,7 @@ c.add_valid("--connect test:///default --test-stub-command", use_default_args=Fa
 c.add_valid("--nodisks --pxe", grep="VM performance may suffer")  # os variant warning
 c.add_invalid("--hvm --nodisks --pxe foobar")  # Positional arguments error
 c.add_invalid("--nodisks --pxe --name test")  # Colliding name
-c.add_compare("--os-type linux --cdrom %(EXISTIMG1)s --disk size=1 --disk %(EXISTIMG2)s,device=cdrom", "cdrom-double")  # ensure --disk device=cdrom is ordered after --cdrom, this is important for virtio-win installs with a driver ISO
+c.add_compare("--cdrom %(EXISTIMG1)s --disk size=1 --disk %(EXISTIMG2)s,device=cdrom", "cdrom-double")  # ensure --disk device=cdrom is ordered after --cdrom, this is important for virtio-win installs with a driver ISO
 c.add_valid("--connect %s --pxe --disk size=1" % utils.URIs.test_defaultpool_collision)  # testdriver already has a pool using the 'default' path, make sure we don't error
 c.add_compare("--connect %(URI-KVM)s --reinstall test-clone-simple --pxe", "reinstall-pxe")  # compare --reinstall with --pxe
 c.add_compare("--connect %(URI-KVM)s --reinstall test-clone-simple --location http://example.com", "reinstall-location")  # compare --reinstall with --location

--- a/tests/test_osdict.py
+++ b/tests/test_osdict.py
@@ -18,15 +18,6 @@ from tests import utils
 ##################
 
 
-def test_osdict_aliases_ro():
-    aliases = getattr(OSDB, "_aliases")
-
-    if len(aliases) != 42:
-        raise AssertionError(_("OSDB._aliases changed size. It "
-            "should never be extended, since it is only for back "
-            "compat with pre-libosinfo osdict.py"))
-
-
 def test_list_os():
     OSDB.list_os()
 

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -129,56 +129,6 @@ class _OSDB(object):
         self.__os_loader = None
         self.__all_variants = None
 
-    # This is only for back compatibility with pre-libosinfo support.
-    # This should never change.
-    _aliases = {
-        "altlinux": "altlinux1.0",
-        "debianetch": "debian4",
-        "debianlenny": "debian5",
-        "debiansqueeze": "debian6",
-        "debianwheezy": "debian7",
-        "freebsd10": "freebsd10.0",
-        "freebsd6": "freebsd6.0",
-        "freebsd7": "freebsd7.0",
-        "freebsd8": "freebsd8.0",
-        "freebsd9": "freebsd9.0",
-        "mandriva2009": "mandriva2009.0",
-        "mandriva2010": "mandriva2010.0",
-        "mbs1": "mbs1.0",
-        "msdos": "msdos6.22",
-        "openbsd4": "openbsd4.2",
-        "opensolaris": "opensolaris2009.06",
-        "opensuse11": "opensuse11.4",
-        "opensuse12": "opensuse12.3",
-        "rhel4": "rhel4.0",
-        "rhel5": "rhel5.0",
-        "rhel6": "rhel6.0",
-        "rhel7": "rhel7.0",
-        "ubuntuhardy": "ubuntu8.04",
-        "ubuntuintrepid": "ubuntu8.10",
-        "ubuntujaunty": "ubuntu9.04",
-        "ubuntukarmic": "ubuntu9.10",
-        "ubuntulucid": "ubuntu10.04",
-        "ubuntumaverick": "ubuntu10.10",
-        "ubuntunatty": "ubuntu11.04",
-        "ubuntuoneiric": "ubuntu11.10",
-        "ubuntuprecise": "ubuntu12.04",
-        "ubuntuquantal": "ubuntu12.10",
-        "ubunturaring": "ubuntu13.04",
-        "ubuntusaucy": "ubuntu13.10",
-        "virtio26": "fedora10",
-        "vista": "winvista",
-        "winxp64": "winxp",
-
-        # Old --os-type values
-        "linux": "generic",
-        "windows": "winxp",
-        "solaris": "solaris10",
-        "unix": "freebsd9.0",
-        "other": "generic",
-    }
-
-
     #################
     # Internal APIs #
     #################
@@ -229,15 +179,6 @@ class _OSDB(object):
             raise ValueError(_("Unknown libosinfo ID '%s'") % full_id)
 
     def lookup_os(self, key, raise_error=False):
-        if key not in self._all_variants and key in self._aliases:
-            alias = self._aliases[key]
-            # Added 2018-10-02. Maybe remove aliases in a year
-            msg = (_("OS name '%(oldname)s' is deprecated, using '%(newname)s' "
-                    "instead. This alias will be removed in the future.") %
-                    {"oldname": key, "newname": alias})
-            log.warning(msg)
-            key = alias
-
         ret = self._all_variants.get(key)
         if ret is None and raise_error:
             raise ValueError(_("Unknown OS name '%s'. "

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -151,12 +151,14 @@ class _OSDB(object):
         return self.__os_loader
 
     @property
+    def _os_db(self):
+        return self._os_loader.get_db()
+
+    @property
     def _all_variants(self):
         if not self.__all_variants:
-            loader = self._os_loader
             allvariants = {}
-            db = loader.get_db()
-            oslist = db.get_os_list()
+            oslist = self._os_db.get_os_list()
             for o in _OsinfoIter(oslist):
                 osi = _OsVariant(o)
                 for name in osi.get_short_ids():
@@ -192,8 +194,8 @@ class _OSDB(object):
             log.debug("Error creating libosinfo media object: %s", str(e))
             return None
 
-        if not self._os_loader.get_db().identify_media(media):
-            return None  # pragma: no cover
+        if not self._os_db.identify_media(media):
+            return []  # pragma: no cover
         return media.get_os().get_short_id(), _OsMedia(media)
 
     def guess_os_by_tree(self, location):
@@ -212,14 +214,13 @@ class _OSDB(object):
                 "location=%s : %s", location, str(e))
             return None
 
-        db = self._os_loader.get_db()
-        if hasattr(db, "identify_tree"):
+        if hasattr(self._os_db, "identify_tree"):
             # osinfo_db_identify_tree is part of libosinfo 1.6.0
-            if not db.identify_tree(tree):
+            if not self._os_db.identify_tree(tree):
                 return None  # pragma: no cover
             return tree.get_os().get_short_id(), _OsTree(tree)
         else:  # pragma: no cover
-            osobj, treeobj = self._os_loader.get_db().guess_os_from_tree(tree)
+            osobj, treeobj = self._os_db.guess_os_from_tree(tree)
             if not osobj:
                 return None  # pragma: no cover
             return osobj.get_short_id(), _OsTree(treeobj)

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -127,19 +127,22 @@ class _OSDB(object):
     """
     def __init__(self):
         self.__os_loader = None
+        self.__os_generic = None
         self.__all_variants = None
 
     #################
     # Internal APIs #
     #################
 
-    def _make_default_variants(self, allvariants):
-        # Add our custom generic variant
-        o = Libosinfo.Os()
-        o.set_param("short-id", "generic")
-        o.set_param("name", _("Generic OS"))
-        v = _OsVariant(o)
-        allvariants[v.name] = v
+    @property
+    def _os_generic(self):
+        if not self.__os_generic:
+            # Add our custom generic variant
+            o = Libosinfo.Os()
+            o.set_param("short-id", "generic")
+            o.set_param("name", _("Generic OS"))
+            self.__os_generic = _OsVariant(o)
+        return self.__os_generic
 
     @property
     def _os_loader(self):
@@ -164,7 +167,7 @@ class _OSDB(object):
                 for name in osi.get_short_ids():
                     allvariants[name] = osi
 
-            self._make_default_variants(allvariants)
+            allvariants["generic"] = self._os_generic
             self.__all_variants = allvariants
         return self.__all_variants
 


### PR DESCRIPTION
This removes the old OS name aliases which were targetted for removal 3 years ago

After doing that a bit of the internal code for osinfo DB handling can be simplified by removing the cache.