### PR TITLE
tests: skip mdev tests for libvirt older than 10.4.0

### DIFF
--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -850,25 +850,6 @@
         <char>/dev/pty7</char>
       </source>
     </hostdev>
-    <hostdev mode="subsystem" type="mdev" managed="no" model="vfio-ccw">
-      <address type="ccw" cssid="0xfe" ssid="0x1" devno="0x0008"/>
-      <source>
-        <address uuid="8e37ee90-2b51-45e3-9b25-bf8283c03110"/>
-      </source>
-    </hostdev>
-    <hostdev mode="subsystem" type="mdev" managed="no" model="vfio-ap">
-      <source>
-        <address uuid="11f92c9d-b0b0-4016-b306-a8071277f8b9"/>
-      </source>
-    </hostdev>
-    <hostdev mode="subsystem" type="mdev" managed="yes" model="vfio-pci" display="off" ramfb="off">
-      <address type="pci" domain="0" bus="1" slot="1" function="0">
-        <zpci uid="0x0001" fid="0x00000001"/>
-      </address>
-      <source>
-        <address uuid="4b20d080-1b54-4048-85b3-a6a62d165c01"/>
-      </source>
-    </hostdev>
     <redirdev bus="usb" type="spicevmc"/>
     <redirdev bus="usb" type="tcp">
       <source host="localhost" service="4000"/>

--- a/tests/data/cli/compare/virt-install-mdev-devices.xml
+++ b/tests/data/cli/compare/virt-install-mdev-devices.xml
@@ -1,0 +1,101 @@
+<domain type="kvm">
+  <name>fedora</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/unknown"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/var/lib/libvirt/images/fedora.qcow2"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="virtio"/>
+    </video>
+    <hostdev mode="subsystem" type="mdev" managed="no" model="vfio-ccw">
+      <address type="ccw" cssid="0xfe" ssid="0x1" devno="0x0008"/>
+      <source>
+        <address uuid="8e37ee90-2b51-45e3-9b25-bf8283c03110"/>
+      </source>
+    </hostdev>
+    <hostdev mode="subsystem" type="mdev" managed="no" model="vfio-ap">
+      <source>
+        <address uuid="11f92c9d-b0b0-4016-b306-a8071277f8b9"/>
+      </source>
+    </hostdev>
+    <hostdev mode="subsystem" type="mdev" managed="yes" model="vfio-pci" display="off" ramfb="off">
+      <address type="pci" domain="0" bus="1" slot="1" function="0">
+        <zpci uid="0x0001" fid="0x00000001"/>
+      </address>
+      <source>
+        <address uuid="4b20d080-1b54-4048-85b3-a6a62d165c01"/>
+      </source>
+    </hostdev>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+  </devices>
+</domain>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -704,9 +704,6 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --hostdev wlan0,type=net
 --hostdev /dev/vdz,type=storage
 --hostdev /dev/pty7,type=misc
---hostdev mdev_8e37ee90_2b51_45e3_9b25_bf8283c03110,address.type=ccw,address.cssid=0xfe,address.ssid=0x1,address.devno=0x0008
---hostdev mdev_11f92c9d_b0b0_4016_b306_a8071277f8b9
---hostdev mdev_4b20d080_1b54_4048_85b3_a6a62d165c01,address.type=pci,address.domain=0x0000,address.bus=0x01,address.slot=0x01,address.function=0x0,address.zpci.uid=0x0001,address.zpci.fid=0x00000001
 
 
 --filesystem /source,/target,alias.name=testfsalias,driver.ats=on,driver.iommu=off,driver.packed=on,driver.page_per_vq=off
@@ -804,6 +801,13 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 
 
 """, "many-devices", predefine_check="8.4.0")
+
+# Need to extract from the many-devices test as it was fixed in libvirt 10.4.0
+c.add_compare("""
+--hostdev mdev_8e37ee90_2b51_45e3_9b25_bf8283c03110,address.type=ccw,address.cssid=0xfe,address.ssid=0x1,address.devno=0x0008
+--hostdev mdev_11f92c9d_b0b0_4016_b306_a8071277f8b9
+--hostdev mdev_4b20d080_1b54_4048_85b3_a6a62d165c01,address.type=pci,address.domain=0x0000,address.bus=0x01,address.slot=0x01,address.function=0x0,address.zpci.uid=0x0001,address.zpci.fid=0x00000001
+""", "mdev-devices", prerun_check="10.4.0")
 
 
 # Specific XML test cases #1
@@ -1473,7 +1477,7 @@ c.add_compare("--remove-device --disk /dev/null", "remove-disk-path")
 c.add_compare("--remove-device --video all", "remove-video-all")
 c.add_compare("--remove-device --host-device 0x04b3:0x4485", "remove-hostdev-name")
 c.add_compare("--remove-device --memballoon all", "remove-memballoon")
-c.add_compare("--add-device --hostdev mdev_8e37ee90_2b51_45e3_9b25_bf8283c03110", "add-hostdev-mdev")
+c.add_compare("--add-device --hostdev mdev_8e37ee90_2b51_45e3_9b25_bf8283c03110", "add-hostdev-mdev", prerun_check="10.4.0")
 c.add_compare("--remove-device --hostdev mdev_b1ae8bf6_38b0_4c81_9d44_78ce3f520496", "remove-hostdev-mdev")
 
 c = vixml.add_category("add/rm devices and start", "test-state-shutoff --print-diff --start")
@@ -1485,7 +1489,7 @@ c.add_compare("--define --add-device --host-device usb_device_4b3_4485_noserial"
 c.add_compare("--add-device --disk %(EXISTIMG1)s,bus=virtio,target=vdf", "add-disk-basic-start")
 c.add_compare("--add-device --disk %(NEWIMG1)s,size=.01", "add-disk-create-storage-start")
 c.add_compare("--remove-device --disk /dev/null", "remove-disk-path-start")
-c.add_compare("--add-device --hostdev mdev_8e37ee90_2b51_45e3_9b25_bf8283c03110", "add-hostdev-mdev-start")
+c.add_compare("--add-device --hostdev mdev_8e37ee90_2b51_45e3_9b25_bf8283c03110", "add-hostdev-mdev-start", prerun_check="10.4.0")
 
 c = vixml.add_category("add/rm devices OS KVM", "--connect %(URI-KVM-X86)s test --print-diff --define")
 c.add_compare("--add-device --disk %(EXISTIMG1)s", "kvm-add-disk-os-from-xml")  # Guest OS (none) from XML

--- a/tests/test_nodedev.py
+++ b/tests/test_nodedev.py
@@ -44,6 +44,14 @@ def _testNode2DeviceCompare(conn, nodename, devfile, nodedev=None):
     utils.diff_compare(dev.get_xml() + "\n", devfile)
 
 
+def check_version(conn, version):
+    if conn.support._check_version(version):
+        return
+
+    msg = f"Skipping check due to version < {version}"
+    raise pytest.skip(msg)
+
+
 def testFunkyChars():
     # Ensure parsing doesn't fail
     conn = utils.URIs.open_testdriver_cached()
@@ -129,6 +137,7 @@ def testDRMDevice():
 
 def testDASDMdev():
     conn = utils.URIs.open_testdriver_cached()
+    check_version(conn, "10.4.0")
     devname = "mdev_8e37ee90_2b51_45e3_9b25_bf8283c03110"
     dev = _nodeDevFromName(conn, devname)
     assert dev.name == devname
@@ -139,6 +148,7 @@ def testDASDMdev():
 
 def testAPQNMdev():
     conn = utils.URIs.open_testdriver_cached()
+    check_version(conn, "10.4.0")
     devname = "mdev_11f92c9d_b0b0_4016_b306_a8071277f8b9"
     dev = _nodeDevFromName(conn, devname)
     assert dev.name == devname
@@ -149,6 +159,7 @@ def testAPQNMdev():
 
 def testPCIMdev():
     conn = utils.URIs.open_testdriver_cached()
+    check_version(conn, "10.4.0")
     devname = "mdev_4b20d080_1b54_4048_85b3_a6a62d165c01"
     dev = _nodeDevFromName(conn, devname)
     assert dev.name == devname
@@ -158,10 +169,9 @@ def testPCIMdev():
     assert dev.get_mdev_uuid() == "4b20d080-1b54-4048-85b3-a6a62d165c01"
 
 
-# libvirt <7.3.0 doesn't support <uuid> in the mdev node device xml
-@pytest.mark.skipif(libvirt.getVersion() < 7003000, reason="libvirt version doesn't support new mdev format")
 def testPCIMdevNewFormat():
     conn = utils.URIs.open_testdriver_cached()
+    check_version(conn, "10.4.0")
     devname = "mdev_35ceae7f_eea5_4f28_b7f3_7b12a3e62d3c_0000_06_00_0"
     dev = _nodeDevFromName(conn, devname)
     assert dev.name == devname


### PR DESCRIPTION
The test driver was broken for some time and our mdev tests were failing on most libvirt versions. Recently this was fixed in libvirt 10.4.0 so skip these tests unless we have new enough libvirt.

This requires extracting some mdev devices from many-devices test case.