### PR TITLE
Add support for missing Hyper-V features and enable most of them by default

### DIFF
--- a/tests/data/capabilities/kvm-x86_64-domcaps-latest.xml
+++ b/tests/data/capabilities/kvm-x86_64-domcaps-latest.xml
@@ -1,19 +1,21 @@
 <domainCapabilities>
   <path>/usr/bin/qemu-system-x86_64</path>
   <domain>kvm</domain>
-  <machine>pc-q35-7.0</machine>
+  <machine>pc-q35-9.0</machine>
   <arch>x86_64</arch>
-  <vcpu max='288'/>
+  <vcpu max='4096'/>
   <iothreads supported='yes'/>
   <os supported='yes'>
     <enum name='firmware'>
       <value>efi</value>
     </enum>
     <loader supported='yes'>
+      <value>/usr/share/edk2/ovmf/OVMF_CODE_4M.secboot.qcow2</value>
       <value>/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd</value>
+      <value>/usr/share/edk2/ovmf/OVMF_CODE_4M.qcow2</value>
       <value>/usr/share/edk2/ovmf/OVMF_CODE.fd</value>
       <value>/usr/share/edk2/ovmf/OVMF.amdsev.fd</value>
-      <value>/usr/share/edk2/ovmf/OVMF.inteltdx.fd</value>
+      <value>/usr/share/edk2/ovmf/OVMF.inteltdx.secboot.fd</value>
       <enum name='type'>
         <value>rom</value>
         <value>pflash</value>
@@ -194,7 +196,10 @@
         <value>scsi</value>
       </enum>
       <enum name='capsType'/>
-      <enum name='pciBackend'/>
+      <enum name='pciBackend'>
+        <value>default</value>
+        <value>vfio</value>
+      </enum>
     </hostdev>
     <rng supported='yes'>
       <enum name='model'>
@@ -223,6 +228,7 @@
       <enum name='backendModel'>
         <value>passthrough</value>
         <value>emulator</value>
+        <value>external</value>
       </enum>
       <enum name='backendVersion'>
         <value>1.2</value>
@@ -241,6 +247,18 @@
         <value>spicevmc</value>
       </enum>
     </channel>
+    <crypto supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+      </enum>
+      <enum name='type'>
+        <value>qemu</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>builtin</value>
+        <value>lkcf</value>
+      </enum>
+    </crypto>
   </devices>
   <features>
     <gic supported='no'/>
@@ -248,9 +266,28 @@
     <genid supported='yes'/>
     <backingStoreInput supported='yes'/>
     <backup supported='yes'/>
+    <async-teardown supported='yes'/>
     <sev supported='no'/>
     <sgx supported='no'/>
+    <hyperv supported='yes'>
+      <enum name='features'>
+        <value>relaxed</value>
+        <value>vapic</value>
+        <value>spinlocks</value>
+        <value>vpindex</value>
+        <value>runtime</value>
+        <value>synic</value>
+        <value>stimer</value>
+        <value>reset</value>
+        <value>vendor_id</value>
+        <value>frequencies</value>
+        <value>reenlightenment</value>
+        <value>tlbflush</value>
+        <value>ipi</value>
+        <value>evmcs</value>
+        <value>avic</value>
+      </enum>
+    </hyperv>
   </features>
 </domainCapabilities>
-
 

--- a/tests/data/cli/compare/virt-install-hyperv_disable_vpindex.xml
+++ b/tests/data/cli/compare/virt-install-hyperv_disable_vpindex.xml
@@ -1,0 +1,83 @@
+<domain type="kvm">
+  <name>win11</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://microsoft.com/win/11"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>4</vcpu>
+  <os firmware="efi">
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <hyperv>
+      <vpindex state="off"/>
+      <relaxed state="on"/>
+      <vapic state="on"/>
+      <spinlocks state="on" retries="8191"/>
+      <runtime state="on"/>
+      <frequencies state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
+    </hyperv>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="localtime">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+    <timer name="hypervclock" present="yes"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000e"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <tpm model="tpm-crb">
+      <backend type="emulator"/>
+    </tpm>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="qxl"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-hyperv_no_domcaps.xml
+++ b/tests/data/cli/compare/virt-install-hyperv_no_domcaps.xml
@@ -1,0 +1,72 @@
+<domain type="kvm">
+  <name>win11</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://microsoft.com/win/11"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>4</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="custom" match="exact">
+    <model>Skylake-Client-noTSX-IBRS</model>
+  </cpu>
+  <clock offset="localtime">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+    <timer name="hypervclock" present="yes"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000e"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="qxl"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-kvm-win10.xml
+++ b/tests/data/cli/compare/virt-install-kvm-win10.xml
@@ -21,6 +21,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
     <vmport state="off"/>
   </features>
@@ -96,6 +105,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
     <vmport state="off"/>
   </features>

--- a/tests/data/cli/compare/virt-install-kvm-win2k3-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-kvm-win2k3-cdrom.xml
@@ -21,6 +21,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
     <vmport state="off"/>
   </features>
@@ -93,6 +102,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
     <vmport state="off"/>
   </features>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -137,6 +137,7 @@
       <relaxed state="off"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="5678"/>
+      <vpindex state="on"/>
       <synic state="on"/>
       <reset state="on"/>
     </hyperv>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -140,6 +140,7 @@
       <vpindex state="on"/>
       <runtime state="on"/>
       <synic state="on"/>
+      <stimer state="on"/>
       <reset state="on"/>
     </hyperv>
     <vmport state="off"/>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -145,6 +145,7 @@
       </stimer>
       <reset state="on"/>
       <frequencies state="on"/>
+      <reenlightenment state="on"/>
     </hyperv>
     <vmport state="off"/>
     <kvm>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -147,6 +147,7 @@
       <frequencies state="on"/>
       <reenlightenment state="on"/>
       <tlbflush state="on"/>
+      <ipi state="on"/>
     </hyperv>
     <vmport state="off"/>
     <kvm>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -149,6 +149,7 @@
       <tlbflush state="on"/>
       <ipi state="on"/>
       <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
     <vmport state="off"/>
     <kvm>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -138,6 +138,7 @@
       <vapic state="on"/>
       <spinlocks state="on" retries="5678"/>
       <vpindex state="on"/>
+      <runtime state="on"/>
       <synic state="on"/>
       <reset state="on"/>
     </hyperv>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -134,11 +134,11 @@
     <viridian/>
     <pmu state="off"/>
     <hyperv>
-      <reset state="on"/>
-      <vapic state="on"/>
       <relaxed state="off"/>
+      <vapic state="on"/>
       <spinlocks state="on" retries="5678"/>
       <synic state="on"/>
+      <reset state="on"/>
     </hyperv>
     <vmport state="off"/>
     <kvm>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -146,6 +146,7 @@
       <reset state="on"/>
       <frequencies state="on"/>
       <reenlightenment state="on"/>
+      <tlbflush state="on"/>
     </hyperv>
     <vmport state="off"/>
     <kvm>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -140,7 +140,9 @@
       <vpindex state="on"/>
       <runtime state="on"/>
       <synic state="on"/>
-      <stimer state="on"/>
+      <stimer state="on">
+        <direct state="on"/>
+      </stimer>
       <reset state="on"/>
     </hyperv>
     <vmport state="off"/>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -148,6 +148,7 @@
       <reenlightenment state="on"/>
       <tlbflush state="on"/>
       <ipi state="on"/>
+      <evmcs state="on"/>
     </hyperv>
     <vmport state="off"/>
     <kvm>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -144,6 +144,7 @@
         <direct state="on"/>
       </stimer>
       <reset state="on"/>
+      <frequencies state="on"/>
     </hyperv>
     <vmport state="off"/>
     <kvm>

--- a/tests/data/cli/compare/virt-install-os-detect-fail-fallback.xml
+++ b/tests/data/cli/compare/virt-install-os-detect-fail-fallback.xml
@@ -15,11 +15,6 @@
   </os>
   <features>
     <pae/>
-    <hyperv>
-      <relaxed state="on"/>
-      <vapic state="on"/>
-      <spinlocks state="on" retries="8191"/>
-    </hyperv>
   </features>
   <clock offset="localtime"/>
   <pm>
@@ -63,11 +58,6 @@
   </os>
   <features>
     <pae/>
-    <hyperv>
-      <relaxed state="on"/>
-      <vapic state="on"/>
-      <spinlocks state="on" retries="8191"/>
-    </hyperv>
   </features>
   <clock offset="localtime"/>
   <pm>

--- a/tests/data/cli/compare/virt-install-osinfo-win7-unattended.xml
+++ b/tests/data/cli/compare/virt-install-osinfo-win7-unattended.xml
@@ -20,6 +20,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
   </features>
   <cpu mode="host-passthrough"/>
@@ -111,6 +120,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
   </features>
   <cpu mode="host-passthrough"/>

--- a/tests/data/cli/compare/virt-install-unattended-remote-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-unattended-remote-cdrom.xml
@@ -15,11 +15,6 @@
   </os>
   <features>
     <pae/>
-    <hyperv>
-      <relaxed state="on"/>
-      <vapic state="on"/>
-      <spinlocks state="on" retries="8191"/>
-    </hyperv>
   </features>
   <clock offset="localtime"/>
   <pm>
@@ -73,11 +68,6 @@
   </os>
   <features>
     <pae/>
-    <hyperv>
-      <relaxed state="on"/>
-      <vapic state="on"/>
-      <spinlocks state="on" retries="8191"/>
-    </hyperv>
   </features>
   <clock offset="localtime"/>
   <pm>

--- a/tests/data/cli/compare/virt-install-w2k3-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-w2k3-cdrom.xml
@@ -16,11 +16,6 @@
   </os>
   <features>
     <pae/>
-    <hyperv>
-      <relaxed state="on"/>
-      <vapic state="on"/>
-      <spinlocks state="on" retries="8191"/>
-    </hyperv>
   </features>
   <cpu>
     <topology sockets="1" dies="1" cores="4" threads="1"/>
@@ -67,11 +62,6 @@
   </os>
   <features>
     <pae/>
-    <hyperv>
-      <relaxed state="on"/>
-      <vapic state="on"/>
-      <spinlocks state="on" retries="8191"/>
-    </hyperv>
   </features>
   <cpu>
     <topology sockets="1" dies="1" cores="4" threads="1"/>

--- a/tests/data/cli/compare/virt-install-win11.xml
+++ b/tests/data/cli/compare/virt-install-win11.xml
@@ -21,6 +21,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
     <vmport state="off"/>
   </features>
@@ -111,6 +120,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
     <vmport state="off"/>
   </features>

--- a/tests/data/cli/compare/virt-install-win7-uefi.xml
+++ b/tests/data/cli/compare/virt-install-win7-uefi.xml
@@ -23,6 +23,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
     <vmport state="off"/>
   </features>
@@ -124,6 +133,15 @@
       <relaxed state="on"/>
       <vapic state="on"/>
       <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
     </hyperv>
     <vmport state="off"/>
   </features>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -575,7 +575,8 @@ hyperv.stimer.direct.state=on,\
 hyperv.reset.state=off,hyperv_reset=on,\
 hyperv.frequencies.state=on,\
 hyperv.reenlightenment.state=on,\
-hyperv.tlbflush.state=on
+hyperv.tlbflush.state=on,\
+hyperv.ipi.state=on
 
 
 --clock offset=utc,hpet_present=no,rtc_tickpolicy=merge,timer2.name=hypervclock,timer3.name=pit,timer1.present=yes,timer3.tickpolicy=delay,timer2.present=no,timer4.name=rtc,timer5.name=tsc,timer6.name=tsc,timer4.track=wall,timer5.frequency=10,timer6.mode=emulate,timer7.name=rtc,timer7.tickpolicy=catchup,timer7.catchup.threshold=123,timer7.catchup.slew=120,timer7.catchup.limit=10000,rtc_present=no,pit_present=yes,pit_tickpolicy=catchup,tsc_present=no,platform_present=no,hypervclock_present=no,platform_tickpolicy=foo,hpet_tickpolicy=bar,tsc_tickpolicy=wibble,kvmclock_tickpolicy=wobble,hypervclock_tickpolicy=woo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -562,7 +562,13 @@ memorytune0.vcpus=0-3,memorytune0.node0.id=0,memorytune0.node0.bandwidth=60
 --metadata title=my-title,description=my-description,uuid=00000000-1111-2222-3333-444444444444,genid=e9392370-2917-565e-692b-d057f46512d6,genid_enable=yes
 
 
---features apic.eoi=off,hap=on,hyperv.synic.state=on,hyperv.reset.state=off,hyperv.spinlocks.state=on,hyperv.spinlocks.retries=5678,pae=on,pmu.state=on,pvspinlock.state=off,smm.state=off,viridian=on,vmcoreinfo.state=on,vmport.state=off,kvm.hidden.state=on,hyperv.vapic.state=off,hyperv.relaxed.state=off,gic.version=host,kvm.hint-dedicated.state=on,kvm.poll-control.state=on,ioapic.driver=qemu,acpi=off,eoi=on,privnet=on,hyperv_synic=on,hyperv_reset=on,hyperv_spinlocks=on,hyperv_spinlocks_retries=5678,vmport=off,pmu=off,vmcoreinfo=on,kvm_hidden=off,hyperv_vapic=on,smm=off
+--features apic.eoi=off,hap=on,pae=on,pmu.state=on,pvspinlock.state=off,smm.state=off,viridian=on,vmcoreinfo.state=on,vmport.state=off,kvm.hidden.state=on,gic.version=host,kvm.hint-dedicated.state=on,kvm.poll-control.state=on,ioapic.driver=qemu,acpi=off,eoi=on,privnet=on,vmport=off,pmu=off,vmcoreinfo=on,kvm_hidden=off,smm=off,\
+hyperv.relaxed.state=off,\
+hyperv.vapic.state=off,hyperv_vapic=on,\
+hyperv.spinlocks.state=on,hyperv_spinlocks=on,\
+hyperv.spinlocks.retries=5678,hyperv_spinlocks_retries=5678,\
+hyperv.synic.state=on,hyperv_synic=on,\
+hyperv.reset.state=off,hyperv_reset=on
 
 
 --clock offset=utc,hpet_present=no,rtc_tickpolicy=merge,timer2.name=hypervclock,timer3.name=pit,timer1.present=yes,timer3.tickpolicy=delay,timer2.present=no,timer4.name=rtc,timer5.name=tsc,timer6.name=tsc,timer4.track=wall,timer5.frequency=10,timer6.mode=emulate,timer7.name=rtc,timer7.tickpolicy=catchup,timer7.catchup.threshold=123,timer7.catchup.slew=120,timer7.catchup.limit=10000,rtc_present=no,pit_present=yes,pit_tickpolicy=catchup,tsc_present=no,platform_present=no,hypervclock_present=no,platform_tickpolicy=foo,hpet_tickpolicy=bar,tsc_tickpolicy=wibble,kvmclock_tickpolicy=wobble,hypervclock_tickpolicy=woo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -568,6 +568,7 @@ hyperv.vapic.state=off,hyperv_vapic=on,\
 hyperv.spinlocks.state=on,hyperv_spinlocks=on,\
 hyperv.spinlocks.retries=5678,hyperv_spinlocks_retries=5678,\
 hyperv.vpindex.state=on,\
+hyperv.runtime.state=on,\
 hyperv.synic.state=on,hyperv_synic=on,\
 hyperv.reset.state=off,hyperv_reset=on
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -574,7 +574,8 @@ hyperv.stimer.state=on,\
 hyperv.stimer.direct.state=on,\
 hyperv.reset.state=off,hyperv_reset=on,\
 hyperv.frequencies.state=on,\
-hyperv.reenlightenment.state=on
+hyperv.reenlightenment.state=on,\
+hyperv.tlbflush.state=on
 
 
 --clock offset=utc,hpet_present=no,rtc_tickpolicy=merge,timer2.name=hypervclock,timer3.name=pit,timer1.present=yes,timer3.tickpolicy=delay,timer2.present=no,timer4.name=rtc,timer5.name=tsc,timer6.name=tsc,timer4.track=wall,timer5.frequency=10,timer6.mode=emulate,timer7.name=rtc,timer7.tickpolicy=catchup,timer7.catchup.threshold=123,timer7.catchup.slew=120,timer7.catchup.limit=10000,rtc_present=no,pit_present=yes,pit_tickpolicy=catchup,tsc_present=no,platform_present=no,hypervclock_present=no,platform_tickpolicy=foo,hpet_tickpolicy=bar,tsc_tickpolicy=wibble,kvmclock_tickpolicy=wobble,hypervclock_tickpolicy=woo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,6 +72,7 @@ TEST_DATA = {
     'URI-TEST-FULL': utils.URIs.test_full,
     'URI-TEST-REMOTE': utils.URIs.test_remote,
     'URI-KVM-X86': utils.URIs.kvm_x86,
+    'URI-KVM-X86-NODOMCAPS': utils.URIs.kvm_x86_nodomcaps,
     'URI-KVM-ARMV7L': utils.URIs.kvm_armv7l,
     'URI-KVM-AARCH64': utils.URIs.kvm_aarch64,
     'URI-KVM-LOONGARCH64': utils.URIs.kvm_loongarch64,
@@ -1355,6 +1356,10 @@ c.add_valid("--pxe", grep="User stopped the VM", env={"VIRTINST_TESTSUITE_HACK_D
 c.add_valid("--connect %(URI-KVM-X86)s --install fedora28 --cloud-init", grep="Password for first root login")  # make sure we print the root login password
 c.add_invalid("--pxe --autoconsole badval", grep="Unknown autoconsole type 'badval'")
 c.add_invalid("--pxe --autoconsole text --wait -1", grep="exceeded specified time limit")  # hits a specific code path where we skip console waitpid
+
+c = vinst.add_category("hyperv", "--disk none --osinfo win11 --import")
+c.add_compare("--connect %(URI-KVM-X86)s --features hyperv.vpindex.state=off", "hyperv_disable_vpindex")  # disable feature that is required by others to test they are not enabled by default
+c.add_compare("--connect %(URI-KVM-X86-NODOMCAPS)s", "hyperv_no_domcaps")  # don't use domain capabilities to enable only some features by version check
 
 
 ##################

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -577,7 +577,8 @@ hyperv.frequencies.state=on,\
 hyperv.reenlightenment.state=on,\
 hyperv.tlbflush.state=on,\
 hyperv.ipi.state=on,\
-hyperv.evmcs.state=on
+hyperv.evmcs.state=on,\
+hyperv.avic.state=on
 
 
 --clock offset=utc,hpet_present=no,rtc_tickpolicy=merge,timer2.name=hypervclock,timer3.name=pit,timer1.present=yes,timer3.tickpolicy=delay,timer2.present=no,timer4.name=rtc,timer5.name=tsc,timer6.name=tsc,timer4.track=wall,timer5.frequency=10,timer6.mode=emulate,timer7.name=rtc,timer7.tickpolicy=catchup,timer7.catchup.threshold=123,timer7.catchup.slew=120,timer7.catchup.limit=10000,rtc_present=no,pit_present=yes,pit_tickpolicy=catchup,tsc_present=no,platform_present=no,hypervclock_present=no,platform_tickpolicy=foo,hpet_tickpolicy=bar,tsc_tickpolicy=wibble,kvmclock_tickpolicy=wobble,hypervclock_tickpolicy=woo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -573,7 +573,8 @@ hyperv.synic.state=on,hyperv_synic=on,\
 hyperv.stimer.state=on,\
 hyperv.stimer.direct.state=on,\
 hyperv.reset.state=off,hyperv_reset=on,\
-hyperv.frequencies.state=on
+hyperv.frequencies.state=on,\
+hyperv.reenlightenment.state=on
 
 
 --clock offset=utc,hpet_present=no,rtc_tickpolicy=merge,timer2.name=hypervclock,timer3.name=pit,timer1.present=yes,timer3.tickpolicy=delay,timer2.present=no,timer4.name=rtc,timer5.name=tsc,timer6.name=tsc,timer4.track=wall,timer5.frequency=10,timer6.mode=emulate,timer7.name=rtc,timer7.tickpolicy=catchup,timer7.catchup.threshold=123,timer7.catchup.slew=120,timer7.catchup.limit=10000,rtc_present=no,pit_present=yes,pit_tickpolicy=catchup,tsc_present=no,platform_present=no,hypervclock_present=no,platform_tickpolicy=foo,hpet_tickpolicy=bar,tsc_tickpolicy=wibble,kvmclock_tickpolicy=wobble,hypervclock_tickpolicy=woo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -576,7 +576,8 @@ hyperv.reset.state=off,hyperv_reset=on,\
 hyperv.frequencies.state=on,\
 hyperv.reenlightenment.state=on,\
 hyperv.tlbflush.state=on,\
-hyperv.ipi.state=on
+hyperv.ipi.state=on,\
+hyperv.evmcs.state=on
 
 
 --clock offset=utc,hpet_present=no,rtc_tickpolicy=merge,timer2.name=hypervclock,timer3.name=pit,timer1.present=yes,timer3.tickpolicy=delay,timer2.present=no,timer4.name=rtc,timer5.name=tsc,timer6.name=tsc,timer4.track=wall,timer5.frequency=10,timer6.mode=emulate,timer7.name=rtc,timer7.tickpolicy=catchup,timer7.catchup.threshold=123,timer7.catchup.slew=120,timer7.catchup.limit=10000,rtc_present=no,pit_present=yes,pit_tickpolicy=catchup,tsc_present=no,platform_present=no,hypervclock_present=no,platform_tickpolicy=foo,hpet_tickpolicy=bar,tsc_tickpolicy=wibble,kvmclock_tickpolicy=wobble,hypervclock_tickpolicy=woo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -572,7 +572,8 @@ hyperv.runtime.state=on,\
 hyperv.synic.state=on,hyperv_synic=on,\
 hyperv.stimer.state=on,\
 hyperv.stimer.direct.state=on,\
-hyperv.reset.state=off,hyperv_reset=on
+hyperv.reset.state=off,hyperv_reset=on,\
+hyperv.frequencies.state=on
 
 
 --clock offset=utc,hpet_present=no,rtc_tickpolicy=merge,timer2.name=hypervclock,timer3.name=pit,timer1.present=yes,timer3.tickpolicy=delay,timer2.present=no,timer4.name=rtc,timer5.name=tsc,timer6.name=tsc,timer4.track=wall,timer5.frequency=10,timer6.mode=emulate,timer7.name=rtc,timer7.tickpolicy=catchup,timer7.catchup.threshold=123,timer7.catchup.slew=120,timer7.catchup.limit=10000,rtc_present=no,pit_present=yes,pit_tickpolicy=catchup,tsc_present=no,platform_present=no,hypervclock_present=no,platform_tickpolicy=foo,hpet_tickpolicy=bar,tsc_tickpolicy=wibble,kvmclock_tickpolicy=wobble,hypervclock_tickpolicy=woo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -571,6 +571,7 @@ hyperv.vpindex.state=on,\
 hyperv.runtime.state=on,\
 hyperv.synic.state=on,hyperv_synic=on,\
 hyperv.stimer.state=on,\
+hyperv.stimer.direct.state=on,\
 hyperv.reset.state=off,hyperv_reset=on
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -570,6 +570,7 @@ hyperv.spinlocks.retries=5678,hyperv_spinlocks_retries=5678,\
 hyperv.vpindex.state=on,\
 hyperv.runtime.state=on,\
 hyperv.synic.state=on,hyperv_synic=on,\
+hyperv.stimer.state=on,\
 hyperv.reset.state=off,hyperv_reset=on
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -567,6 +567,7 @@ hyperv.relaxed.state=off,\
 hyperv.vapic.state=off,hyperv_vapic=on,\
 hyperv.spinlocks.state=on,hyperv_spinlocks=on,\
 hyperv.spinlocks.retries=5678,hyperv_spinlocks_retries=5678,\
+hyperv.vpindex.state=on,\
 hyperv.synic.state=on,hyperv_synic=on,\
 hyperv.reset.state=off,hyperv_reset=on
 

--- a/virtinst/capabilities.py
+++ b/virtinst/capabilities.py
@@ -20,6 +20,7 @@ class _CapsCPU(XMLBuilder):
     XML_NAME = "cpu"
     arch = XMLProperty("./arch")
     model = XMLProperty("./model")
+    vendor = XMLProperty("./vendor")
 
 
 ######################################

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3014,6 +3014,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.runtime.state", "hyperv_runtime", is_onoff=True)
         cls.add_arg("hyperv.synic.state", "hyperv_synic", is_onoff=True)
         cls.add_arg("hyperv.stimer.state", "hyperv_stimer", is_onoff=True)
+        cls.add_arg("hyperv.stimer.direct.state", "hyperv_stimer_direct", is_onoff=True)
         cls.add_arg("hyperv.reset.state", "hyperv_reset", is_onoff=True)
 
         cls.add_arg("vmport.state", "vmport", is_onoff=True)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3013,6 +3013,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.vpindex.state", "hyperv_vpindex", is_onoff=True)
         cls.add_arg("hyperv.runtime.state", "hyperv_runtime", is_onoff=True)
         cls.add_arg("hyperv.synic.state", "hyperv_synic", is_onoff=True)
+        cls.add_arg("hyperv.stimer.state", "hyperv_stimer", is_onoff=True)
         cls.add_arg("hyperv.reset.state", "hyperv_reset", is_onoff=True)
 
         cls.add_arg("vmport.state", "vmport", is_onoff=True)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3011,6 +3011,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.spinlocks.state", "hyperv_spinlocks", is_onoff=True)
         cls.add_arg("hyperv.spinlocks.retries", "hyperv_spinlocks_retries")
         cls.add_arg("hyperv.vpindex.state", "hyperv_vpindex", is_onoff=True)
+        cls.add_arg("hyperv.runtime.state", "hyperv_runtime", is_onoff=True)
         cls.add_arg("hyperv.synic.state", "hyperv_synic", is_onoff=True)
         cls.add_arg("hyperv.reset.state", "hyperv_reset", is_onoff=True)
 

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3018,6 +3018,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.reset.state", "hyperv_reset", is_onoff=True)
         cls.add_arg("hyperv.frequencies.state", "hyperv_frequencies", is_onoff=True)
         cls.add_arg("hyperv.reenlightenment.state", "hyperv_reenlightenment", is_onoff=True)
+        cls.add_arg("hyperv.tlbflush.state", "hyperv_tlbflush", is_onoff=True)
 
         cls.add_arg("vmport.state", "vmport", is_onoff=True)
         cls.add_arg("kvm.hidden.state", "kvm_hidden", is_onoff=True)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3021,6 +3021,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.tlbflush.state", "hyperv_tlbflush", is_onoff=True)
         cls.add_arg("hyperv.ipi.state", "hyperv_ipi", is_onoff=True)
         cls.add_arg("hyperv.evmcs.state", "hyperv_evmcs", is_onoff=True)
+        cls.add_arg("hyperv.avic.state", "hyperv_avic", is_onoff=True)
 
         cls.add_arg("vmport.state", "vmport", is_onoff=True)
         cls.add_arg("kvm.hidden.state", "kvm_hidden", is_onoff=True)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3010,6 +3010,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.vapic.state", "hyperv_vapic", is_onoff=True)
         cls.add_arg("hyperv.spinlocks.state", "hyperv_spinlocks", is_onoff=True)
         cls.add_arg("hyperv.spinlocks.retries", "hyperv_spinlocks_retries")
+        cls.add_arg("hyperv.vpindex.state", "hyperv_vpindex", is_onoff=True)
         cls.add_arg("hyperv.synic.state", "hyperv_synic", is_onoff=True)
         cls.add_arg("hyperv.reset.state", "hyperv_reset", is_onoff=True)
 

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3019,6 +3019,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.frequencies.state", "hyperv_frequencies", is_onoff=True)
         cls.add_arg("hyperv.reenlightenment.state", "hyperv_reenlightenment", is_onoff=True)
         cls.add_arg("hyperv.tlbflush.state", "hyperv_tlbflush", is_onoff=True)
+        cls.add_arg("hyperv.ipi.state", "hyperv_ipi", is_onoff=True)
 
         cls.add_arg("vmport.state", "vmport", is_onoff=True)
         cls.add_arg("kvm.hidden.state", "kvm_hidden", is_onoff=True)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3016,6 +3016,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.stimer.state", "hyperv_stimer", is_onoff=True)
         cls.add_arg("hyperv.stimer.direct.state", "hyperv_stimer_direct", is_onoff=True)
         cls.add_arg("hyperv.reset.state", "hyperv_reset", is_onoff=True)
+        cls.add_arg("hyperv.frequencies.state", "hyperv_frequencies", is_onoff=True)
 
         cls.add_arg("vmport.state", "vmport", is_onoff=True)
         cls.add_arg("kvm.hidden.state", "kvm_hidden", is_onoff=True)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3020,6 +3020,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.reenlightenment.state", "hyperv_reenlightenment", is_onoff=True)
         cls.add_arg("hyperv.tlbflush.state", "hyperv_tlbflush", is_onoff=True)
         cls.add_arg("hyperv.ipi.state", "hyperv_ipi", is_onoff=True)
+        cls.add_arg("hyperv.evmcs.state", "hyperv_evmcs", is_onoff=True)
 
         cls.add_arg("vmport.state", "vmport", is_onoff=True)
         cls.add_arg("kvm.hidden.state", "kvm_hidden", is_onoff=True)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3017,6 +3017,7 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("hyperv.stimer.direct.state", "hyperv_stimer_direct", is_onoff=True)
         cls.add_arg("hyperv.reset.state", "hyperv_reset", is_onoff=True)
         cls.add_arg("hyperv.frequencies.state", "hyperv_frequencies", is_onoff=True)
+        cls.add_arg("hyperv.reenlightenment.state", "hyperv_reenlightenment", is_onoff=True)
 
         cls.add_arg("vmport.state", "vmport", is_onoff=True)
         cls.add_arg("kvm.hidden.state", "kvm_hidden", is_onoff=True)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2985,12 +2985,12 @@ class ParserFeatures(VirtCLIParser):
         "gic.version": "gic_version",
         "smm.state": "smm",
         "vmcoreinfo.state": "vmcoreinfo",
-        "hyperv.reset.state": "hyperv_reset",
-        "hyperv.vapic.state": "hyperv_vapic",
         "hyperv.relaxed.state": "hyperv_relaxed",
+        "hyperv.vapic.state": "hyperv_vapic",
         "hyperv.spinlocks.state": "hyperv_spinlocks",
         "hyperv.spinlocks.retries": "hyperv_spinlocks_retries",
         "hyperv.synic.state": "hyperv_synic",
+        "hyperv.reset.state": "hyperv_reset",
     }
 
     @classmethod
@@ -3006,12 +3006,12 @@ class ParserFeatures(VirtCLIParser):
         cls.add_arg("apic.eoi", "eoi", is_onoff=True)
         cls.add_arg("pmu.state", "pmu", is_onoff=True)
 
-        cls.add_arg("hyperv.reset.state", "hyperv_reset", is_onoff=True)
-        cls.add_arg("hyperv.vapic.state", "hyperv_vapic", is_onoff=True)
         cls.add_arg("hyperv.relaxed.state", "hyperv_relaxed", is_onoff=True)
+        cls.add_arg("hyperv.vapic.state", "hyperv_vapic", is_onoff=True)
         cls.add_arg("hyperv.spinlocks.state", "hyperv_spinlocks", is_onoff=True)
         cls.add_arg("hyperv.spinlocks.retries", "hyperv_spinlocks_retries")
         cls.add_arg("hyperv.synic.state", "hyperv_synic", is_onoff=True)
+        cls.add_arg("hyperv.reset.state", "hyperv_reset", is_onoff=True)
 
         cls.add_arg("vmport.state", "vmport", is_onoff=True)
         cls.add_arg("kvm.hidden.state", "kvm_hidden", is_onoff=True)

--- a/virtinst/domain/clock.py
+++ b/virtinst/domain/clock.py
@@ -27,6 +27,12 @@ class DomainClock(XMLBuilder):
     offset = XMLProperty("./@offset")
     timers = XMLChildProperty(_ClockTimer)
 
+    def has_hyperv_timer(self):
+        for timer in self.timers:
+            if timer.name == "hypervclock":
+                return True
+
+        return False
 
     ##################
     # Default config #

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -31,6 +31,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_spinlocks = XMLProperty("./hyperv/spinlocks/@state", is_onoff=True)
     hyperv_spinlocks_retries = XMLProperty("./hyperv/spinlocks/@retries",
                                            is_int=True)
+    hyperv_vpindex = XMLProperty("./hyperv/vpindex/@state", is_onoff=True)
     hyperv_synic = XMLProperty("./hyperv/synic/@state", is_onoff=True)
     hyperv_reset = XMLProperty("./hyperv/reset/@state", is_onoff=True)
 

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -42,6 +42,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_tlbflush = XMLProperty("./hyperv/tlbflush/@state", is_onoff=True)
     hyperv_ipi = XMLProperty("./hyperv/ipi/@state", is_onoff=True)
     hyperv_evmcs = XMLProperty("./hyperv/evmcs/@state", is_onoff=True)
+    hyperv_avic = XMLProperty("./hyperv/avic/@state", is_onoff=True)
 
     vmport = XMLProperty("./vmport/@state", is_onoff=True)
     kvm_hidden = XMLProperty("./kvm/hidden/@state", is_onoff=True)

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -38,6 +38,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_stimer_direct = XMLProperty("./hyperv/stimer/direct/@state", is_onoff=True)
     hyperv_reset = XMLProperty("./hyperv/reset/@state", is_onoff=True)
     hyperv_frequencies = XMLProperty("./hyperv/frequencies/@state", is_onoff=True)
+    hyperv_reenlightenment = XMLProperty("./hyperv/reenlightenment/@state", is_onoff=True)
 
     vmport = XMLProperty("./vmport/@state", is_onoff=True)
     kvm_hidden = XMLProperty("./kvm/hidden/@state", is_onoff=True)

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -26,13 +26,13 @@ class DomainFeatures(XMLBuilder):
     pmu = XMLProperty("./pmu/@state", is_onoff=True)
     eoi = XMLProperty("./apic/@eoi", is_onoff=True)
 
-    hyperv_reset = XMLProperty("./hyperv/reset/@state", is_onoff=True)
-    hyperv_vapic = XMLProperty("./hyperv/vapic/@state", is_onoff=True)
     hyperv_relaxed = XMLProperty("./hyperv/relaxed/@state", is_onoff=True)
+    hyperv_vapic = XMLProperty("./hyperv/vapic/@state", is_onoff=True)
     hyperv_spinlocks = XMLProperty("./hyperv/spinlocks/@state", is_onoff=True)
     hyperv_spinlocks_retries = XMLProperty("./hyperv/spinlocks/@retries",
                                            is_int=True)
     hyperv_synic = XMLProperty("./hyperv/synic/@state", is_onoff=True)
+    hyperv_reset = XMLProperty("./hyperv/reset/@state", is_onoff=True)
 
     vmport = XMLProperty("./vmport/@state", is_onoff=True)
     kvm_hidden = XMLProperty("./kvm/hidden/@state", is_onoff=True)

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -37,6 +37,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_stimer = XMLProperty("./hyperv/stimer/@state", is_onoff=True)
     hyperv_stimer_direct = XMLProperty("./hyperv/stimer/direct/@state", is_onoff=True)
     hyperv_reset = XMLProperty("./hyperv/reset/@state", is_onoff=True)
+    hyperv_frequencies = XMLProperty("./hyperv/frequencies/@state", is_onoff=True)
 
     vmport = XMLProperty("./vmport/@state", is_onoff=True)
     kvm_hidden = XMLProperty("./kvm/hidden/@state", is_onoff=True)

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -34,6 +34,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_vpindex = XMLProperty("./hyperv/vpindex/@state", is_onoff=True)
     hyperv_runtime = XMLProperty("./hyperv/runtime/@state", is_onoff=True)
     hyperv_synic = XMLProperty("./hyperv/synic/@state", is_onoff=True)
+    hyperv_stimer = XMLProperty("./hyperv/stimer/@state", is_onoff=True)
     hyperv_reset = XMLProperty("./hyperv/reset/@state", is_onoff=True)
 
     vmport = XMLProperty("./vmport/@state", is_onoff=True)

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -32,6 +32,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_spinlocks_retries = XMLProperty("./hyperv/spinlocks/@retries",
                                            is_int=True)
     hyperv_vpindex = XMLProperty("./hyperv/vpindex/@state", is_onoff=True)
+    hyperv_runtime = XMLProperty("./hyperv/runtime/@state", is_onoff=True)
     hyperv_synic = XMLProperty("./hyperv/synic/@state", is_onoff=True)
     hyperv_reset = XMLProperty("./hyperv/reset/@state", is_onoff=True)
 

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -41,6 +41,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_reenlightenment = XMLProperty("./hyperv/reenlightenment/@state", is_onoff=True)
     hyperv_tlbflush = XMLProperty("./hyperv/tlbflush/@state", is_onoff=True)
     hyperv_ipi = XMLProperty("./hyperv/ipi/@state", is_onoff=True)
+    hyperv_evmcs = XMLProperty("./hyperv/evmcs/@state", is_onoff=True)
 
     vmport = XMLProperty("./vmport/@state", is_onoff=True)
     kvm_hidden = XMLProperty("./kvm/hidden/@state", is_onoff=True)

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -40,6 +40,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_frequencies = XMLProperty("./hyperv/frequencies/@state", is_onoff=True)
     hyperv_reenlightenment = XMLProperty("./hyperv/reenlightenment/@state", is_onoff=True)
     hyperv_tlbflush = XMLProperty("./hyperv/tlbflush/@state", is_onoff=True)
+    hyperv_ipi = XMLProperty("./hyperv/ipi/@state", is_onoff=True)
 
     vmport = XMLProperty("./vmport/@state", is_onoff=True)
     kvm_hidden = XMLProperty("./kvm/hidden/@state", is_onoff=True)

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -39,6 +39,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_reset = XMLProperty("./hyperv/reset/@state", is_onoff=True)
     hyperv_frequencies = XMLProperty("./hyperv/frequencies/@state", is_onoff=True)
     hyperv_reenlightenment = XMLProperty("./hyperv/reenlightenment/@state", is_onoff=True)
+    hyperv_tlbflush = XMLProperty("./hyperv/tlbflush/@state", is_onoff=True)
 
     vmport = XMLProperty("./vmport/@state", is_onoff=True)
     kvm_hidden = XMLProperty("./kvm/hidden/@state", is_onoff=True)

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -59,6 +59,22 @@ class DomainFeatures(XMLBuilder):
     # Default config #
     ##################
 
+    def _set_hyperv_defaults(self, guest):
+        if not guest.hyperv_supported():
+            return
+
+        if not self.conn.support.conn_hyperv_vapic():
+            return
+
+        if self.hyperv_relaxed is None:
+            self.hyperv_relaxed = True
+        if self.hyperv_vapic is None:
+            self.hyperv_vapic = True
+        if self.hyperv_spinlocks is None:
+            self.hyperv_spinlocks = True
+        if self.hyperv_spinlocks_retries is None:
+            self.hyperv_spinlocks_retries = 8191
+
     def set_defaults(self, guest):
         if guest.os.is_container():
             self.acpi = None
@@ -84,13 +100,4 @@ class DomainFeatures(XMLBuilder):
             else:
                 self.pae = capsinfo.guest.supports_pae()
 
-        if (guest.hyperv_supported() and
-            self.conn.support.conn_hyperv_vapic()):
-            if self.hyperv_relaxed is None:
-                self.hyperv_relaxed = True
-            if self.hyperv_vapic is None:
-                self.hyperv_vapic = True
-            if self.hyperv_spinlocks is None:
-                self.hyperv_spinlocks = True
-            if self.hyperv_spinlocks_retries is None:
-                self.hyperv_spinlocks_retries = 8191
+        self._set_hyperv_defaults(guest)

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -81,6 +81,26 @@ class DomainFeatures(XMLBuilder):
         _enable("vapic")
         _enable("spinlocks")
         _enable("spinlocks_retries", feature="spinlocks", value=8191)
+        _enable("vpindex")
+        _enable("runtime")
+        _enable("synic", requires=["vpindex"])
+
+        # Both hyperv_stimer and hyperv_stimer requires hv-timer to be enabled
+        # which libvirt hides under hypervclock timer.
+        if guest.clock.has_hyperv_timer():
+            _enable("stimer", requires=["vpindex", "synic"])
+            _enable("stimer_direct", requires=["vpindex", "synic", "stimer"])
+
+        _enable("frequencies")
+
+        _enable("tlbflush", requires=["vpindex"])
+        _enable("ipi", requires=["vpindex"])
+
+        if guest.conn.caps.host.cpu.vendor == "Intel":
+            _enable("evmcs", requires=["vapic"])
+
+        if self.apic is True:
+            _enable("avic")
 
     def set_defaults(self, guest):
         if guest.os.is_container():

--- a/virtinst/domain/features.py
+++ b/virtinst/domain/features.py
@@ -35,6 +35,7 @@ class DomainFeatures(XMLBuilder):
     hyperv_runtime = XMLProperty("./hyperv/runtime/@state", is_onoff=True)
     hyperv_synic = XMLProperty("./hyperv/synic/@state", is_onoff=True)
     hyperv_stimer = XMLProperty("./hyperv/stimer/@state", is_onoff=True)
+    hyperv_stimer_direct = XMLProperty("./hyperv/stimer/direct/@state", is_onoff=True)
     hyperv_reset = XMLProperty("./hyperv/reset/@state", is_onoff=True)
 
     vmport = XMLProperty("./vmport/@state", is_onoff=True)

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -121,6 +121,7 @@ class _Features(_CapsBlock):
     XML_NAME = "features"
     gic = XMLChildProperty(_make_capsblock("gic"), is_single=True)
     sev = XMLChildProperty(_SEV, is_single=True)
+    hyperv = XMLChildProperty(_make_capsblock("hyperv"), is_single=True)
 
 
 class _MemoryBacking(_CapsBlock):
@@ -486,3 +487,12 @@ class DomainCapabilities(XMLBuilder):
         Return True if libvirt advertises support for memfd memory backend
         """
         return self.memorybacking.get_enum("sourceType").has_value("memfd")
+
+    def supported_hyperv_features(self):
+        """
+        Return list of supported Hyper-V features.
+        """
+        if not self.features.hyperv.supported:
+            return []
+
+        return self.features.hyperv.get_enum("features").get_values()

--- a/virtinst/support.py
+++ b/virtinst/support.py
@@ -247,8 +247,6 @@ class SupportCache:
     conn_pm_disable = _make(hv_version={"qemu": "1.2.0", "test": 0})
     conn_qcow2_lazy_refcounts = _make(
         version="1.1.0", hv_version={"qemu": "1.2.0", "test": 0})
-    conn_hyperv_vapic = _make(
-        version="1.1.0", hv_version={"qemu": "1.1.0", "test": 0})
     conn_hyperv_clock = _make(
         version="1.2.2", hv_version={"qemu": "1.5.3", "test": 0})
     conn_domain_capabilities = _make(


### PR DESCRIPTION
This patch series doesn't add support for `vendor_id` feature for now, that will be done in future.

We will not enable `reset` as it is not exported by modern Hyper-V versions and `reenlightenment` is mostly useful when migrating VMs with Hyper-V running inside and requires some other bits to make it work correctly.

Fixes #154