### PR TITLE
console: allow localhost connections over TCP

### DIFF
--- a/virtManager/details/sshtunnels.py
+++ b/virtManager/details/sshtunnels.py
@@ -69,7 +69,8 @@ class ConnectionInfo(object):
 
         if (not self.need_tunnel() and
             self.transport and
-            self._is_listen_localhost(self.get_conn_host()[0])):
+            self._is_listen_localhost() and
+            not self._is_listen_localhost(self._connhost)):
             return _("Guest is on a remote host with transport '%s' "
                 "but is only configured to listen locally. "
                 "To connect remotely you will need to change the guest's "


### PR DESCRIPTION
Fix console config validation for an edge case where both libvirt and Spice/VNC TCP connection are on localhost. Transport over TCP does not necessarily mean that libvirt connection is to a remote host.

Compare libvirt and graphics device addresses to localhost individually. Raise an error only when guest device is bound to localhost but libvirt connection is non-local (remote).

Validation that prevents fully local TCP seems to go back all the way to bc13c302de4 ("console: Warn if qemu+tcp URI and listen == 127.0.0.1").