### PR TITLE
fix isolated pep 517 build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "docutils"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ import subprocess
 
 import setuptools
 import setuptools.command.install
-import setuptools.command.install_egg_info
 try:
     # Use the setuptools build command with setuptools >= 62.4.0
     import setuptools.command.build
@@ -231,14 +230,6 @@ from %(pkgname)s import %(filename)s
 
         self.run_command("build_i18n")
         super().run()
-
-
-class my_egg_info(setuptools.command.install_egg_info.install_egg_info):
-    """
-    Disable egg_info installation, seems pointless for a non-library
-    """
-    def run(self):
-        pass
 
 
 class my_install(setuptools.command.install.install):
@@ -537,7 +528,6 @@ setuptools.setup(
         'build_i18n': my_build_i18n,
 
         'install': my_install,
-        'install_egg_info': my_egg_info,
 
         'configure': configure,
 

--- a/virt-manager.spec
+++ b/virt-manager.spec
@@ -132,6 +132,7 @@ machine).
 
 %{_datadir}/%{name}/ui/*.ui
 %{_datadir}/%{name}/virtManager
+%{python3_sitelib}/virt_manager-*.egg-info/
 
 %{_datadir}/%{name}/icons
 %{_datadir}/icons/hicolor/*/apps/*


### PR DESCRIPTION
This allows users to install via a standard isolated [PEP 517](https://peps.python.org/pep-0517/) build

- Adds `pyproject.toml` to explicitly define build requirements (i.e. `setuptools` and also `docutils`, since setup.py needs `rst2man`)
- Removes custom (disabled) `egg_info` command (`setuptools` needs it to [extract build requirements](https://github.com/pypa/setuptools/blob/1ed759173983656734c3606e9c97a348895e5e0c/setuptools/build_meta.py#L291))
- ~Don't attempt to run `gtk-update-icon-cache` / `glib-compile-schemas` unless found~

Before:

```console
$ pip install git+https://github.com/virt-manager/virt-manager
# ...
  × Building wheel for virt-manager (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      # ...
      Didn't find rst2man or rst2man.py
```

After:

```console
$ pip install git+https://github.com/branchvincent/virt-manager@pep517
# ...
Successfully installed virt-manager-4.1.0
```
