### PR TITLE
Check availability of usb redirdevs and spicevmc channels in domcaps

### DIFF
--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -92,6 +92,8 @@ def testDomainCapabilitiesx86():
 
     assert caps.supports_filesystem_virtiofs()
     assert caps.supports_memorybacking_memfd()
+    assert caps.supports_redirdev_usb()
+    assert caps.supports_channel_spicevmc()
 
     xml = open(DATADIR + "/kvm-x86_64-domcaps-amd-sev.xml").read()
     caps = DomainCapabilities(utils.URIs.open_testdriver_cached(), xml)

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -113,6 +113,7 @@ class _Devices(_CapsBlock):
     graphics = XMLChildProperty(_make_capsblock("graphics"), is_single=True)
     tpm = XMLChildProperty(_make_capsblock("tpm"), is_single=True)
     filesystem = XMLChildProperty(_make_capsblock("filesystem"), is_single=True)
+    redirdev = XMLChildProperty(_make_capsblock("redirdev"), is_single=True)
 
 
 class _Features(_CapsBlock):
@@ -447,6 +448,18 @@ class DomainCapabilities(XMLBuilder):
             return self.conn.caps.host.cpu.arch in ["i686", "x86_64"]
 
         return self.devices.graphics.get_enum("type").has_value("spice")
+
+    def supports_redirdev_usb(self):
+        """
+        Return False if libvirt explicitly advertises no support for
+        USB redirect
+        """
+        if self.devices.redirdev.supported is None:
+            # Follow the original behavior in case of talking to older
+            # libvirt.
+            return True
+
+        return self.devices.redirdev.get_enum("bus").has_value("usb")
 
     def supports_filesystem_virtiofs(self):
         """

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -114,6 +114,7 @@ class _Devices(_CapsBlock):
     tpm = XMLChildProperty(_make_capsblock("tpm"), is_single=True)
     filesystem = XMLChildProperty(_make_capsblock("filesystem"), is_single=True)
     redirdev = XMLChildProperty(_make_capsblock("redirdev"), is_single=True)
+    channel = XMLChildProperty(_make_capsblock("channel"), is_single=True)
 
 
 class _Features(_CapsBlock):
@@ -448,6 +449,18 @@ class DomainCapabilities(XMLBuilder):
             return self.conn.caps.host.cpu.arch in ["i686", "x86_64"]
 
         return self.devices.graphics.get_enum("type").has_value("spice")
+
+    def supports_channel_spicevmc(self):
+        """
+        Return False if libvirt explicitly advertises no support for
+        spice channel
+        """
+        if self.devices.channel.supported is None:
+            # Follow the original behavior in case of talking to older
+            # libvirt.
+            return True
+
+        return self.devices.channel.get_enum("type").has_value("spicevmc")
 
     def supports_redirdev_usb(self):
         """

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -1155,6 +1155,8 @@ class Guest(XMLBuilder):
         self.add_device(dev)
 
     def _add_spice_usbredir(self):
+        if not self.lookup_domcaps().supports_redirdev_usb():
+            return
         if self.skip_default_usbredir:
             return
         if self.devices.redirdev:

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -1127,6 +1127,8 @@ class Guest(XMLBuilder):
             self.add_device(ctrl)
 
     def _add_spice_channels(self):
+        if not self.lookup_domcaps().supports_channel_spicevmc():
+            return
         if self.skip_default_channel:
             return
         for chn in self.devices.channel:


### PR DESCRIPTION
v1 -> v2: Follow the original behavior in case of talking to older libvirt.

Libvirt domcaps can advertise the redirect devices and spicevmc channel devices since v8.9.0.
Virt-install adds usb redirdevs and spicevmc channels by default on x86.

This patchset adds checks to avoid using redirect devices/spicevmc channel devices when not supported by the target qemu.