### PR TITLE
cloner: clone serial files 

### DIFF
--- a/tests/data/cli/compare/virt-clone-serial.xml
+++ b/tests/data/cli/compare/virt-clone-serial.xml
@@ -1,0 +1,31 @@
+<domain type="test">
+  <name>__virtinst_cli_test-clone1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>8388608</memory>
+  <currentMemory>2097152</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <clock offset="utc"/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <serial type="file">
+      <source path="/tmp/__virtinst_cli_test-clone1.file">
+        <seclabel model="dac" relabel="no"/>
+      </source>
+    </serial>
+    <serial type="file">
+      <source path="/tmp/__virtinst_cli_other-serial-clone.file"/>
+    </serial>
+    <serial type="unix">
+      <source mode="connect" path="/tmp/__virtinst_cli_socket.sock"/>
+    </serial>
+    <console type="file">
+      <source path="/tmp/__virtinst_cli_serial-exists-clone.file"/>
+    </console>
+  </devices>
+</domain>

--- a/tests/data/cli/virtclone/clone-serial.xml
+++ b/tests/data/cli/virtclone/clone-serial.xml
@@ -1,0 +1,31 @@
+<domain type="test">
+  <name>__virtinst_cli_test-clone</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>8388608</memory>
+  <currentMemory>2097152</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <clock offset="utc"/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <serial type="file">
+      <source path="/tmp/__virtinst_cli_test-clone.file">
+        <seclabel model="dac" relabel="no"/>
+      </source>
+    </serial>
+    <serial type="file">
+      <source path="/tmp/__virtinst_cli_other-serial.file"/>
+    </serial>
+    <serial type="unix">
+      <source mode="connect" path="/tmp/__virtinst_cli_socket.sock"/>
+    </serial>
+    <console type="file">
+      <source path="/tmp/__virtinst_cli_serial-exists.file"/>
+    </console>
+  </devices>
+</domain>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,12 +52,18 @@ NEW_FILES = [
     TMP_IMAGE_DIR + "new3.img",
     TMP_IMAGE_DIR + "exist1-clone.img",
     TMP_IMAGE_DIR + "exist2-clone.img",
+
+    TMP_IMAGE_DIR + "test-clone1.file",
+    TMP_IMAGE_DIR + "other-serial-clone.file",
+    TMP_IMAGE_DIR + "serial-exists-clone-1.file",
 ]
 
 # Images that are expected to exist before a command is run
 EXIST_FILES = [
     TMP_IMAGE_DIR + "exist1.img",
     TMP_IMAGE_DIR + "exist2.img",
+
+    TMP_IMAGE_DIR + "serial-exists-clone.file",
 ]
 
 
@@ -1484,6 +1490,7 @@ _CLONE_NVRAM_MISSING = "--original-xml %s/clone-nvram-missing.xml" % _CLONEXMLDI
 _CLONE_EMPTY = "--original-xml %s/clone-empty.xml" % _CLONEXMLDIR
 _CLONE_NET_RBD = "--original-xml %s/clone-net-rbd.xml" % _CLONEXMLDIR
 _CLONE_NET_HTTP = "--original-xml %s/clone-net-http.xml" % _CLONEXMLDIR
+_CLONE_SERIAL = "--original-xml %s/clone-serial.xml" % _CLONEXMLDIR
 
 
 vclon = App("virt-clone")
@@ -1507,6 +1514,7 @@ c.add_compare(_CLONE_EMPTY + " --auto-clone --print-xml", "empty")  # Auto flag,
 c.add_compare("--connect %(URI-KVM-X86)s -o test-clone-simple --auto -f /foo.img --print-xml", "pool-test-cross-pool")  # cross pool cloning which fails with test driver but let's confirm the XML
 c.add_compare(_CLONE_MANAGED + " --auto-clone", "auto-managed")  # Auto flag w/ managed storage
 c.add_compare(_CLONE_UNMANAGED + " --auto-clone", "auto-unmanaged")  # Auto flag w/ local storage
+c.add_compare(_CLONE_SERIAL + " --auto-clone", "serial")  # Auto flag w/ serial console
 c.add_valid("--connect %(URI-TEST-FULL)s -o test-clone --auto-clone --nonsparse")  # Auto flag, actual VM, skip state check
 c.add_valid("--connect %(URI-TEST-FULL)s -o test-clone-simple -n newvm --preserve-data --file %(EXISTIMG1)s")  # Preserve data shouldn't complain about existing volume
 c.add_valid("-n clonetest " + _CLONE_UNMANAGED + " --file %(EXISTIMG3)s --file %(EXISTIMG4)s --check path_exists=off")  # Skip existing file check


### PR DESCRIPTION
Before this, on clone the serial file would remain the same for the cloned
domain. This doesn't make much sense as the output would be an intermix of two
unrelated output sequences.

Here we apply the same filename changing algorithm, as with disk files.