### PR TITLE
Fix uninitialized controller index

### DIFF
--- a/virtManager/addhardware.py
+++ b/virtManager/addhardware.py
@@ -1562,6 +1562,8 @@ class vmmAddHardware(vmmGObjectUI):
         if len(controller_num) > 0:
             index_new = max([x.index for x in controller_num]) + 1
             dev.index = index_new
+        else:
+            dev.index = 0
 
         dev.type = controller_type
 


### PR DESCRIPTION
When adding a second virtio-scsi controller to a guest from the Add Hardware dialog an exception is thrown.
Error building device XML: unsupported operand type(s) for +: 'NoneType' and 'int'
This happens because the index for the first controller created was not initialized to zero.

Signed-off-by: Charles Arnold <carnold@suse.com>