### PR TITLE
Fix filesystem socket.source

### DIFF
--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -509,9 +509,7 @@
       <readonly/>
       <space_hard_limit>1234</space_hard_limit>
       <space_soft_limit>500</space_soft_limit>
-      <source pool="pool1" volume="vol">
-        <socket>/tmp/foo.sock</socket>
-      </source>
+      <source pool="pool1" volume="vol" socket="/tmp/foo.sock"/>
       <target dir="/foo"/>
       <binary path="/foo/virtiofsd" xattr="off">
         <cache mode="always"/>

--- a/virtinst/devices/filesystem.py
+++ b/virtinst/devices/filesystem.py
@@ -53,7 +53,7 @@ class DeviceFilesystem(Device):
     source_units = XMLProperty("./source/@units")
     source_pool = XMLProperty("./source/@pool")
     source_volume = XMLProperty("./source/@volume")
-    source_socket = XMLProperty("./source/socket")
+    source_socket = XMLProperty("./source/@socket")
 
     binary_path = XMLProperty("./binary/@path")
     binary_xattr = XMLProperty("./binary/@xattr", is_onoff=True)


### PR DESCRIPTION
When specifying the socket.source option for filesystem devices, like
this:
  --filesystem type=mount,driver.type=virtiofs,source.socket=/xyz.sock,target.dir=tag1

virt-install is writing the xml as:

    <filesystem type="mount">
      <source>
        <socket>/xyz.sock</socket>
      </source>
      <target dir="tag1"/>
      <driver type="virtiofs"/>
    </filesystem>

This produces an error such as:

  ERROR missing source information for device mount_tag1

But the socket should be an attribute of source rather than a child
element. After this patch, the same command results in the following XML
and no error is produced:

    <filesystem type="mount">
      <source socket="/xyz.sock"/>
      <target dir="tag1"/>
      <driver type="virtiofs"/>
    </filesystem>

Resolves: RHEL-1126

Signed-off-by: Jonathon Jongsma <jjongsma@redhat.com>
