### PR TITLE
tests: cpio: set owner to 0:0

### DIFF
--- a/virtinst/install/installerinject.py
+++ b/virtinst/install/installerinject.py
@@ -20,7 +20,7 @@ def _run_initrd_commands(initrd, tempdir):
                                  stderr=subprocess.PIPE,
                                  cwd=tempdir)
     cpio_proc = subprocess.Popen(['cpio', '--create', '--null', '--quiet',
-                                  '--format=newc', '--owner=root:root'],
+                                  '--format=newc', '--owner=0:0'],
                                  stdin=find_proc.stdout,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE,


### PR DESCRIPTION
Building virt-manager on macOS with tests enabled fails with the following error:

```
testCLI0051virt_install_initrd_inject: cpio: root:root: invalid group
```

Setting the owner to 0:0 fixes the issue.
