### PR TITLE
virtinstall: Add hint for using logical_block_size and physical_block_size

### DIFF
--- a/virtinst/devices/disk.py
+++ b/virtinst/devices/disk.py
@@ -1015,6 +1015,12 @@ class DeviceDisk(Device):
             if not self.driver_io:
                 self.driver_io = self.IO_MODE_NATIVE
 
+        if self.is_disk():
+            if not self.logical_block_size:
+                self.logical_block_size = 512
+            if not self.physical_block_size:
+                self.physical_block_size = 4096
+
         if discard_unmap:
             if not self.driver_discard:
                 self.driver_discard = "unmap"


### PR DESCRIPTION
virtinstall: Add hint for using logical_block_size and physical_block_size

Add a hint for the user in the form of default values for the logical block and the physical block. Selecting specific values offering a good balance between disk performance and the use of space in primary memory, also these parameters allow you to maintain compatibility with older systems.

Signed-off-by: Efim Shevrin <efim.shevrin@virtuozzo.com>