### PR TITLE
cli: Deprecate -cpu host

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -414,7 +414,7 @@ Some examples:
 ``--cpu core2duo,+x2apic,disable=vmx``
     Expose the core2duo CPU model, force enable x2apic, but do not expose vmx
 
-``--cpu host``
+``--cpu host-model``
     Expose the host CPUs configuration to the guest. This enables the guest to
     take advantage of many of the host CPUs features (better performance), but
     may cause issues if migrating the guest to a host without an identical CPU.

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2338,6 +2338,7 @@ class ParserCPU(VirtCLIParser):
 
     def set_model_cb(self, inst, val, virtarg):
         if val == "host":
+            log.warning(_("CPU model=host is deprecated, use model=host-model"))
             val = inst.SPECIAL_MODE_HOST_MODEL
         if val == "none":
             val = inst.SPECIAL_MODE_CLEAR

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -690,7 +690,7 @@ def vcpu_cli_options(grp, backcompat=True, editexample=False):
                "--vcpus 5,maxvcpus=10,cpuset=1-4,6,8\n"
                "--vcpus sockets=2,cores=4,threads=2"))
 
-    extramsg = "--cpu host"
+    extramsg = "--cpu host-model"
     if editexample:
         extramsg = "--cpu host-model,clearxml=yes"
     grp.add_argument("--cpu", action="append",


### PR DESCRIPTION
While the shorthand saves a tiny bit of typing, it is confusing to people coming from QEMU, where `-cpu host` is the equivalent of our `--cpu host-passthrough`. It's better to stick with the unambiguous names used by libvirt.

Besides, the GUI already uses "host-model" throughout, so advocating its use in the CLI too increases the internal consistency.

https://issues.redhat.com/browse/RHEL-40003