### PR TITLE
Improve riscv64 support

### DIFF
--- a/tests/data/capabilities/qemu-riscv64-domcaps.xml
+++ b/tests/data/capabilities/qemu-riscv64-domcaps.xml
@@ -1,17 +1,16 @@
 <domainCapabilities>
-
-  <!-- Generated on Fedora 29 with QEMU ~4.0.0 and libvirt ~5.3.0 -->
-
   <path>/usr/bin/qemu-system-riscv64</path>
   <domain>qemu</domain>
-  <machine>spike_v1.10</machine>
+  <machine>virt</machine>
   <arch>riscv64</arch>
-  <vcpu max='1'/>
+  <vcpu max='512'/>
   <iothreads supported='yes'/>
   <os supported='yes'>
+    <enum name='firmware'>
+      <value>efi</value>
+    </enum>
     <loader supported='yes'>
-      <value>/usr/share/OVMF/OVMF_CODE.fd</value>
-      <value>/usr/share/OVMF/OVMF_CODE.secboot.fd</value>
+      <value>/usr/share/edk2/riscv/RISCV_VIRT_CODE.qcow2</value>
       <enum name='type'>
         <value>rom</value>
         <value>pflash</value>
@@ -20,13 +19,39 @@
         <value>yes</value>
         <value>no</value>
       </enum>
+      <enum name='secure'>
+        <value>no</value>
+      </enum>
     </loader>
   </os>
   <cpu>
     <mode name='host-passthrough' supported='no'/>
+    <mode name='maximum' supported='yes'>
+      <enum name='maximumMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
     <mode name='host-model' supported='no'/>
-    <mode name='custom' supported='no'/>
+    <mode name='custom' supported='yes'>
+      <model usable='unknown' vendor='unknown'>rv64</model>
+      <model usable='unknown' vendor='unknown'>sifive-e51</model>
+      <model usable='unknown' vendor='unknown'>any</model>
+      <model usable='unknown' vendor='unknown'>x-rv128</model>
+      <model usable='unknown' vendor='unknown'>shakti-c</model>
+      <model usable='unknown' vendor='unknown'>max</model>
+      <model usable='unknown' vendor='unknown'>thead-c906</model>
+      <model usable='unknown' vendor='unknown'>sifive-u54</model>
+      <model usable='unknown' vendor='unknown'>veyron-v1</model>
+    </mode>
   </cpu>
+  <memoryBacking supported='yes'>
+    <enum name='sourceType'>
+      <value>file</value>
+      <value>anonymous</value>
+      <value>memfd</value>
+    </enum>
+  </memoryBacking>
   <devices>
     <disk supported='yes'>
       <enum name='diskDevice'>
@@ -53,14 +78,18 @@
         <value>sdl</value>
         <value>vnc</value>
         <value>spice</value>
+        <value>egl-headless</value>
+        <value>dbus</value>
       </enum>
     </graphics>
     <video supported='yes'>
       <enum name='modelType'>
         <value>vga</value>
         <value>cirrus</value>
-        <value>vmvga</value>
         <value>virtio</value>
+        <value>none</value>
+        <value>bochs</value>
+        <value>ramfb</value>
       </enum>
     </video>
     <hostdev supported='yes'>
@@ -81,11 +110,72 @@
       <enum name='capsType'/>
       <enum name='pciBackend'/>
     </hostdev>
+    <rng supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>random</value>
+        <value>egd</value>
+        <value>builtin</value>
+      </enum>
+    </rng>
+    <filesystem supported='yes'>
+      <enum name='driverType'>
+        <value>path</value>
+        <value>handle</value>
+        <value>virtiofs</value>
+      </enum>
+    </filesystem>
+    <tpm supported='yes'>
+      <enum name='model'>
+        <value>tpm-tis</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>passthrough</value>
+        <value>emulator</value>
+        <value>external</value>
+      </enum>
+      <enum name='backendVersion'>
+        <value>1.2</value>
+        <value>2.0</value>
+      </enum>
+    </tpm>
+    <redirdev supported='yes'>
+      <enum name='bus'>
+        <value>usb</value>
+      </enum>
+    </redirdev>
+    <channel supported='yes'>
+      <enum name='type'>
+        <value>pty</value>
+        <value>unix</value>
+        <value>spicevmc</value>
+      </enum>
+    </channel>
+    <crypto supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+      </enum>
+      <enum name='type'>
+        <value>qemu</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>builtin</value>
+        <value>lkcf</value>
+      </enum>
+    </crypto>
   </devices>
   <features>
     <gic supported='no'/>
-    <vmcoreinfo supported='no'/>
+    <vmcoreinfo supported='yes'/>
     <genid supported='no'/>
+    <backingStoreInput supported='yes'/>
+    <backup supported='yes'/>
+    <async-teardown supported='yes'/>
     <sev supported='no'/>
+    <sgx supported='no'/>
   </features>
 </domainCapabilities>

--- a/tests/data/capabilities/qemu-riscv64.xml
+++ b/tests/data/capabilities/qemu-riscv64.xml
@@ -1,7 +1,5 @@
 <capabilities>
 
-  <!-- Generated on Fedora 29 with QEMU ~4.0.0 and libvirt ~5.3.0 -->
-
   <host>
     <uuid>2b763ba8-82a1-44dd-a197-9132a8d520a2</uuid>
     <cpu>
@@ -86,8 +84,8 @@
     <secmodel>
       <model>dac</model>
       <doi>0</doi>
-      <baselabel type='kvm'>+0:+0</baselabel>
-      <baselabel type='qemu'>+0:+0</baselabel>
+      <baselabel type='kvm'>+107:+107</baselabel>
+      <baselabel type='qemu'>+107:+107</baselabel>
     </secmodel>
   </host>
 
@@ -96,17 +94,19 @@
     <arch name='riscv64'>
       <wordsize>64</wordsize>
       <emulator>/usr/bin/qemu-system-riscv64</emulator>
-      <machine maxCpus='1'>spike_v1.10</machine>
-      <machine maxCpus='8'>virt</machine>
-      <machine maxCpus='1'>sifive_u</machine>
+      <machine maxCpus='512'>virt</machine>
+      <machine maxCpus='8'>spike</machine>
+      <machine maxCpus='5'>microchip-icicle-kit</machine>
+      <machine maxCpus='5'>sifive_u</machine>
+      <machine maxCpus='1'>shakti_c</machine>
       <machine maxCpus='1'>sifive_e</machine>
-      <machine maxCpus='1'>spike_v1.9.1</machine>
       <domain type='qemu'/>
     </arch>
     <features>
       <cpuselection/>
       <deviceboot/>
       <disksnapshot default='on' toggle='no'/>
+      <externalSnapshot/>
     </features>
   </guest>
 

--- a/tests/data/cli/compare/virt-install-aarch64-cloud-init.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-cloud-init.xml
@@ -59,6 +59,7 @@
       <target dev="sda" bus="scsi"/>
       <readonly/>
     </disk>
+    <controller type="scsi" model="virtio-scsi"/>
   </devices>
   <sysinfo type="smbios">
     <system>
@@ -129,5 +130,6 @@
       <target dev="sda" bus="scsi"/>
       <readonly/>
     </disk>
+    <controller type="scsi" model="virtio-scsi"/>
   </devices>
 </domain>

--- a/tests/data/cli/compare/virt-install-riscv64-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-cdrom.xml
@@ -1,0 +1,124 @@
+<domain type="qemu">
+  <name>fedora29-riscv64</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/29"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="riscv64" machine="virt">hvm</type>
+    <boot dev="cdrom"/>
+    <boot dev="hd"/>
+  </os>
+  <clock offset="utc"/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-riscv64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/var/lib/libvirt/images/fedora29-riscv64.qcow2"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <disk type="file" device="cdrom">
+      <driver name="qemu"/>
+      <source file="TESTSUITE_SCRUBBED/tests/data/fakemedia/fake-f26-netinst.iso"/>
+      <target dev="sda" bus="scsi"/>
+      <readonly/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="scsi" model="virtio-scsi"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+  </devices>
+  <on_reboot>destroy</on_reboot>
+</domain>
+<domain type="qemu">
+  <name>fedora29-riscv64</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/29"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="riscv64" machine="virt">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <clock offset="utc"/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-riscv64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/var/lib/libvirt/images/fedora29-riscv64.qcow2"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <disk type="file" device="cdrom">
+      <target dev="sda" bus="scsi"/>
+      <readonly/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="scsi" model="virtio-scsi"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-riscv64-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-cdrom.xml
@@ -9,7 +9,7 @@
   <memory>65536</memory>
   <currentMemory>65536</currentMemory>
   <vcpu>2</vcpu>
-  <os>
+  <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="cdrom"/>
     <boot dev="hd"/>
@@ -55,6 +55,9 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <tpm>
+      <backend type="emulator"/>
+    </tpm>
     <memballoon model="virtio"/>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>
@@ -73,7 +76,7 @@
   <memory>65536</memory>
   <currentMemory>65536</currentMemory>
   <vcpu>2</vcpu>
-  <os>
+  <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
@@ -116,6 +119,9 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <tpm>
+      <backend type="emulator"/>
+    </tpm>
     <memballoon model="virtio"/>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>

--- a/tests/data/cli/compare/virt-install-riscv64-cloud-init.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-cloud-init.xml
@@ -9,7 +9,7 @@
   <memory>65536</memory>
   <currentMemory>65536</currentMemory>
   <vcpu>2</vcpu>
-  <os>
+  <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
   </os>
   <clock offset="utc"/>
@@ -70,7 +70,7 @@
   <memory>65536</memory>
   <currentMemory>65536</currentMemory>
   <vcpu>2</vcpu>
-  <os>
+  <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
@@ -108,6 +108,9 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <tpm>
+      <backend type="emulator"/>
+    </tpm>
     <memballoon model="virtio"/>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>

--- a/tests/data/cli/compare/virt-install-riscv64-cloud-init.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-cloud-init.xml
@@ -56,6 +56,7 @@
       <target dev="sda" bus="scsi"/>
       <readonly/>
     </disk>
+    <controller type="scsi" model="virtio-scsi"/>
   </devices>
   <on_reboot>destroy</on_reboot>
 </domain>
@@ -119,5 +120,6 @@
       <target dev="sda" bus="scsi"/>
       <readonly/>
     </disk>
+    <controller type="scsi" model="virtio-scsi"/>
   </devices>
 </domain>

--- a/tests/data/cli/compare/virt-install-riscv64-cloud-init.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-cloud-init.xml
@@ -1,0 +1,120 @@
+<domain type="qemu">
+  <name>fedora29-riscv64</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/29"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="riscv64" machine="virt">hvm</type>
+  </os>
+  <clock offset="utc"/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-riscv64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2"/>
+      <source file="/pool-dir/testvol1.img"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+    <disk type="file" device="cdrom">
+      <driver name="qemu" type="raw"/>
+      <source file="/VIRTINST-TESTSUITE/cloudinit.iso"/>
+      <target dev="sda" bus="scsi"/>
+      <readonly/>
+    </disk>
+  </devices>
+  <on_reboot>destroy</on_reboot>
+</domain>
+<domain type="qemu">
+  <name>fedora29-riscv64</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/29"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="riscv64" machine="virt">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <clock offset="utc"/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-riscv64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2"/>
+      <source file="/pool-dir/testvol1.img"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+    <disk type="file" device="cdrom">
+      <target dev="sda" bus="scsi"/>
+      <readonly/>
+    </disk>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-riscv64-graphics.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-graphics.xml
@@ -9,7 +9,7 @@
   <memory>65536</memory>
   <currentMemory>65536</currentMemory>
   <vcpu>2</vcpu>
-  <os>
+  <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
@@ -52,6 +52,9 @@
     </channel>
     <input type="tablet" bus="usb"/>
     <input type="keyboard" bus="usb"/>
+    <tpm>
+      <backend type="emulator"/>
+    </tpm>
     <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
       <image compression="off"/>
     </graphics>

--- a/tests/data/cli/compare/virt-install-riscv64-graphics.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-graphics.xml
@@ -47,9 +47,15 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
     <input type="tablet" bus="usb"/>
     <input type="keyboard" bus="usb"/>
-    <graphics type="vnc" port="-1"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
     <video>
       <model type="virtio"/>
     </video>

--- a/tests/data/cli/compare/virt-install-riscv64-headless.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-headless.xml
@@ -9,7 +9,7 @@
   <memory>65536</memory>
   <currentMemory>65536</currentMemory>
   <vcpu>2</vcpu>
-  <os>
+  <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
@@ -47,6 +47,9 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <tpm>
+      <backend type="emulator"/>
+    </tpm>
     <memballoon model="virtio"/>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>

--- a/tests/data/cli/compare/virt-install-riscv64-kernel-boot.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-kernel-boot.xml
@@ -1,0 +1,57 @@
+<domain type="qemu">
+  <name>fedora29-riscv64</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/29"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="riscv64" machine="virt">hvm</type>
+    <kernel>/kernel.img</kernel>
+    <initrd>/initrd.img</initrd>
+    <cmdline>root=/dev/vda2</cmdline>
+  </os>
+  <clock offset="utc"/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-riscv64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2"/>
+      <source file="/pool-dir/testvol1.img"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-riscv64-unattended.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-unattended.xml
@@ -9,7 +9,7 @@
   <memory>65536</memory>
   <currentMemory>65536</currentMemory>
   <vcpu>2</vcpu>
-  <os>
+  <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
   </os>
   <clock offset="utc"/>
@@ -46,6 +46,9 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <tpm>
+      <backend type="emulator"/>
+    </tpm>
     <memballoon model="virtio"/>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>
@@ -70,7 +73,7 @@
   <memory>65536</memory>
   <currentMemory>65536</currentMemory>
   <vcpu>2</vcpu>
-  <os>
+  <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
@@ -108,6 +111,9 @@
       <source mode="bind"/>
       <target type="virtio" name="org.qemu.guest_agent.0"/>
     </channel>
+    <tpm>
+      <backend type="emulator"/>
+    </tpm>
     <memballoon model="virtio"/>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>

--- a/tests/data/cli/compare/virt-install-riscv64-unattended.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-unattended.xml
@@ -59,6 +59,7 @@
       <target dev="sda" bus="scsi"/>
       <readonly/>
     </disk>
+    <controller type="scsi" model="virtio-scsi"/>
   </devices>
   <on_reboot>destroy</on_reboot>
 </domain>
@@ -122,5 +123,6 @@
       <target dev="sda" bus="scsi"/>
       <readonly/>
     </disk>
+    <controller type="scsi" model="virtio-scsi"/>
   </devices>
 </domain>

--- a/tests/data/cli/compare/virt-install-riscv64-unattended.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-unattended.xml
@@ -1,0 +1,120 @@
+<domain type="qemu">
+  <name>fedora29-riscv64</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/29"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="riscv64" machine="virt">hvm</type>
+  </os>
+  <clock offset="utc"/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-riscv64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/var/lib/libvirt/images/fedora29-riscv64.qcow2"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+    <disk type="file" device="cdrom">
+      <driver name="qemu" type="raw"/>
+      <source file="/VIRTINST-TESTSUITE/unattended.iso"/>
+      <target dev="sda" bus="scsi"/>
+      <readonly/>
+    </disk>
+  </devices>
+  <on_reboot>destroy</on_reboot>
+</domain>
+<domain type="qemu">
+  <name>fedora29-riscv64</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/29"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="riscv64" machine="virt">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <clock offset="utc"/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-riscv64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/var/lib/libvirt/images/fedora29-riscv64.qcow2"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+    <disk type="file" device="cdrom">
+      <target dev="sda" bus="scsi"/>
+      <readonly/>
+    </disk>
+  </devices>
+</domain>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1168,6 +1168,10 @@ c.add_compare("--connect %(URI-KVM-S390X)s --arch s390x --nographics --import --
 
 c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --import --disk %(EXISTIMG1)s --network default --graphics none", "riscv64-headless")
 c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --import --disk %(EXISTIMG1)s --network default --graphics spice", "riscv64-graphics")
+c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --import --disk %(EXISTIMG1)s --boot kernel=/kernel.img,initrd=/initrd.img,cmdline='root=/dev/vda2'", "riscv64-kernel-boot")
+c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --import --disk %(EXISTIMG1)s --cloud-init", "riscv64-cloud-init")
+c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --cdrom %(ISO-F26-NETINST)s", "riscv64-cdrom")
+c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --unattended", "riscv64-unattended")
 
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1166,8 +1166,8 @@ c.add_compare("--connect %(URI-KVM-S390X)s --arch s390x --nographics --import --
 # riscv tests #
 ###############
 
-c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --os-variant fedora29 --import --disk %(EXISTIMG1)s --network default --graphics none", "riscv64-headless")
-c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --os-variant fedora29 --import --disk %(EXISTIMG1)s --network default --graphics vnc", "riscv64-graphics")
+c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --import --disk %(EXISTIMG1)s --network default --graphics none", "riscv64-headless")
+c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --import --disk %(EXISTIMG1)s --network default --graphics vnc", "riscv64-graphics")
 
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1167,7 +1167,7 @@ c.add_compare("--connect %(URI-KVM-S390X)s --arch s390x --nographics --import --
 ###############
 
 c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --import --disk %(EXISTIMG1)s --network default --graphics none", "riscv64-headless")
-c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --import --disk %(EXISTIMG1)s --network default --graphics vnc", "riscv64-graphics")
+c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --osinfo fedora29 --import --disk %(EXISTIMG1)s --network default --graphics spice", "riscv64-graphics")
 
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1166,8 +1166,8 @@ c.add_compare("--connect %(URI-KVM-S390X)s --arch s390x --nographics --import --
 # riscv tests #
 ###############
 
-c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --os-variant fedora29 --import --disk %(EXISTIMG1)s --network default --graphics none", "riscv64-headless", precompare_check="5.3.0")
-c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --os-variant fedora29 --import --disk %(EXISTIMG1)s --network default --graphics vnc", "riscv64-graphics", precompare_check="5.3.0", )
+c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --os-variant fedora29 --import --disk %(EXISTIMG1)s --network default --graphics none", "riscv64-headless")
+c.add_compare("--connect %(URI-QEMU-RISCV64)s --arch riscv64 --os-variant fedora29 --import --disk %(EXISTIMG1)s --network default --graphics vnc", "riscv64-graphics")
 
 
 

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -816,7 +816,7 @@ class Guest(XMLBuilder):
         for dev in self.devices.get_all():
             dev.set_defaults(self)
 
-        self._add_virtioscsi_controller()
+        self.add_virtioscsi_controller()
         self._add_q35_pcie_controllers()
         self._add_spice_devices()
 
@@ -1091,7 +1091,7 @@ class Guest(XMLBuilder):
             dev.model = "virtio"
             self.add_device(dev)
 
-    def _add_virtioscsi_controller(self):
+    def add_virtioscsi_controller(self):
         if not self.can_default_virtioscsi():
             return
         if not any([d for d in self.devices.disk if d.bus == "scsi"]):

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -542,7 +542,9 @@ class Guest(XMLBuilder):
             # and doesn't break QEMU internal snapshots
             prefer_efi = self.osinfo.requires_firmware_efi(self.os.arch)
         else:
-            prefer_efi = self.os.is_arm_machvirt() or self.conn.is_bhyve()
+            prefer_efi = (self.os.is_arm_machvirt() or
+                          self.os.is_riscv_virt() or
+                          self.conn.is_bhyve())
 
         log.debug("Prefer EFI => %s", prefer_efi)
         return prefer_efi

--- a/virtinst/install/installer.py
+++ b/virtinst/install/installer.py
@@ -187,6 +187,13 @@ class Installer(object):
         self._unattended_install_cdrom_device = dev.target
         guest.add_device(dev)
 
+        # The CDROM we just added might be a SCSI one. If that's the case,
+        # libvirt will automatically add the necessary controller for us, but
+        # depending on the architecture its choice of model might not be
+        # usable by the guest OS. Try to add a virtio-scsi controller, if
+        # supported, for the best chance of the CDROM actually being picked up
+        guest.add_virtioscsi_controller()
+
         if self.conn.in_testsuite():
             # Hack to set just the XML path differently for the test suite.
             # Setting this via regular 'path' will error that it doesn't exist


### PR DESCRIPTION
Make most things work out of the box when importing existing and upcoming disk images. As a side-effect, make importing aarch64 cloud images smoother too.