### PR TITLE
 console: Select the first embeddable graphics device as graphical console

### DIFF
--- a/virtManager/config.py
+++ b/virtManager/config.py
@@ -208,10 +208,6 @@ class vmmConfig(object):
     def get_ui_dir(self):
         return self.ui_dir
 
-    def embeddable_graphics(self):
-        ret = ["vnc", "spice"]
-        return ret
-
     def inspection_supported(self):
         if not vmmInspection.libguestfs_installed():
             return False  # pragma: no cover

--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -691,7 +691,7 @@ class vmmConsolePages(vmmGObjectUI):
             gdevs = self.vm.xmlobj.devices.graphics
             gdev = gdevs and gdevs[0] or None
             if gdev:
-                ginfo = ConnectionInfo(self.vm.conn, gdev)
+                ginfo = ConnectionInfo(self.vm.conn, gdev, 0)
         except Exception as e:  # pragma: no cover
             # We can fail here if VM is destroyed: xen is a bit racy
             # and can't handle domain lookups that soon after

--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -293,6 +293,10 @@ class _ConsoleMenu:
                 return True
         return False
 
+    def embeddable_graphics(self):
+        ret = ["vnc", "spice"]
+        return ret
+
 
 class vmmConsolePages(vmmGObjectUI):
     """
@@ -700,7 +704,7 @@ class vmmConsolePages(vmmGObjectUI):
                 _("Graphical console not configured for guest"))
             return
 
-        if ginfo.gtype not in self.config.embeddable_graphics():
+        if ginfo.gtype not in self._consolemenu.embeddable_graphics():
             log.debug("Don't know how to show graphics type '%s' "
                           "disabling console page", ginfo.gtype)
 

--- a/virtManager/details/sshtunnels.py
+++ b/virtManager/details/sshtunnels.py
@@ -20,7 +20,8 @@ class ConnectionInfo(object):
     """
     Holds all the bits needed to make a connection to a graphical console
     """
-    def __init__(self, conn, gdev):
+    def __init__(self, conn, gdev, gidx):
+        self.gidx  = gidx
         self.gtype = gdev.type
         self.gport = str(gdev.port) if gdev.port else None
         self.gsocket = (gdev.listens and gdev.listens[0].socket) or gdev.socket

--- a/virtManager/details/viewers.py
+++ b/virtManager/details/viewers.py
@@ -134,7 +134,7 @@ class Viewer(vmmGObject):
         if not self._vm.conn.support.domain_open_graphics():
             return None
 
-        return self._vm.open_graphics_fd()
+        return self._vm.open_graphics_fd(self._ginfo.gidx)
 
     def _open(self):
         if self._ginfo.bad_config():

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -1163,9 +1163,9 @@ class vmmDomain(vmmLibvirtObject):
     def open_console(self, devname, stream, flags=0):
         return self._backend.openConsole(devname, stream, flags)
 
-    def open_graphics_fd(self):
+    def open_graphics_fd(self, idx):
         flags = 0
-        return self._backend.openGraphicsFD(0, flags)
+        return self._backend.openGraphicsFD(idx, flags)
 
     def list_snapshots(self):
         if self._snapshot_list is None:


### PR DESCRIPTION
Currently, when there are multiple graphics devices, the first graphics
device is always selected as the graphical console. For the following
configuration:

    <graphics type="egl-headless">
      <gl rendernode="/dev/dri/renderD128"/>
    </graphics>
    <graphics type="spice" autoport="yes">
      <listen type="address"/>
      <image compression="off"/>
      <gl enable="no"/>
    </graphics>

virt-manager will report an error:

    Cannot display graphical console type 'egl-headless'

The patch will iterate through all graphics devices to try to select the
first embeddable graphics device as graphical console.