### PR TITLE
WIP: Fix userland networking for unprivileged users

### DIFF
--- a/virtManager/device/netlist.py
+++ b/virtManager/device/netlist.py
@@ -144,8 +144,6 @@ class vmmNetworkList(vmmGObjectUI):
         add_usermode = False
         if self.conn.is_qemu_unprivileged():
             log.debug("Using unprivileged qemu, adding usermode net")
-            vnets = []
-            default_bridge = None
             add_usermode = True
 
         if add_usermode:

--- a/virtinst/connection.py
+++ b/virtinst/connection.py
@@ -359,6 +359,8 @@ class VirtinstConnection(object):
     def is_remote(self):
         return bool(self._uriobj.hostname)
     def is_privileged(self):
+        if self.get_uri_path() == "/system" and os.getuid() != 0:
+            return False
         if self.get_uri_path() == "/session":
             return False
         if self.get_uri_path() == "/embed":


### PR DESCRIPTION
This PR cheaply tries to fix usermode networking for unprivileged users. 
For the time being, this is still a WIP as currently a lot of tests will fail since the tests do not expect things like 
`<interface type="user">`. I guess I can add these expected network devices to the XML files, but I'll wait for your input to proceed.

Fixes: https://github.com/virt-manager/virt-manager/issues/353