### PR TITLE
Fix build with setuptools 61+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -530,6 +530,9 @@ setuptools.setup(
             glob.glob("virtinst/install/*.py")),
     ],
 
+    # stop setuptools 61+ thinking we want to include everything automatically
+    py_modules=[],
+
     cmdclass={
         'build': my_build,
         'build_i18n': my_build_i18n,


### PR DESCRIPTION
    + ./setup.py configure --default-hvs qemu,xen,lxc
    error: Multiple top-level packages discovered in a flat-layout: ['po', 'ui', 'man', 'data', 'virtinst', 'virtManager'].
    To avoid accidental inclusion of unwanted files or directories,
    setuptools will not proceed with this build.
    If you are trying to create a single distribution with multiple packages
    on purpose, you should not rely on automatic discovery.
    Instead, consider the following options:
    1. set up custom discovery (`find` directive with `include` or `exclude`)
    2. use a `src-layout`
    3. explicitly set `py_modules` or `packages` with a list of names
    To find more information, look for "package discovery" on setuptools docs.

Downstream bug report: https://bugzilla.redhat.com/2113754