### PR TITLE
Add support for hvf domain type

### DIFF
--- a/virtManager/connection.py
+++ b/virtManager/connection.py
@@ -220,6 +220,8 @@ class vmmConnection(vmmGObject):
             label = "QEMU TCG"
         elif domtype == "kvm":
             label = "KVM"
+        elif domtype == "hvf":
+            label = "Hypervisor.framework"
 
         return label
 

--- a/virtinst/capabilities.py
+++ b/virtinst/capabilities.py
@@ -236,7 +236,7 @@ class Capabilities(XMLBuilder):
         if not domains:
             return None
 
-        priority = ["kvm", "xen", "qemu"]
+        priority = ["kvm", "xen", "hvf", "qemu"]
 
         for t in priority:
             for d in domains:


### PR DESCRIPTION
The default "qemu" domain type on macOS is very slow, so pick up "hvf" when it's available.