### PR TITLE
virt-install: implement passt backend for user network interface

### DIFF
--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -596,6 +596,18 @@
       <mac address="00:11:22:33:44:55"/>
       <model type="vmxnet3"/>
     </interface>
+    <interface type="user">
+      <backend type="passt" logFile="/tmp/foo.log"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+      <portForward proto="tcp" address="192.168.10.10" dev="eth0">
+        <range start="4000" end="5000" to="10000" exclude="no"/>
+        <range start="6000"/>
+      </portForward>
+      <portForward proto="tcp">
+        <range start="2022" to="22"/>
+      </portForward>
+    </interface>
     <smartcard mode="passthrough" type="spicevmc"/>
     <smartcard mode="host" type="tcp"/>
     <smartcard mode="passthrough" type="spicevmc"/>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -630,6 +630,7 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --network vhostuser,source_type=unix,source_path=/tmp/vhost1.sock,source_mode=server,model=virtio,source.type=unix,source.path=/tmp/vhost1.sock,address.type=pci,address.bus=0x00,address.slot=0x10,address.function=0x0,address.domain=0x0000
 --network user,address.type=ccw,address.cssid=0xfe,address.ssid=0,address.devno=01,boot.order=15,boot.loadparm=SYSTEM1
 --network model=vmxnet3
+--network backend.type=passt,backend.logFile=/tmp/foo.log,portForward0.proto=tcp,portForward0.address=192.168.10.10,portForward0.dev=eth0,portForward0.range0.start=4000,portForward0.range0.end=5000,portForward0.range0.to=10000,portForward0.range0.exclude=no,portForward0.range1.start=6000,portForward1.proto=tcp,portForward1.range0.start=2022,portForward1.range0.to=22
 
 
 --graphics sdl

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3825,6 +3825,21 @@ class ParserNetwork(VirtCLIParser):
             val = "down"
         inst.link_state = val
 
+    def portForward_find_inst_cb(self, *args, **kwargs):
+        cliarg = "portForward"  # portForward[0-9]*
+        list_propname = "portForward"  # disk.hosts
+        cb = self._make_find_inst_cb(cliarg, list_propname)
+        return cb(*args, **kwargs)
+
+    def range_find_inst_cb(self, inst, *args, **kwargs):
+        cell = self.portForward_find_inst_cb(inst, *args, **kwargs)
+        inst = cell
+
+        cliarg = "range"  # portForward[0-9]*.range[0-9]*
+        list_propname = "range"  # portForward.range
+        cb = self._make_find_inst_cb(cliarg, list_propname)
+        return cb(inst, *args, **kwargs)
+
     @classmethod
     def _virtcli_class_init(cls):
         VirtCLIParser._virtcli_class_init_common(cls)
@@ -3839,6 +3854,8 @@ class ParserNetwork(VirtCLIParser):
 
         # Standard XML options
         cls.add_arg("type", "type", cb=cls.set_type_cb)
+        cls.add_arg("backend.type", "backend.type")
+        cls.add_arg("backend.logFile", "backend.logFile")
         cls.add_arg("trustGuestRxFilters", "trustGuestRxFilters", is_onoff=True)
         cls.add_arg("source", "source")
         cls.add_arg("source.mode", "source_mode")
@@ -3873,6 +3890,20 @@ class ParserNetwork(VirtCLIParser):
                     "virtualport.profileid")
         cls.add_arg("virtualport.parameters.interfaceid",
                     "virtualport.interfaceid")
+        cls.add_arg("portForward[0-9]*.proto", "proto",
+                    find_inst_cb=cls.portForward_find_inst_cb)
+        cls.add_arg("portForward[0-9]*.address", "address",
+                    find_inst_cb=cls.portForward_find_inst_cb)
+        cls.add_arg("portForward[0-9]*.dev", "dev",
+                    find_inst_cb=cls.portForward_find_inst_cb)
+        cls.add_arg("portForward[0-9]*.range[0-9]*.start", "start",
+                    find_inst_cb=cls.range_find_inst_cb)
+        cls.add_arg("portForward[0-9]*.range[0-9]*.end", "end",
+                    find_inst_cb=cls.range_find_inst_cb)
+        cls.add_arg("portForward[0-9]*.range[0-9]*.to", "to",
+                    find_inst_cb=cls.range_find_inst_cb)
+        cls.add_arg("portForward[0-9]*.range[0-9]*.exclude", "exclude",
+                    is_onoff=True, find_inst_cb=cls.range_find_inst_cb)
 
 
 ######################


### PR DESCRIPTION
Add new `--network backend.type` attribute, libvirt currently supports only `passt`. If not network type is specified virt-install will pick `user` type as it is required for `passt` backend.

This also introduces support to specify portForward and specifying port range as well.

For more details see [1].

[1] <https://libvirt.org/formatdomain.html#userspace-slirp-or-passt-connection>

Fixes: https://github.com/virt-manager/virt-manager/issues/488