### PR TITLE
setup: add bits for setuptools-61

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -547,4 +547,5 @@ setuptools.setup(
     },
 
     distclass=VMMDistribution,
+    packages=[],
 )


### PR DESCRIPTION
Quoting https://github.com/pypa/setuptools/issues/3227
"Setuptools >= 61, intentionally changes the way packages are built in the
 sensec that it will try to find files and fail if something is weird.

 Empty packages (like this one), are asked to explicitly add packages=[]
 to their configuration.

 This intentional change in behaviour is described in
 https://setuptools.pypa.io/en/latest/history.html#v61-0-0."

Bug: https://bugs.gentoo.org/836645
Signed-off-by: Peter Alfredsen <crabbedhaloablution@icloud.com>