### PR TITLE
tests: in xml osinfo url change http to https

### DIFF
--- a/tests/data/cli/compare/virt-install-osinfo-unattended-treeapis.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-unattended-treeapis.xml
@@ -13,7 +13,7 @@
     <type arch="x86_64" machine="pc-i440fx-6.1">hvm</type>
     <kernel>/VIRTINST-TESTSUITE/vmlinuz</kernel>
     <initrd>/VIRTINST-TESTSUITE/initrd.img</initrd>
-    <cmdline>ks=file:/fedora.ks method=http://archive.fedoraproject.org/pub/archive/fedora/linux/releases/17/Fedora/x86_64/os/</cmdline>
+    <cmdline>ks=file:/fedora.ks method=https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/17/Fedora/x86_64/os/</cmdline>
   </os>
   <features>
     <acpi/>

--- a/tests/data/cli/compare/virt-install-osinfo-url-unattended.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-url-unattended.xml
@@ -13,7 +13,7 @@
     <type arch="x86_64" machine="q35">hvm</type>
     <kernel>/VIRTINST-TESTSUITE/vmlinuz</kernel>
     <initrd>/VIRTINST-TESTSUITE/initrd.img</initrd>
-    <cmdline>ks=file:/fedora.ks inst.repo=http://archives.fedoraproject.org/pub/archive/fedora/linux/releases/26/Server/x86_64/os/</cmdline>
+    <cmdline>ks=file:/fedora.ks inst.repo=https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/26/Server/x86_64/os/</cmdline>
   </os>
   <features>
     <acpi/>

--- a/tests/data/cli/compare/virt-install-osinfo-url-with-disk.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-url-with-disk.xml
@@ -13,7 +13,7 @@
     <type arch="x86_64" machine="q35">hvm</type>
     <kernel>/VIRTINST-TESTSUITE/vmlinuz</kernel>
     <initrd>/VIRTINST-TESTSUITE/initrd.img</initrd>
-    <cmdline>method=http://archives.fedoraproject.org/pub/archive/fedora/linux/releases/26/Server/x86_64/os/</cmdline>
+    <cmdline>method=https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/26/Server/x86_64/os/</cmdline>
   </os>
   <features>
     <acpi/>

--- a/tests/data/cli/compare/virt-install-osinfo-url.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-url.xml
@@ -13,7 +13,7 @@
     <type arch="x86_64" machine="q35">hvm</type>
     <kernel>/VIRTINST-TESTSUITE/vmlinuz</kernel>
     <initrd>/VIRTINST-TESTSUITE/initrd.img</initrd>
-    <cmdline>method=http://archives.fedoraproject.org/pub/archive/fedora/linux/releases/26/Server/x86_64/os/</cmdline>
+    <cmdline>method=https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/26/Server/x86_64/os/</cmdline>
   </os>
   <features>
     <acpi/>


### PR DESCRIPTION
this will avoid tests to fails only for different url http->https

this solves a FTBFS that was spotted in debian QA tests and reported in: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1042147