### PR TITLE
Add "vmm" shortcut keyword

### DIFF
--- a/data/virt-manager.desktop.in
+++ b/data/virt-manager.desktop.in
@@ -5,4 +5,5 @@ Icon=virt-manager
 Exec=virt-manager
 Type=Application
 Terminal=false
+Keywords=vmm;
 Categories=System;


### PR DESCRIPTION
Adding this keyword will help finding the virtual machine manager application from start menu.