### PR TITLE
virtinst: fix "lookup_capsinfo" usage (Issue 539)

### DIFF
--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -632,7 +632,12 @@ class Guest(XMLBuilder):
         def _compare_machine(domcaps):
             if self.os.machine == domcaps.machine:
                 return True
-            capsinfo = self.lookup_capsinfo()
+            try:
+                capsinfo = self.lookup_capsinfo()
+            except Exception:
+                log.exception("Error fetching machine list for alias "
+                                  "resolution, assuming mismatch");
+                return False
             if capsinfo.is_machine_alias(self.os.machine, domcaps.machine):
                 return True
             return False

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -630,9 +630,9 @@ class Guest(XMLBuilder):
 
     def lookup_domcaps(self):
         def _compare_machine(domcaps):
-            capsinfo = self.lookup_capsinfo()
             if self.os.machine == domcaps.machine:
                 return True
+            capsinfo = self.lookup_capsinfo()
             if capsinfo.is_machine_alias(self.os.machine, domcaps.machine):
                 return True
             return False


### PR DESCRIPTION
These patches address https://github.com/virt-manager/virt-manager/issues/539 ; please see my analysis there (although the commit messages are verbose too).

Thanks!