### PR TITLE
virtinst: fix return type in guess_os_by_iso

### DIFF
--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -191,7 +191,7 @@ class _OSDB(object):
             return None
 
         if not self._os_db.identify_media(media):
-            return []  # pragma: no cover
+            return None  # pragma: no cover
         return media.get_os().get_short_id(), _OsMedia(media)
 
     def guess_os_by_tree(self, location):


### PR DESCRIPTION
Accidentally changed in

  commit 302ef1f09669516677d83979536617f1705e1c75
  Author: Daniel P. Berrangé <berrange@redhat.com>
  Date:   Fri Nov 26 18:51:49 2021 +0000

    virtinst/osdict: add a property for the OsinfoDb object

Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>