### PR TITLE
man/virt-install: Add a note about different behavior of --boot on s390x

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -929,6 +929,8 @@ Some examples:
 ``--boot cdrom,fd,hd,network``
     Set the boot device priority as first cdrom, first floppy, first harddisk,
     network PXE boot.
+    Note: s390x guests only support one boot device, so everything except
+    the first device type will be ignored.
 
 ``--boot kernel=KERNEL,initrd=INITRD,kernel_args="console=/dev/ttyS0"``
     Have guest permanently boot off a local kernel/initrd pair, with the


### PR DESCRIPTION
It is common on x86 and other architectures to install a guest from network by using "--boot hd,network" with virt-install - as long as the hard disk is not bootable yet, the installation will be started via network, and once it finished, the guest can boot from hd during the next reboot.

However, this does not work on s390x since this architecture only supports one single boot device to be passed to the guest. Thus add a note to the documentation to avoid that people are running again into this common pitfall.

Buglink: https://bugzilla.redhat.com/show_bug.cgi?id=2032472
