### PR TITLE
Make unicode error when listing data in pool more readable

### DIFF
--- a/virtinst/pollhelpers.py
+++ b/virtinst/pollhelpers.py
@@ -55,7 +55,12 @@ def fetch_volumes(backend, pool, origmap, build_cb):
     typename = "volume"
     list_cb = pool.listAllVolumes
     support_cb = backend.support.conn_storage
-    return _new_poll_helper(origmap, typename, list_cb, build_cb, support_cb)
+    try:
+        return _new_poll_helper(origmap, typename, list_cb, build_cb, support_cb)
+    except UnicodeDecodeError:
+        raise RuntimeError(_("Some files in the '%(pool_name)s' pool have unsupported "
+                           "characters in name. Please remove this file or "
+                           "undefine the pool.") % {"pool_name": pool.name()})
 
 
 def fetch_nodedevs(backend, origmap, build_cb):


### PR DESCRIPTION
If you unpack tarball from another system it could have a broken names of the files. If this file is part of the pool then running a VM will end up with a hard to understand error. Make the error easy to understand.

Reproducer:
```
mkdir ''$'\320''½'$'\250\316''ļ'$'\376\274\320'
curl -LO https://dl.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Bas
e-36-1.5.x86_64.qcow2
virt-install --connect=qemu:///system --name=test --os-variant=fedora36 --import --disk "size=20,path=$(realpath $PWD)/Fedora-Cloud-Base-36-1.5.x86_64.qcow2"
```

Without this change you will get error:
```
ERROR    Error: --disk size=20,path=/<snip>/virt-manager/test-data2/Fedora-Cloud-Base-36-1.5.x86_64.qcow2: 'utf-8' codec can't decode byte 0xd0 in position 0: invalid continuation byte
```

With this change you will get error:
```
ERROR    Error: --disk size=20,path=/<snip>/virt-manager/test-data2/Fedora-Cloud-Base-36-1.5.x86_64.qcow2: Some files in the 'test-data2' pool have unsupported characters in name. Please remove this file or undefine the pool.
```

This change will make such an error much easy to understand than before. Right now, I would know where to look to solve the issue on my side.

Resolves bug https://bugzilla.redhat.com/show_bug.cgi?id=2115101 .