### PR TITLE
virt-install: add `OVMF_CODE_4M.fd` to UEFI x86_64 arch patterns and fix catchall pattern

### DIFF
--- a/tests/test_xmlparse.py
+++ b/tests/test_xmlparse.py
@@ -77,7 +77,7 @@ def testAlterGuest():
 
     check = _make_checker(guest)
 
-    # Check specific vcpu_current behaviro
+    # Check specific vcpu_current behavior
     check("vcpus", 5, 10)
     assert guest.vcpu_current is None
     check("vcpu_current", None, 15)

--- a/virtManager/createvm.py
+++ b/virtManager/createvm.py
@@ -2095,7 +2095,7 @@ class vmmCreateVM(vmmGObjectUI):
             meter.start(_(prog['status']), None)
 
         asyncjob.details_enable()
-        # Use logging filter to show messages of the progreess on the GUI
+        # Use logging filter to show messages of the progress on the GUI
         class SetStateFilter(logging.Filter):
             def filter(self, record):
                 asyncjob.details_update("%s\n" % record.getMessage())

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -275,10 +275,11 @@ class DomainCapabilities(XMLBuilder):
         ],
         "x86_64": [
             r".*edk2-x86_64-.*\.fd",  # upstream qemu
-            r".*OVMF_CODE\.fd",  # RHEL
+            r".*OVMF_CODE\.fd",  # RHEL, Debian, Ubuntu
+            r".*OVMF_CODE_4M\.fd",  # Debian, Ubuntu
             r".*ovmf-x64/OVMF.*\.fd",  # gerd's firmware repo
             r".*ovmf-x86_64-.*",  # SUSE
-            r".*ovmf.*", ".*OVMF.*",  # generic attempt at a catchall
+            r".*ovmf.*", r".*OVMF.*",  # generic attempt at a catchall
         ],
         "aarch64": [
             r".*AAVMF_CODE\.fd",  # RHEL


### PR DESCRIPTION
Newer versions of the OVMF package in Debian and Ubuntu have started to ship 4M OVMF FW images with `_4M` suffix in their name, and updated the firmware descriptor JSON files to point to them. The problem with that is, virt-install's UEFI x86_64 arch pattern for OVMF does not explicitly cover the `_4M` suffix, causing virt-install to fallback to capability based image selection and it picks up an unintended firmware image on Debian and Ubuntu (i.e.,secure boot enforced) as a result. [1]

There is an existing catchall `.*OVMF.*` pattern that should've matched to the new name, but it is not a raw string literal (lacks 'r' before dquote) so it does not work as intended.
    
This patch adds the `.*OVMF_CODE_4M\.fd` pattern, and fixes the `.*OVMF.*` catchall pattern.

Also, added a unit test to verify that `find_uefi_path_for_arch` behaves as intended.

[1]: [launchpad bug #2004618](https://bugs.launchpad.net/ubuntu/+source/edk2/+bug/2004618)
