### PR TITLE
Use GtkFileChooserNative

### DIFF
--- a/virtManager/error.py
+++ b/virtManager/error.py
@@ -234,7 +234,7 @@ class vmmErrorDialog(vmmGObject):
 
     def browse_local(self, dialog_name, start_folder=None,
                      _type=None, dialog_type=None,
-                     choose_button=None, default_name=None,
+                     choose_label=None, default_name=None,
                      confirm_overwrite=False):
         """
         Helper function for launching a filechooser
@@ -246,19 +246,11 @@ class vmmErrorDialog(vmmGObject):
         """
         if dialog_type is None:
             dialog_type = Gtk.FileChooserAction.OPEN
-        if choose_button is None:
-            choose_button = Gtk.STOCK_OPEN
 
-        buttons = (Gtk.STOCK_CANCEL,
-                   Gtk.ResponseType.CANCEL,
-                   choose_button,
-                   Gtk.ResponseType.ACCEPT)
-
-        fcdialog = Gtk.FileChooserDialog(title=dialog_name,
-                                    parent=self.get_parent(),
-                                    action=dialog_type,
-                                    buttons=buttons)
-        fcdialog.set_default_response(Gtk.ResponseType.ACCEPT)
+        fcdialog = Gtk.FileChooserNative.new(title=dialog_name,
+                                             parent=self.get_parent(),
+                                             action=dialog_type,
+                                             accept_label=choose_label)
 
         if default_name:
             fcdialog.set_current_name(default_name)

--- a/virtManager/vmwindow.py
+++ b/virtManager/vmwindow.py
@@ -558,7 +558,7 @@ class vmmVMWindow(vmmGObjectUI):
             _("Save Virtual Machine Screenshot"),
             _type=("png", _("PNG files")),
             dialog_type=Gtk.FileChooserAction.SAVE,
-            choose_button=Gtk.STOCK_SAVE,
+            choose_label=_("_Save"),
             start_folder=start_folder,
             default_name=default,
             confirm_overwrite=True)


### PR DESCRIPTION
Use [GtkFileChooserNative](https://docs.gtk.org/gtk3/class.FileChooserNative.html) instead of [GtkFileChooserDialog](https://docs.gtk.org/gtk3/class.FileChooserDialog.html) to integrate better with the platform (e.g. use the portal implementation when run with GTK_USE_PORTAL=1, resulting in the KDE Frameworks implementation being used when
xdg-desktop-portal-kde is in use). Quoting from the [GtkFileChooserDialog doc](https://docs.gtk.org/gtk3/class.FileChooserDialog.html):

> If you want to integrate well with the platform you should use the
> GtkFileChooserNative API, which will use a platform-specific dialog if
> available and fall back to GtkFileChooserDialog otherwise.

Also replace the use of [GTK_STOCK_CANCEL](https://docs.gtk.org/gtk3/const.STOCK_CANCEL.html) and [GTK_STOCK_OPEN](https://docs.gtk.org/gtk3/const.STOCK_OPEN.html) which were deprecated in GTK 3.10 with the corresponding labels as suggested in their doc.

Fixes #315