### PR TITLE
Improve storage browser performance

### DIFF
--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -114,6 +114,14 @@ def test_disk_path_in_use_kernel():
     assert vms == ["test-arm-kernel"]
 
 
+def test_disk_paths_in_use():
+    conn = utils.URIs.open_kvm()
+
+    vms = virtinst.DeviceDisk.paths_in_use_by(
+            conn, ["/pool-dir/test-arm-kernel", "/pool-dir/test-arm-initrd"])
+    assert vms == [["test-arm-kernel"], ["test-arm-kernel"]]
+
+
 def test_disk_diskbackend_misc():
     # Test get_size() with vol_install
     conn = utils.URIs.open_testdefault_cached()

--- a/virtManager/hoststorage.py
+++ b/virtManager/hoststorage.py
@@ -406,9 +406,17 @@ class vmmHostStorage(vmmGObjectUI):
         vadj = self.widget("vol-scroll").get_vadjustment()
         vscroll_percent = vadj.get_value() // max(vadj.get_upper(), 1)
 
+        paths = []
         for vol in vols:
             try:
-                path = vol.get_target_path()
+                paths.append(vol.get_target_path())
+            except Exception:
+                log.debug("Error getting target path for '%s'", vol, exc_info=True)
+                paths.append(None)
+        names_list = DeviceDisk.paths_in_use_by(pool.conn.get_backend(), paths)
+
+        for vol, path, names in zip(vols, paths, names_list):
+            try:
                 name = vol.get_pretty_name(pool.get_type())
                 cap = str(vol.get_capacity())
                 sizestr = vol.get_pretty_capacity()
@@ -421,8 +429,6 @@ class vmmHostStorage(vmmGObjectUI):
             namestr = None
             try:
                 if path:
-                    names = DeviceDisk.path_in_use_by(vol.conn.get_backend(),
-                                                       path)
                     namestr = ", ".join(names)
                     if not namestr:
                         namestr = None


### PR DESCRIPTION
In current virt-manager, the storage browser could be extremely slow (or even unusable), when the first pool shown has many files:

https://github.com/virt-manager/virt-manager/assets/2109893/92fa74cd-3934-47be-a58e-271b2566e1c7

After debugging it shows that following code in virtinst/devices/disk.py, `DeviceDisk.path_in_use_by`:

```python
        volmap = dict((vol.backing_store, vol)
                      for vol in conn.fetch_all_vols() if vol.backing_store)
```

takes 0.03s on my laptop every time, and as `vmmHostStorage._populate_vols()` calls `DeviceDisk.path_in_use_by` for every vol, when there are thousands of volumes in a pool (which is usually the case when pool is a local directory), it could take at least half a minute for one call to `_populate_vols()`.

This pull request attempts to fix this by adding a new static method `DeviceDisk.paths_in_use_by`, which ensures that `conn.fetch_all_vols()` is only called once for a list of paths, and adjust `vmmHostStorage._populate_vols()` for this new method.

And the performance is much better on my laptop now:

https://github.com/virt-manager/virt-manager/assets/2109893/7e60302d-aeec-4f36-8529-09449246668f
