### PR TITLE
fix indentation of multiline log.exception() invocations

### DIFF
--- a/virtManager/hoststorage.py
+++ b/virtManager/hoststorage.py
@@ -427,8 +427,7 @@ class vmmHostStorage(vmmGObjectUI):
                     if not namestr:
                         namestr = None
             except Exception:  # pragma: no cover
-                log.exception("Failed to determine if storage volume in "
-                                  "use.")
+                log.exception("Failed to determine if storage volume in use.")
 
             sensitive = True
             if self._vol_sensitive_cb:

--- a/virtManager/lib/inspection.py
+++ b/virtManager/lib/inspection.py
@@ -115,9 +115,8 @@ def _perform_inspection(conn, vm):  # pragma: no cover
             g.mount_ro(dev, mp)
             filesystems_mounted = True
         except Exception:
-            log.exception("%s: exception mounting %s on %s "
-                              "(ignored)",
-                              prettyvm, dev, mp)
+            log.exception("%s: exception mounting %s on %s (ignored)",
+                          prettyvm, dev, mp)
 
     icon = None
     apps = None
@@ -154,7 +153,7 @@ def _perform_inspection(conn, vm):  # pragma: no cover
                 apps.append(app)
         except Exception:
             log.exception("%s: exception while listing apps (ignored)",
-                              prettyvm)
+                          prettyvm)
 
     # Force the libguestfs handle to close right now.
     del g

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -1429,7 +1429,7 @@ class vmmDomain(vmmLibvirtObject):
             self._backend.undefineFlags(flags)
         except libvirt.libvirtError:
             log.exception("libvirt undefineFlags failed, "
-                              "falling back to old style")
+                          "falling back to old style")
             self._backend.undefine()
 
     @vmmLibvirtObject.lifecycle_action

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -636,7 +636,7 @@ class Guest(XMLBuilder):
                 capsinfo = self.lookup_capsinfo()
             except Exception:
                 log.exception("Error fetching machine list for alias "
-                                  "resolution, assuming mismatch");
+                              "resolution, assuming mismatch");
                 return False
             if capsinfo.is_machine_alias(self.os.machine, domcaps.machine):
                 return True


### PR DESCRIPTION
Commit f107e3998908 ("Switch to more traditional logging structure", 2019-06-17) replaced "logging.exception" with "log.exception", effectively shifting the argument lists 4 characters to the left. The second and further lines of multiline invocations were not accordingly unindented, however, which ended up setting a suboptimal precedent as well. Unindent those lines now.

Reported-by: Cole Robinson <crobinso@redhat.com>