### PR TITLE
Improve debuggability of virt-install

### DIFF
--- a/virtinst/capabilities.py
+++ b/virtinst/capabilities.py
@@ -129,6 +129,19 @@ class _CapsGuest(XMLBuilder):
                 ret.append(m.canonical)
         return ret
 
+    def is_machine_alias(self, domain, src, tgt):
+        """
+        Determine if machine @src is an alias for machine @tgt
+        """
+        mobjs = (domain and domain.machines) or self.machines
+        for m in mobjs:
+            log.debug("Check %s == %s %s == %s", m.name, src, m.canonical, tgt)
+            if m.name == src and m.canonical == tgt:
+                log.debug("ok")
+                return True
+        log.debug("not ok")
+        return False
+
     def is_kvm_available(self):
         """
         Return True if kvm guests can be installed
@@ -178,6 +191,9 @@ class _CapsInfo(object):
 
         self.emulator = self.domain.emulator or self.guest.emulator
         self.machines = self.guest.all_machine_names(self.domain)
+
+    def is_machine_alias(self, src, tgt):
+        return self.guest.is_machine_alias(self.domain, src, tgt)
 
 
 class Capabilities(XMLBuilder):

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -214,10 +214,21 @@ def getConnection(uri, conn=None):
         # preopened connection passed in via test suite
         return conn
 
+    def format_version(num):
+        log.debug(num)
+        maj = int(num / 1000000)
+        min = int(num / 1000) % 1000
+        mic = num % 1000
+        return "%s.%s.%s" % (maj, min, mic)
+
     log.debug("Requesting libvirt URI %s", (uri or "default"))
     conn = VirtinstConnection(uri)
     conn.open(_openauth_cb, None)
-    log.debug("Received libvirt URI %s", conn.uri)
+    log.debug("Received libvirt URI %s versions library=%s driver=%s hypervisor=%s",
+              conn.uri,
+              format_version(libvirt.getVersion()),
+              format_version(conn.getLibVersion()),
+              format_version(conn.getVersion()))
 
     return conn
 

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -201,7 +201,8 @@ def setupLogging(appname, debug_stdout, do_quiet, cli_app=True):
     sys.excepthook = exception_log
 
     # Log the app command string
-    log.debug("Launched with command line: %s", " ".join(sys.argv))
+    log.debug("Version %s launched with command line: %s",
+              BuildConfig.version, " ".join(sys.argv))
 
 
 ##############################

--- a/virtinst/connection.py
+++ b/virtinst/connection.py
@@ -104,8 +104,9 @@ class VirtinstConnection(object):
 
     def _get_caps(self):
         if not self._caps:
-            self._caps = Capabilities(self,
-                self._libvirtconn.getCapabilities())
+            capsxml = self._libvirtconn.getCapabilities()
+            self._caps = Capabilities(self, capsxml)
+            log.debug("Fetched capabilities for %s: %s", self._uri, capsxml)
         return self._caps
     caps = property(_get_caps)
 

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -241,6 +241,8 @@ class DomainCapabilities(XMLBuilder):
             try:
                 xml = conn.getDomainCapabilities(emulator, arch,
                     machine, hvtype)
+                log.debug("Fetched domain capabilities for (%s,%s,%s,%s): %s",
+                          emulator, arch, machine, hvtype, xml)
             except Exception:  # pragma: no cover
                 log.debug("Error fetching domcapabilities XML",
                     exc_info=True)

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -618,13 +618,21 @@ class Guest(XMLBuilder):
         return True
 
     def lookup_domcaps(self):
+        def _compare_machine(domcaps):
+            capsinfo = self.lookup_capsinfo()
+            if self.os.machine == domcaps.machine:
+                return True
+            if capsinfo.is_machine_alias(self.os.machine, domcaps.machine):
+                return True
+            return False
+
         # We need to regenerate domcaps cache if any of these values change
         def _compare(domcaps):  # pragma: no cover
             if self.type == "test":
                 # Test driver doesn't support domcaps. We kinda fake it in
                 # some cases, but it screws up the checking here for parsed XML
                 return True
-            if self.os.machine and self.os.machine != domcaps.machine:
+            if self.os.machine and not _compare_machine(domcaps):
                 return False
             if self.type and self.type != domcaps.domain:
                 return False


### PR DESCRIPTION
Debugging a recent bug report with virt-install was more challenging than it ought to have been. The only source of information was the virt-install --debug output, because the host OS was an automated system with no direct access available. There were various key bits of info missing in the --debug logs including host capabilities, domain capabilities, virt-install version and various libvirt versions. This series addresses those log output gaps.