### PR TITLE
console: When resizing window to VM, unmaximize only if maximized

### DIFF
--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -514,7 +514,9 @@ class vmmConsolePages(vmmGObjectUI):
         viewer_alloc = self.widget("console-gfx-scroll").get_allocation()
         desktop_w, desktop_h = self._viewer.console_get_desktop_resolution()
 
-        self.topwin.unmaximize()
+        if self.topwin.is_maximized():
+            self.topwin.unmaximize()
+
         self.topwin.resize(
             desktop_w + (top_w - viewer_alloc.width),
             desktop_h + (top_h - viewer_alloc.height))


### PR DESCRIPTION
Under a KDE Wayland session, unmaximizing a normal window, then resizing it right away results in nothing happening. Check if the console window is maximized first.

As for *why* this is the case, I don't know. If the window is maximized when trying to resize to VM, everything works. Maybe it's some sort of a race condition in Gtk that needs further investigation, but for now, this at least fixes virt-manager.