### PR TITLE
addhardware: add "none" video type

### DIFF
--- a/virtManager/addhardware.py
+++ b/virtManager/addhardware.py
@@ -810,6 +810,7 @@ class vmmAddHardware(vmmGObjectUI):
             values.append([m, vmmAddHardware.video_pretty_model(m)])
         if not values:
             values.append([None, _("Hypervisor default")])
+        values.append(["none", _("None")])
         default = DeviceVideo.default_model(vm.xmlobj)
         uiutil.build_simple_combo(combo, values, default_value=default)
 


### PR DESCRIPTION
In some setups, it is useful to have Spice input, clipboard, audio, etc.,
but not video, for instance when doing GPU passthrough -- one can
interact inside the VM via Spice rather than USB passthrough, and use
a plugged-in monitor or alternate VM viewers like Looking Glass[1] for
video.

It is already possible to specify a "none" video device by manually
typing into the "Model" combobox and hitting "Apply". Yet, this is
unintuitive. Despite being documented everywhere GPU passthrough is
brought up, in the Looking Glass community we still get ~daily support
requests from users who couldn't figure out how to disable Spice video.

This patch makes "None" an explicit option in the video model combobox,
in the hopes that this is more straightforward for users to get right.

[1]: https://looking-glass.io/

Signed-off-by: Tudor Brindus <contact@tbrindus.ca>