### PR TITLE
ui: Fix too wide lables

### DIFF
--- a/ui/details.ui
+++ b/ui/details.ui
@@ -3545,6 +3545,7 @@
                                     <property name="halign">start</property>
                                     <property name="label" translatable="yes">label508</property>
                                     <property name="selectable">True</property>
+                                    <property name="ellipsize">start</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">1</property>
@@ -3797,6 +3798,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label">label</property>
+                                    <property name="wrap">True</property>
                                     <property name="selectable">True</property>
                                   </object>
                                   <packing>


### PR DESCRIPTION
When some lables have too much content, they will become very wide,
causing the window to widen.

Signed-off-by: Feng Jiang <jiangfeng@kylinos.cn>