### PR TITLE
Fixed issue where applications list was too narrow to read in OS info

### DIFF
--- a/ui/details.ui
+++ b/ui/details.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -791,7 +791,9 @@
                                 <property name="height-request">150</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
+                                <property name="hexpand">True</property>
                                 <property name="shadow-type">etched-in</property>
+                                <property name="propagate-natural-width">True</property>
                                 <child>
                                   <object class="GtkTreeView" id="inspection-apps">
                                     <property name="visible">True</property>

--- a/ui/details.ui
+++ b/ui/details.ui
@@ -788,7 +788,7 @@
                             <property name="margin-top">3</property>
                             <child>
                               <object class="GtkScrolledWindow" id="scrolledwindow6">
-                                <property name="height-request">150</property>
+                                <property name="height-request">200</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="hexpand">True</property>


### PR DESCRIPTION
Under OS information the Applications list was too narrow to read, so I have enabled expanding horizontally.

Before:
![image](https://user-images.githubusercontent.com/71675376/227916221-51d3d84b-412d-4c65-ba2f-9aa5db8c28d4.png)

After:
![image](https://user-images.githubusercontent.com/71675376/227916338-585e308a-0128-4b7b-806f-d8e5abfcf0c1.png)
