### PR TITLE
setup.py: move global args to install args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -242,6 +242,16 @@ class my_egg_info(setuptools.command.install_egg_info.install_egg_info):
 
 
 class my_install(setuptools.command.install.install):
+    setuptools.command.install.install.user_options += [
+        ("no-update-icon-cache", None, "Don't run gtk-update-icon-cache"),
+        ("no-compile-schemas", None, "Don't compile gsettings schemas"),
+    ]
+
+    def initialize_options(self):
+        setuptools.command.install.install.initialize_options(self)
+        self.no_update_icon_cache = None
+        self.no_compile_schemas = None
+
     """
     Error if we weren't 'configure'd with the correct install prefix
     """
@@ -266,12 +276,12 @@ class my_install(setuptools.command.install.install):
     def run(self):
         setuptools.command.install.install.run(self)
 
-        if not self.distribution.no_update_icon_cache:
+        if not self.no_update_icon_cache:
             print("running gtk-update-icon-cache")
             icon_path = os.path.join(self.install_data, "share/icons/hicolor")
             self.spawn(["gtk-update-icon-cache", "-q", "-t", icon_path])
 
-        if not self.distribution.no_compile_schemas:
+        if not self.no_compile_schemas:
             print("compiling gsettings schemas")
             gschema_install = os.path.join(self.install_data,
                 "share/glib-2.0/schemas")
@@ -421,14 +431,8 @@ class CheckPylint(setuptools.Command):
 
 
 class VMMDistribution(setuptools.dist.Distribution):
-    global_options = setuptools.dist.Distribution.global_options + [
-        ("no-update-icon-cache", None, "Don't run gtk-update-icon-cache"),
-        ("no-compile-schemas", None, "Don't compile gsettings schemas"),
-    ]
 
     def __init__(self, *args, **kwargs):
-        self.no_update_icon_cache = False
-        self.no_compile_schemas = False
         setuptools.dist.Distribution.__init__(self, *args, **kwargs)
 
 


### PR DESCRIPTION
Hello,
This PR is part of the current contribution of virt-manager packaging into Yocto `meta-virtualization` layer. This patch is used to have the ability to build and install virt-manager on non GUI system, and so, to avoid building the unneeded dependency in this use case. See the contribution mail submission here: https://lists.yoctoproject.org/g/meta-virtualization/message/8601

Waiting for your review, feel free to ask any questions or remarks.
Regards,
Paul Le Guen de Kerneizon, Savoir-faire Linux