### PR TITLE
virt-xml: make it easier to switch between Spice and VNC graphics

### DIFF
--- a/man/virt-xml.rst
+++ b/man/virt-xml.rst
@@ -71,6 +71,10 @@ XML ACTIONS
     before applying the requested changes. This allows completely rebuilding
     an XML block. See EXAMPLES for some usage.
 
+    It is possible to edit multiple XML blocks but every XML block needs to
+    be paired with it's own ``--edit``. So for example you can edit graphics
+    and video using ``--edit --graphics vnc --edit --video virtio``.
+
     EDIT-OPTIONS examples:
 
     * ``--edit``

--- a/tests/data/cli/compare/virt-xml-change-graphics-and-video.xml
+++ b/tests/data/cli/compare/virt-xml-change-graphics-and-video.xml
@@ -1,0 +1,26 @@
+     <emulator>/usr/bin/qemu-system-x86_64</emulator>
+     <controller type="usb" index="0" model="qemu-xhci" ports="15"/>
+     <controller type="virtio-serial" index="0"/>
+-    <channel type="spicevmc">
+-      <target type="virtio" name="com.redhat.spice.0"/>
+-    </channel>
+-    <graphics type="spice" autoport="yes">
++    <graphics type="vnc" autoport="yes">
+       <listen type="address"/>
+       <image compression="off"/>
+       <gl enable="no"/>
+     </graphics>
+-    <audio id="1" type="spice"/>
+     <video>
+-      <model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
++      <model type="virtio" vram="65536" heads="1" primary="yes"/>
+     </video>
+-    <redirdev bus="usb" type="spicevmc">
+-    </redirdev>
+-    <redirdev bus="usb" type="spicevmc">
+-    </redirdev>
+   </devices>
+ </domain>
+
+Domain 'test-spice' defined successfully.
+Changes will take effect after the domain is fully powered off.

--- a/tests/data/cli/compare/virt-xml-change-spice-to-vnc.xml
+++ b/tests/data/cli/compare/virt-xml-change-spice-to-vnc.xml
@@ -1,0 +1,11 @@
+     <channel type="spicevmc">
+       <target type="virtio" name="com.redhat.spice.0"/>
+     </channel>
+-    <graphics type="spice" autoport="yes">
++    <graphics type="vnc" autoport="yes">
+       <listen type="address"/>
+       <image compression="off"/>
+       <gl enable="no"/>
+
+Domain 'test-spice' defined successfully.
+Changes will take effect after the domain is fully powered off.

--- a/tests/data/cli/compare/virt-xml-change-spice-to-vnc.xml
+++ b/tests/data/cli/compare/virt-xml-change-spice-to-vnc.xml
@@ -1,11 +1,25 @@
-     <channel type="spicevmc">
-       <target type="virtio" name="com.redhat.spice.0"/>
-     </channel>
+     <emulator>/usr/bin/qemu-system-x86_64</emulator>
+     <controller type="usb" index="0" model="qemu-xhci" ports="15"/>
+     <controller type="virtio-serial" index="0"/>
+-    <channel type="spicevmc">
+-      <target type="virtio" name="com.redhat.spice.0"/>
+-    </channel>
 -    <graphics type="spice" autoport="yes">
 +    <graphics type="vnc" autoport="yes">
        <listen type="address"/>
        <image compression="off"/>
        <gl enable="no"/>
+     </graphics>
+-    <audio id="1" type="spice"/>
+     <video>
+       <model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
+     </video>
+-    <redirdev bus="usb" type="spicevmc">
+-    </redirdev>
+-    <redirdev bus="usb" type="spicevmc">
+-    </redirdev>
+   </devices>
+ </domain>
 
 Domain 'test-spice' defined successfully.
 Changes will take effect after the domain is fully powered off.

--- a/tests/data/cli/compare/virt-xml-edit-graphics-spice-gl.xml
+++ b/tests/data/cli/compare/virt-xml-edit-graphics-spice-gl.xml
@@ -1,3 +1,11 @@
+       <vapic state="on"/>
+       <spinlocks state="on" retries="12287"/>
+     </hyperv>
++    <vmport state="off"/>
+   </features>
+   <cpu mode="custom" match="exact">
+     <model fallback="allow">core2duo</model>
+@@
          <device path="/dev/tzz"/>
        </backend>
      </tpm>
@@ -9,6 +17,16 @@
      </graphics>
      <sound model="sb16"/>
      <sound model="es1370"/>
+@@
+     <vsock model="virtio">
+       <cid auto="no" address="5"/>
+     </vsock>
++    <channel type="spicevmc">
++      <target type="virtio" name="com.redhat.spice.0"/>
++    </channel>
+   </devices>
+   <seclabel type="dynamic" model="selinux" relabel="yes"/>
+   <keywrap>
 
 Domain 'test-for-virtxml' defined successfully.
 Changes will take effect after the domain is fully powered off.

--- a/tests/data/cli/compare/virt-xml-multiple-edit.xml
+++ b/tests/data/cli/compare/virt-xml-multiple-edit.xml
@@ -1,0 +1,13 @@
+   <os>
+     <type arch="i686">hvm</type>
+     <boot dev="hd"/>
++    <boot dev="network"/>
+   </os>
+   <clock offset="utc"/>
+   <on_poweroff>destroy</on_poweroff>
+@@
+   <on_crash>destroy</on_crash>
+   <devices>
+   </devices>
++  <cpu mode="host-passthrough"/>
+ </domain>

--- a/tests/data/cli/compare/virt-xml-remove-spice-graphics.xml
+++ b/tests/data/cli/compare/virt-xml-remove-spice-graphics.xml
@@ -1,0 +1,14 @@
+     <channel type="spicevmc">
+       <target type="virtio" name="com.redhat.spice.0"/>
+     </channel>
+-    <graphics type="spice" autoport="yes">
+-      <listen type="address"/>
+-      <image compression="off"/>
+-      <gl enable="no"/>
+-    </graphics>
+     <audio id="1" type="spice"/>
+     <video>
+       <model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
+
+Domain 'test-spice' defined successfully.
+Changes will take effect after the domain is fully powered off.

--- a/tests/data/cli/compare/virt-xml-remove-spice-graphics.xml
+++ b/tests/data/cli/compare/virt-xml-remove-spice-graphics.xml
@@ -1,14 +1,24 @@
-     <channel type="spicevmc">
-       <target type="virtio" name="com.redhat.spice.0"/>
-     </channel>
+     <emulator>/usr/bin/qemu-system-x86_64</emulator>
+     <controller type="usb" index="0" model="qemu-xhci" ports="15"/>
+     <controller type="virtio-serial" index="0"/>
+-    <channel type="spicevmc">
+-      <target type="virtio" name="com.redhat.spice.0"/>
+-    </channel>
 -    <graphics type="spice" autoport="yes">
 -      <listen type="address"/>
 -      <image compression="off"/>
 -      <gl enable="no"/>
 -    </graphics>
-     <audio id="1" type="spice"/>
+-    <audio id="1" type="spice"/>
      <video>
        <model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
+     </video>
+-    <redirdev bus="usb" type="spicevmc">
+-    </redirdev>
+-    <redirdev bus="usb" type="spicevmc">
+-    </redirdev>
+   </devices>
+ </domain>
 
 Domain 'test-spice' defined successfully.
 Changes will take effect after the domain is fully powered off.

--- a/tests/data/testdriver/testsuite.xml
+++ b/tests/data/testdriver/testsuite.xml
@@ -97,6 +97,47 @@
 
 
 <domain type='test'>
+  <name>test-spice</name>
+  <uuid>12345678-1234-FFFF-1234-12345678ABCD</uuid>
+  <memory unit='KiB'>1048576</memory>
+  <currentMemory unit='KiB'>1048576</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state='off'/>
+    <smm state='on'/>
+  </features>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <controller type='usb' index='0' model='qemu-xhci' ports='15'/>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+    </channel>
+    <graphics type='spice' autoport='yes' connected='fail'>
+      <listen type='address'/>
+      <image compression='off'/>
+      <gl enable='no'/>
+    </graphics>
+    <audio id='1' type='spice'/>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'/>
+    <redirdev bus='usb' type='spicevmc'/>
+  </devices>
+</domain>
+
+
+<domain type='test'>
    <name>test-for-virtxml</name>
   <metadata>
     <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1345,7 +1345,9 @@ c.add_invalid("test --cpu host-passthrough", grep="One of --edit, ")  # conflict
 c.add_invalid("test --edit --add-device --disk path=foo", grep="Conflicting options --edit, --add-device")
 c.add_invalid("test --edit 0 --disk path=", grep="Invalid --edit option '0'")
 c.add_invalid("test --edit --hostdev driver_name=vfio", grep='No --hostdev objects found in the XML')
-c.add_invalid("test --edit --cpu host-passthrough --boot hd,network", grep="Only one change operation may be specified")
+c.add_invalid("test --edit --cpu host-passthrough --boot hd,network", grep="Each XML-ACTION requires one --edit option.")
+c.add_invalid("test --edit --cpu host-passthrough --edit", grep="Each XML-ACTION requires one --edit option.")
+c.add_compare("test --print-diff --edit --cpu host-passthrough --edit --boot hd,network", "multiple-edit")
 c.add_invalid("test --edit", grep="No change specified.")
 c.add_invalid("test --edit 2 --cpu host-passthrough", grep="'--edit 2' requested but there's only 1 --cpu object in the XML")
 c.add_invalid("test-for-virtxml --edit 5 --tpm /dev/tpm", grep="'--edit 5' requested but there's only 1 --tpm object in the XML")
@@ -1355,6 +1357,7 @@ c.add_invalid("test-for-virtxml --edit --graphics password=foo,keymap= --update 
 c.add_invalid("--build-xml --memory 10,maxmemory=20", grep="--build-xml not supported for --memory")
 c.add_invalid("test-state-shutoff --edit sparse=no --disk path=blah", grep="Don't know how to match device type 'disk' property 'sparse'")
 c.add_invalid("test --add-device --xml ./@foo=bar", grep="--xml can only be used with --edit")
+c.add_invalid("test --edit --xml ./@foo=bar --edit --video model=virtio", grep="--xml cannot be used with any other XML-ACTION")
 c.add_invalid("test-for-virtxml --edit --boot refresh-machine-type=yes", grep="Don't know how to refresh")
 c.add_compare("test --print-xml --edit --vcpus 7", "print-xml")  # test --print-xml
 c.add_compare("--edit --cpu host-passthrough", "stdin-edit", input_file=(_VIRTXMLDIR + "virtxml-stdin-edit.xml"))  # stdin test

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1478,6 +1478,7 @@ c.add_compare("--remove-device --hostdev mdev_b1ae8bf6_38b0_4c81_9d44_78ce3f5204
 c = vixml.add_category("edit/remove spice graphics", "test-spice --print-diff --define")
 c.add_compare("--edit --graphics type=vnc", "change-spice-to-vnc")
 c.add_compare("--remove-device --graphics type=spice", "remove-spice-graphics")
+c.add_compare("--edit --graphics type=vnc --edit --video model=virtio", "change-graphics-and-video")
 
 c = vixml.add_category("add/rm devices and start", "test-state-shutoff --print-diff --start")
 c.add_invalid("--add-device --pm suspend_to_disk=yes", grep="Cannot use --add-device with --pm")  # --add-device without a device

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1472,6 +1472,10 @@ c.add_compare("--remove-device --memballoon all", "remove-memballoon")
 c.add_compare("--add-device --hostdev mdev_8e37ee90_2b51_45e3_9b25_bf8283c03110", "add-hostdev-mdev")
 c.add_compare("--remove-device --hostdev mdev_b1ae8bf6_38b0_4c81_9d44_78ce3f520496", "remove-hostdev-mdev")
 
+c = vixml.add_category("edit/remove spice graphics", "test-spice --print-diff --define")
+c.add_compare("--edit --graphics type=vnc", "change-spice-to-vnc")
+c.add_compare("--remove-device --graphics type=spice", "remove-spice-graphics")
+
 c = vixml.add_category("add/rm devices and start", "test-state-shutoff --print-diff --start")
 c.add_invalid("--add-device --pm suspend_to_disk=yes", grep="Cannot use --add-device with --pm")  # --add-device without a device
 c.add_invalid("--remove-device --clock utc", grep="Cannot use --remove-device with --clock")  # --remove-device without a dev

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -622,21 +622,11 @@ class vmmDomain(vmmLibvirtObject):
         """
         Remove passed device from the inactive guest XML
         """
-        # If serial and duplicate console are both present, they both need
-        # to be removed at the same time
-        con = None
-        if self.serial_is_console_dup(devobj):
-            con = self.xmlobj.devices.console[0]
-
         xmlobj = self._make_xmlobj_to_define()
         editdev = self._lookup_device_to_define(xmlobj, devobj, False)
         if not editdev:
             return  # pragma: no cover
 
-        if con:
-            rmcon = xmlobj.find_device(con)
-            if rmcon:
-                xmlobj.remove_device(rmcon)
         xmlobj.remove_device(editdev)
 
         self._redefine_xmlobj(xmlobj)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3919,9 +3919,12 @@ class ParserGraphics(VirtCLIParser):
         inst.keymap = val
 
     def set_type_cb(self, inst, val, virtarg):
-        if val == "default":
-            return
-        inst.type = val
+        if self.editing:
+            self.guest.change_graphics(val, inst)
+        else:
+            if val == "default":
+                return
+            inst.type = val
 
     def listens_find_inst_cb(self, *args, **kwargs):
         cliarg = "listens"  # listens[0-9]*

--- a/virtinst/devices/device.py
+++ b/virtinst/devices/device.py
@@ -132,6 +132,7 @@ class Device(XMLBuilder):
             "interface":     ["macaddr", "xmlindex"],
             "input":         ["bus", "type", "xmlindex"],
             "sound":         ["model", "xmlindex"],
+            "audio":         ["type", "id"],
             "video":         ["model", "xmlindex"],
             "watchdog":      ["model", "xmlindex"],
             "hostdev":       ["type", "managed", "xmlindex",

--- a/virtinst/devices/graphics.py
+++ b/virtinst/devices/graphics.py
@@ -39,11 +39,22 @@ class DeviceGraphics(Device):
     TYPE_RDP = "rdp"
     TYPE_SPICE = "spice"
 
-    _XML_PROP_ORDER = ["type", "gl", "_port", "_tlsPort", "autoport", "websocket",
+    _XML_PROP_ORDER = ["_type", "gl", "_port", "_tlsPort", "autoport", "websocket",
                        "keymap", "_listen",
                        "passwd", "display", "xauth"]
 
     keymap = XMLProperty("./@keymap")
+
+    def _set_type(self, val):
+        self._type = val
+        # connected is valid for Spice and VNC, but VNC accepts only 'keep' and
+        # libvirt errors out if there is any other value
+        if val == "vnc" and self.connected != "keep":
+            self.connected = None
+    def _get_type(self):
+        return self._type
+    _type = XMLProperty("./@type")
+    type = property(_get_type, _set_type)
 
     def _set_port(self, val):
         val = _validate_port("Port", val)
@@ -85,7 +96,6 @@ class DeviceGraphics(Device):
     _listen = XMLProperty("./@listen")
     listen = property(_get_listen, _set_listen)
 
-    type = XMLProperty("./@type")
     passwd = XMLProperty("./@passwd")
     passwdValidTo = XMLProperty("./@passwdValidTo")
     socket = XMLProperty("./@socket")

--- a/virtinst/devices/video.py
+++ b/virtinst/devices/video.py
@@ -11,14 +11,24 @@ from ..xmlbuilder import XMLProperty
 class DeviceVideo(Device):
     XML_NAME = "video"
 
-    _XML_PROP_ORDER = ["model", "vram", "heads", "vgamem"]
-    model = XMLProperty("./model/@type")
+    _XML_PROP_ORDER = ["_model", "vram", "heads", "vgamem"]
     vram = XMLProperty("./model/@vram", is_int=True)
     vram64 = XMLProperty("./model/@vram64", is_int=True)
     ram = XMLProperty("./model/@ram", is_int=True)
     heads = XMLProperty("./model/@heads", is_int=True)
     vgamem = XMLProperty("./model/@vgamem", is_int=True)
     accel3d = XMLProperty("./model/acceleration/@accel3d", is_yesno=True)
+
+    def _set_model(self, val):
+        self._model = val
+        if self._model != "qxl":
+            self.ram = None
+            self.vgamem = None
+            self.vram64 = None
+    def _get_model(self):
+        return self._model
+    _model = XMLProperty("./model/@type")
+    model = property(_get_model, _set_model)
 
 
     ##################

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -785,6 +785,13 @@ class Guest(XMLBuilder):
                 self.vcpus = defCPUs
         self.cpu.set_topology_defaults(self.vcpus)
 
+    def change_graphics(self, val, inst):
+        inst.type = val
+        if val == "spice":
+            self._add_spice_devices()
+        else:
+            self._remove_spice_devices(inst)
+
     def set_defaults(self, _guest):
         self.set_capabilities_defaults()
 

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -504,6 +504,7 @@ class Guest(XMLBuilder):
     def remove_device(self, dev):
         self.devices.remove_child(dev)
         self._remove_duplicate_console(dev)
+        self._remove_spice_devices(dev)
 
     devices = XMLChildProperty(_DomainDevices, is_single=True)
 
@@ -1206,3 +1207,26 @@ class Guest(XMLBuilder):
         if condup:
             log.debug("Found duplicate console device:\n%s", condup.get_xml())
             self.devices.remove_child(condup)
+
+    def _remove_spice_audio(self):
+        for audio in self.devices.audio:
+            if audio.type == "spice":
+                self.devices.remove_child(audio)
+
+    def _remove_spice_channels(self):
+        for channel in self.devices.channel:
+            if channel.type == DeviceChannel.TYPE_SPICEVMC:
+                self.devices.remove_child(channel)
+
+    def _remove_spice_usbredir(self):
+        for redirdev in self.devices.redirdev:
+            if redirdev.type == "spicevmc":
+                self.devices.remove_child(redirdev)
+
+    def _remove_spice_devices(self, rmdev):
+        if rmdev.DEVICE_TYPE != "graphics" or self.has_spice():
+            return
+
+        self._remove_spice_audio()
+        self._remove_spice_channels()
+        self._remove_spice_usbredir()

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -500,8 +500,11 @@ class Guest(XMLBuilder):
 
     def add_device(self, dev):
         self.devices.add_child(dev)
+
     def remove_device(self, dev):
         self.devices.remove_child(dev)
+        self._remove_duplicate_console(dev)
+
     devices = XMLChildProperty(_DomainDevices, is_single=True)
 
     def find_device(self, origdev):
@@ -1197,3 +1200,9 @@ class Guest(XMLBuilder):
         self._add_spice_channels()
         self._add_spice_sound()
         self._add_spice_usbredir()
+
+    def _remove_duplicate_console(self, dev):
+        condup = DeviceConsole.get_console_duplicate(self, dev)
+        if condup:
+            log.debug("Found duplicate console device:\n%s", condup.get_xml())
+            self.devices.remove_child(condup)

--- a/virtinst/virtxml.py
+++ b/virtinst/virtxml.py
@@ -10,7 +10,6 @@ import libvirt
 
 from . import cli
 from .cli import fail, fail_conflicting, print_stdout, print_stderr
-from .devices import DeviceConsole
 from .guest import Guest
 from .logger import log
 from . import xmlutil
@@ -188,13 +187,6 @@ def action_remove_device(guest, options, parserclass):
     devs = _find_objects_to_edit(guest, "remove-device",
         getattr(options, parserclass.cli_arg_name)[-1], parserclass)
     devs = xmlutil.listify(devs)
-
-    # Check for console duplicate devices
-    for dev in devs[:]:
-        condup = DeviceConsole.get_console_duplicate(guest, dev)
-        if condup:
-            log.debug("Found duplicate console device:\n%s", condup.get_xml())
-            devs.append(condup)
 
     for dev in devs:
         guest.remove_device(dev)


### PR DESCRIPTION
When switching between Spice and VNC graphics it is usually not enough to just change the graphics type. For example spice uses additional devices to offer full functionality and they are added by virt-install/virt-manager whenever spice graphics is used.

With these changes using:

  `virt-xml {VM} --edit --graphics vnc`

will remove all Spice only related devices as well. Previously this invocation would fail as libvirt doesn't allow having other Spice devices without Spice graphics.

There might be use cases where video device needs to be changed together with graphics or in general any other devices changed together. To make that happen we now allow multiple edits at the same time. So for example:

  `virt-xml {VM} --edit --graphics vnc --edit --video virtio`

will now work.