### PR TITLE
 domain: don't attempt to predict if VM supports snapshots 

### DIFF
--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -1190,7 +1190,8 @@ class vmmDomain(vmmLibvirtObject):
             if diskOnly:
                 flags = (flags | libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_DISK_ONLY)
             log.debug("Creating snapshot flags=%s xml=\n%s", flags, xml)
-        self._backend.snapshotCreateXML(xml, flags)
+        obj = self._backend.snapshotCreateXML(xml, flags)
+        log.debug("returned new snapshot XML:\n%s", obj.getXMLDesc(0))
 
     def _get_agent(self):
         """

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -473,25 +473,6 @@ class vmmDomain(vmmLibvirtObject):
         if not self.conn.support.domain_list_snapshots(self._backend):
             return _("Libvirt connection does not support snapshots.")
 
-        if self.list_snapshots():
-            return
-
-        # Check if our disks are all qcow2
-        seen_qcow2 = False
-        for disk in self.get_disk_devices_norefresh():
-            if disk.read_only:
-                continue
-            if disk.is_empty():
-                continue
-            if disk.driver_type == "qcow2":
-                seen_qcow2 = True
-                continue
-            return _("Snapshots are only supported if all writeable disks "
-                     "images allocated to the guest are qcow2 format.")
-        if not seen_qcow2:
-            return _("Snapshots require at least one writeable qcow2 disk "
-                     "image allocated to the guest.")
-
     def get_domain_capabilities(self):
         if not self._domain_caps:
             self._domain_caps = self.get_xmlobj().lookup_domcaps()


### PR DESCRIPTION
internal snapshots largely only work if the VM is backed by a single
qcow2 disk. But newly supported external snapshots support other
disk formats, and multiple disks.

Drop the old validation checking. Let's just leave it up to libvirt
to give us an error at snapshot creation time