### PR TITLE
virtinst: fix check for UEFI in SEV setup

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1067,6 +1067,7 @@ c = vinst.add_category("kvm-x86_64-launch-security", "--disk none --noautoconsol
 c.add_compare("--boot uefi --machine q35 --launchSecurity type=sev,reducedPhysBits=1,policy=0x0001,cbitpos=47,dhCert=BASE64CERT,session=BASE64SESSION --connect " + utils.URIs.kvm_amd_sev, "x86_64-launch-security-sev-full")  # Full cmdline
 c.add_compare("--boot uefi --machine q35 --launchSecurity sev --connect " + utils.URIs.kvm_amd_sev, "x86_64-launch-security-sev")  # Fill in platform data from domcaps
 c.add_valid("--boot uefi --machine q35 --launchSecurity sev,reducedPhysBits=1,cbitpos=47 --connect " + utils.URIs.kvm_amd_sev)  # Default policy == 0x0003 will be used
+c.add_valid("--boot firmware=efi --machine q35 --launchSecurity sev,reducedPhysBits=1,cbitpos=47 --connect " + utils.URIs.kvm_amd_sev)  # Default policy == 0x0003 will be used
 c.add_invalid("--launchSecurity policy=0x0001 --connect " + utils.URIs.kvm_amd_sev)  # Missing launchSecurity 'type'
 c.add_invalid("--launchSecurity sev --connect " + utils.URIs.kvm_amd_sev)  # Fail if loader isn't UEFI
 c.add_invalid("--boot uefi --launchSecurity sev --connect " + utils.URIs.kvm_amd_sev)  # Fail if machine type isn't Q35

--- a/virtinst/domain/launch_security.py
+++ b/virtinst/domain/launch_security.py
@@ -30,7 +30,7 @@ class DomainLaunchSecurity(XMLBuilder):
         # exercise for pc-i440fx to make SEV work, AMD recommends Q35 anyway
         # NOTE: at some point both of these platform checks should be put in
         # validate(), once that accepts the 'guest' instance
-        if guest.os.is_q35() is False or guest.os.loader_type != "pflash":
+        if not guest.os.is_q35() or not guest.is_uefi():
             raise RuntimeError(_("SEV launch security requires a Q35 UEFI machine"))
 
         # libvirt or QEMU might not support SEV


### PR DESCRIPTION
The code was only checking the manual approach to enabling UEFI, not the
modern automatic approach.

Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>