### PR TITLE
domain: Use KEEP_TPM flag for domain rename

### DIFF
--- a/tests/uitests/data/live/uitests-firmware-efi.xml
+++ b/tests/uitests/data/live/uitests-firmware-efi.xml
@@ -10,5 +10,10 @@
   <features>
     <acpi/>
   </features>
+  <devices>
+    <tpm model='tpm-crb'>
+      <backend type='emulator' version='2.0'/>
+    </tpm>
+  </devices>
 </domain>
 

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -436,6 +436,10 @@ class vmmDomain(vmmLibvirtObject):
         return bool(self.get_xmlobj().is_uefi() or
                     self.get_xmlobj().os.nvram)
 
+    def has_tpm_state(self):
+        return any(tpm.type == "emulator"
+                   for tpm in self.get_xmlobj().devices.tpm)
+
     def is_persistent(self):
         return bool(self._backend.isPersistent())
 
@@ -1414,6 +1418,9 @@ class vmmDomain(vmmLibvirtObject):
         else:
             if self.has_nvram():
                 flags |= getattr(libvirt, "VIR_DOMAIN_UNDEFINE_KEEP_NVRAM", 0)
+            if (self.has_tpm_state() and
+                self.conn.support.domain_undefine_keep_tpm()):
+                flags |= getattr(libvirt, "VIR_DOMAIN_UNDEFINE_KEEP_TPM", 0)
         try:
             self._backend.undefineFlags(flags)
         except libvirt.libvirtError:

--- a/virtinst/support.py
+++ b/virtinst/support.py
@@ -296,6 +296,8 @@ class SupportCache:
     domain_state = _make(function="virDomain.state", run_args=())
     domain_open_graphics = _make(function="virDomain.openGraphicsFD",
         version="1.2.8", hv_version={"qemu": 0})
+    domain_undefine_keep_tpm = _make(
+            hv_libvirt_version={"qemu": "8.9.0"})
 
     # Pool checks
     pool_metadata_prealloc = _make(


### PR DESCRIPTION
If the VM has implicit TPM state, use the VIR_DOMAIN_UNDEFINE_KEEP_TPM flag to preserve that state when renaming the VM (if libvirt is new enough).

The state is stored based on VM UUID and nothing else, and the UUID is preserved during rename, so we don't need to do any of the same trickery that's required for nvram duplication.