### PR TITLE
virt-clone: Copy disk permissions as well

### DIFF
--- a/virtinst/storage.py
+++ b/virtinst/storage.py
@@ -528,6 +528,7 @@ class StorageVolume(_StorageObject):
         self.format = parsevol.format
         self.capacity = parsevol.capacity
         self.allocation = parsevol.allocation
+        self.permissions.mode = parsevol.permissions.mode
         if not self._pool:
             self.pool = self._input_vol.storagePoolLookupByVolume()
 


### PR DESCRIPTION
When cloning using libvirt APIs the function virStorageVolCreateXMLFrom is used.  However name and permissions are taken from the new XML [1]. By copying the permissions (only the mode is used) we can avoid some unexpected issues.

[1] https://libvirt.org/html/libvirt-libvirt-storage.html#virStorageVolCreateXMLFrom

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2115153