### PR TITLE
virt-xml: add `--convert-to-vnc`

### DIFF
--- a/man/virt-xml.rst
+++ b/man/virt-xml.rst
@@ -222,6 +222,28 @@ Sub options are:
     we add to the VM by default.
 
 
+``--convert-to-vnc``
+^^^^^^^^^^^^^^^^^^^^
+
+**Syntax:** ``--convert-to-vnc`` [OPTIONS]
+
+Convert an existing VM to exclusively use a single VNC graphics device.
+
+It will attempt to remove all references to any non-VNC graphics config, like
+Spice. For example:
+
+* ``qxl`` devices will be replaced
+* all ``spicevmc`` and ``spiceport`` devices will be removed
+* spice GL will be converted to ``egl-headless``
+
+Sub options are:
+
+``qemu-vdagent=on|off``
+    Add a ``qemu-vdagent`` device if one is not already configured.
+    This replaces some functionality of the spice vdagent.
+    This defaults to ``off`` but that could change in the future.
+
+
 XML OPTIONS
 ===========
 

--- a/tests/data/cli/compare/virt-xml-convert-to-vnc-vdagent.xml
+++ b/tests/data/cli/compare/virt-xml-convert-to-vnc-vdagent.xml
@@ -1,0 +1,15 @@
+   <on_reboot>restart</on_reboot>
+   <on_crash>destroy</on_crash>
+   <devices>
++    <channel type="qemu-vdagent">
++      <target type="virtio" name="com.redhat.spice.0"/>
++    </channel>
++    <graphics type="vnc" port="-1"/>
++    <video>
++      <model type="vga"/>
++    </video>
+   </devices>
+ </domain>
+
+Domain 'test' defined successfully.
+Changes will take effect after the domain is fully powered off.

--- a/tests/data/cli/compare/virt-xml-convert-to-vnc.xml
+++ b/tests/data/cli/compare/virt-xml-convert-to-vnc.xml
@@ -1,0 +1,12 @@
+   <on_reboot>restart</on_reboot>
+   <on_crash>destroy</on_crash>
+   <devices>
++    <graphics type="vnc" port="-1"/>
++    <video>
++      <model type="vga"/>
++    </video>
+   </devices>
+ </domain>
+
+Domain 'test' defined successfully.
+Changes will take effect after the domain is fully powered off.

--- a/tests/data/xmlparse/convert-to-vnc-empty-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-empty-in.xml
@@ -1,0 +1,13 @@
+<domain type='qemu'>
+  <name>convert-me</name>
+  <memory unit='KiB'>8388608</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='i686'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+  </devices>
+</domain>
+

--- a/tests/data/xmlparse/convert-to-vnc-empty-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-empty-out.xml
@@ -1,0 +1,13 @@
+<domain type="qemu">
+  <name>convert-me</name>
+  <memory unit="KiB">8388608</memory>
+  <currentMemory unit="KiB">2097152</currentMemory>
+  <vcpu placement="static">2</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <devices>
+    <graphics type="vnc" port="-1"/>
+  </devices>
+</domain>

--- a/tests/data/xmlparse/convert-to-vnc-empty-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-empty-out.xml
@@ -8,6 +8,9 @@
     <boot dev="hd"/>
   </os>
   <devices>
+    <channel type="qemu-vdagent">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
     <graphics type="vnc" port="-1"/>
     <video>
       <model type="vga"/>

--- a/tests/data/xmlparse/convert-to-vnc-empty-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-empty-out.xml
@@ -9,5 +9,8 @@
   </os>
   <devices>
     <graphics type="vnc" port="-1"/>
+    <video>
+      <model type="vga"/>
+    </video>
   </devices>
 </domain>

--- a/tests/data/xmlparse/convert-to-vnc-has-vnc-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-has-vnc-in.xml
@@ -23,7 +23,7 @@
     <sound model="ich9"/>
     <audio type='spice'/>
     <video>
-      <model type="virtio"/>
+      <model type="qxl" heads='4' vgamem='1'/>
     </video>
     <redirdev bus="usb" type="spicevmc"/>
     <redirdev bus="usb" type="spicevmc"/>

--- a/tests/data/xmlparse/convert-to-vnc-has-vnc-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-has-vnc-in.xml
@@ -1,0 +1,31 @@
+<domain type="kvm">
+  <name>convert-me</name>
+  <memory>2097152</memory>
+  <currentMemory>2097152</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <devices>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <graphics type="vnc" port="5907"/>
+    <sound model="ich9"/>
+    <audio type='spice'/>
+    <video>
+      <model type="virtio"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+</domain>

--- a/tests/data/xmlparse/convert-to-vnc-has-vnc-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-has-vnc-in.xml
@@ -13,7 +13,7 @@
     <vmport state="off"/>
   </features>
   <devices>
-    <channel type="spicevmc">
+    <channel type="qemu-vdagent">
       <target type="virtio" name="com.redhat.spice.0"/>
     </channel>
     <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">

--- a/tests/data/xmlparse/convert-to-vnc-has-vnc-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-has-vnc-out.xml
@@ -13,6 +13,9 @@
     <vmport state="off"/>
   </features>
   <devices>
+    <channel type="qemu-vdagent">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
     <graphics type="vnc" port="5907"/>
     <sound model="ich9"/>
     <video>

--- a/tests/data/xmlparse/convert-to-vnc-has-vnc-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-has-vnc-out.xml
@@ -1,0 +1,22 @@
+<domain type="kvm">
+  <name>convert-me</name>
+  <memory>2097152</memory>
+  <currentMemory>2097152</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <devices>
+    <graphics type="vnc" port="5907"/>
+    <sound model="ich9"/>
+    <video>
+      <model type="virtio"/>
+    </video>
+  </devices>
+</domain>

--- a/tests/data/xmlparse/convert-to-vnc-has-vnc-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-has-vnc-out.xml
@@ -16,7 +16,7 @@
     <graphics type="vnc" port="5907"/>
     <sound model="ich9"/>
     <video>
-      <model type="virtio"/>
+      <model type="vga"/>
     </video>
   </devices>
 </domain>

--- a/tests/data/xmlparse/convert-to-vnc-spice-devices-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-devices-in.xml
@@ -26,5 +26,15 @@
     </video>
     <redirdev bus="usb" type="spicevmc"/>
     <redirdev bus="usb" type="spicevmc"/>
+    <serial type='spiceport'>
+      <source channel='org.qemu.console.serial.0'/>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='spiceport'>
+      <source channel='org.qemu.console.serial.0'/>
+      <target type='serial' port='0'/>
+    </console>
   </devices>
 </domain>

--- a/tests/data/xmlparse/convert-to-vnc-spice-devices-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-devices-in.xml
@@ -1,0 +1,30 @@
+<domain type="kvm">
+  <name>convert-me</name>
+  <memory>2097152</memory>
+  <currentMemory>2097152</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <devices>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <audio type='spice'/>
+    <video>
+      <model type="virtio"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+</domain>

--- a/tests/data/xmlparse/convert-to-vnc-spice-devices-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-devices-in.xml
@@ -22,6 +22,9 @@
     <sound model="ich9"/>
     <audio type='spice'/>
     <video>
+      <model type="qxl" primary='yes'/>
+    </video>
+    <video>
       <model type="virtio"/>
     </video>
     <redirdev bus="usb" type="spicevmc"/>

--- a/tests/data/xmlparse/convert-to-vnc-spice-devices-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-devices-out.xml
@@ -16,6 +16,9 @@
     <graphics type="vnc" port="-1"/>
     <sound model="ich9"/>
     <video>
+      <model type="vga"/>
+    </video>
+    <video>
       <model type="virtio"/>
     </video>
   </devices>

--- a/tests/data/xmlparse/convert-to-vnc-spice-devices-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-devices-out.xml
@@ -1,0 +1,22 @@
+<domain type="kvm">
+  <name>convert-me</name>
+  <memory>2097152</memory>
+  <currentMemory>2097152</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="network"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <devices>
+    <graphics type="vnc" port="-1"/>
+    <sound model="ich9"/>
+    <video>
+      <model type="virtio"/>
+    </video>
+  </devices>
+</domain>

--- a/tests/data/xmlparse/convert-to-vnc-spice-manyopts-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-manyopts-in.xml
@@ -1,0 +1,20 @@
+<domain type='qemu'>
+  <name>convert-me</name>
+  <memory unit='KiB'>8388608</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='i686'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <clock offset='utc'/>
+  <devices>
+    <graphics type='spice' port='5907' tlsPort='5901' autoport='no' passwd='sercet' passwdValidTo='2011-05-31T16:11:22' connected='disconnect' keymap='de' listen='127.0.0.1'>
+      <listen type='socket' socket='/tmp/spice.sock'/>
+      <listen type='address' address='127.0.0.1'/>
+      <gl enable='yes' rendernode='/dev/my/rendernode'/>
+    </graphics>
+    <graphics type='sdl'/>
+  </devices>
+</domain>
+

--- a/tests/data/xmlparse/convert-to-vnc-spice-manyopts-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-manyopts-in.xml
@@ -12,6 +12,8 @@
     <graphics type='spice' port='5907' tlsPort='5901' autoport='no' passwd='sercet' passwdValidTo='2011-05-31T16:11:22' connected='disconnect' keymap='de' listen='127.0.0.1'>
       <listen type='socket' socket='/tmp/spice.sock'/>
       <listen type='address' address='127.0.0.1'/>
+      <clipboard copypaste='no'/>
+      <mouse mode='client'/>
       <gl enable='yes' rendernode='/dev/my/rendernode'/>
     </graphics>
     <graphics type='sdl'/>

--- a/tests/data/xmlparse/convert-to-vnc-spice-manyopts-in.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-manyopts-in.xml
@@ -15,6 +15,14 @@
       <gl enable='yes' rendernode='/dev/my/rendernode'/>
     </graphics>
     <graphics type='sdl'/>
+    <video>
+      <model type='virtio'>
+        <acceleration accel3d='yes'/>
+      </model>
+    </video>
+    <video>
+      <model type='qxl'/>
+    </video>
   </devices>
 </domain>
 

--- a/tests/data/xmlparse/convert-to-vnc-spice-manyopts-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-manyopts-out.xml
@@ -1,0 +1,20 @@
+<domain type="qemu">
+  <name>convert-me</name>
+  <memory unit="KiB">8388608</memory>
+  <currentMemory unit="KiB">2097152</currentMemory>
+  <vcpu placement="static">2</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <clock offset="utc"/>
+  <devices>
+    <graphics type="vnc" port="5907" keymap="de" listen="127.0.0.1" passwd="sercet" passwdValidTo="2011-05-31T16:11:22">
+      <listen type="socket" socket="/tmp/spice.sock"/>
+      <listen type="address" address="127.0.0.1"/>
+    </graphics>
+    <graphics type="egl-headless">
+      <gl rendernode="/dev/my/rendernode"/>
+    </graphics>
+  </devices>
+</domain>

--- a/tests/data/xmlparse/convert-to-vnc-spice-manyopts-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-manyopts-out.xml
@@ -13,6 +13,11 @@
       <listen type="socket" socket="/tmp/spice.sock"/>
       <listen type="address" address="127.0.0.1"/>
     </graphics>
+    <video>
+      <model type="virtio" primary="yes">
+        <acceleration accel3d="yes"/>
+      </model>
+    </video>
     <graphics type="egl-headless">
       <gl rendernode="/dev/my/rendernode"/>
     </graphics>

--- a/tests/data/xmlparse/convert-to-vnc-spice-manyopts-out.xml
+++ b/tests/data/xmlparse/convert-to-vnc-spice-manyopts-out.xml
@@ -18,6 +18,13 @@
         <acceleration accel3d="yes"/>
       </model>
     </video>
+    <channel type="qemu-vdagent">
+      <source>
+        <clipboard copypaste="no"/>
+        <mouse mode="client"/>
+      </source>
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
     <graphics type="egl-headless">
       <gl rendernode="/dev/my/rendernode"/>
     </graphics>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1439,6 +1439,8 @@ c.add_compare("test --add-device --network default --update --confirm --no-defin
 # --convert-* tests
 c.add_compare("--connect %(URI-KVM-X86)s --print-diff --define --edit --convert-to-q35", "convert-to-q35", input_file=(_VIRTXMLDIR + "convert-to-q35-win10-in.xml"))
 c.add_compare("--connect %(URI-KVM-X86)s --print-diff --define --edit --convert-to-q35 num_pcie_root_ports=7", "convert-to-q35-numports", input_file=(_VIRTXMLDIR + "convert-to-q35-win10-in.xml"))
+c.add_compare("--connect %(URI-KVM-X86)s test --print-diff --define --edit --convert-to-vnc", "convert-to-vnc")
+c.add_compare("--connect %(URI-KVM-X86)s test --print-diff --define --edit --convert-to-vnc qemu-vdagent=on", "convert-to-vnc-vdagent")
 
 # Regression testing for historical --add-device/--remove-device/--edit multi option handling
 # Single `--edit` with multiple options are processed in sequence

--- a/tests/test_xmlparse.py
+++ b/tests/test_xmlparse.py
@@ -1220,12 +1220,12 @@ def testConvertToQ35():
 def testConvertToVNC():
     conn = utils.URIs.openconn(utils.URIs.kvm_x86)
 
-    def _test(filename_base):
+    def _test(filename_base, **kwargs):
         guest, outfile = _get_test_content(conn, filename_base)
-        guest.convert_to_vnc()
+        guest.convert_to_vnc(**kwargs)
         _alter_compare(conn, guest.get_xml(), outfile)
 
-    _test("convert-to-vnc-empty")
+    _test("convert-to-vnc-empty", qemu_vdagent=True)
     _test("convert-to-vnc-spice-devices")
-    _test("convert-to-vnc-spice-manyopts")
-    _test("convert-to-vnc-has-vnc")
+    _test("convert-to-vnc-spice-manyopts", qemu_vdagent=True)
+    _test("convert-to-vnc-has-vnc", qemu_vdagent=True)

--- a/tests/test_xmlparse.py
+++ b/tests/test_xmlparse.py
@@ -1215,3 +1215,17 @@ def testConvertToQ35():
 
     _test("convert-to-q35-win10")
     _test("convert-to-q35-f39", num_pcie_root_ports=5)
+
+
+def testConvertToVNC():
+    conn = utils.URIs.openconn(utils.URIs.kvm_x86)
+
+    def _test(filename_base):
+        guest, outfile = _get_test_content(conn, filename_base)
+        guest.convert_to_vnc()
+        _alter_compare(conn, guest.get_xml(), outfile)
+
+    _test("convert-to-vnc-empty")
+    _test("convert-to-vnc-spice-devices")
+    _test("convert-to-vnc-spice-manyopts")
+    _test("convert-to-vnc-has-vnc")

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -1678,6 +1678,28 @@ class ParserConvertToQ35(VirtCLIParser):
         self.guest.convert_to_q35(**inst.__dict__)
 
 
+############################
+# --convert-to-vnc parsing #
+############################
+
+class ParserConvertToVNC(VirtCLIParser):
+    cli_arg_name = "convert_to_vnc"
+    supports_clearxml = False
+
+    @classmethod
+    def _virtcli_class_init(cls):
+        VirtCLIParser._virtcli_class_init_common(cls)
+        cls.add_arg("qemu-vdagent", "qemu_vdagent")
+
+    def parse(self, inst):
+        class ConvertToVNCData:
+            qemu_vdagent = None
+
+        inst = ConvertToVNCData()
+        super().parse(inst)
+        self.guest.convert_to_vnc(**inst.__dict__)
+
+
 ########################
 # --unattended parsing #
 ########################

--- a/virtinst/devices/video.py
+++ b/virtinst/devices/video.py
@@ -19,6 +19,7 @@ class DeviceVideo(Device):
     vgamem = XMLProperty("./model/@vgamem", is_int=True)
     accel3d = XMLProperty("./model/acceleration/@accel3d", is_yesno=True)
     blob = XMLProperty("./model/@blob", is_onoff=True)
+    primary = XMLProperty("./model/@primary", is_yesno=True)
 
     def _set_model(self, val):
         self._model = val

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -1355,10 +1355,16 @@ class Guest(XMLBuilder):
             if redirdev.type == "spicevmc":
                 self.devices.remove_child(redirdev)
 
+    def _remove_spiceport(self):
+        for dev in self.devices.serial + self.devices.console:
+            if dev.type == dev.TYPE_SPICEPORT:
+                self.devices.remove_child(dev)
+
     def _force_remove_spice_devices(self):
         self._remove_spice_audio()
         self._remove_spice_channels()
         self._remove_spice_usbredir()
+        self._remove_spiceport()
 
     def _remove_spice_devices(self, rmdev):
         if rmdev.DEVICE_TYPE != "graphics" or self.has_spice():

--- a/virtinst/virtxml.py
+++ b/virtinst/virtxml.py
@@ -491,6 +491,12 @@ def parse_args():
         const=cli.VirtCLIParser.OPTSTR_EMPTY,
         help=_("Convert an existing VM from PC/i440FX to Q35."))
 
+    cli.ParserConvertToVNC.register()
+    conv.add_argument("--convert-to-vnc", nargs="?",
+        const=cli.VirtCLIParser.OPTSTR_EMPTY,
+        help=_("Convert an existing VM to use VNC graphics. "
+               "This removes any remnants of Spice graphics."))
+
     g = parser.add_argument_group(_("XML options"))
     cli.add_disk_option(g, editexample=True)
     cli.add_net_option(g)


### PR DESCRIPTION
This series adds a `virt-xml --convert-to-vnc` option, for handling everything I can think of to try and convert an existing VM to use VNC.

The primary usecase is spice->VNC, with particular emphasis on the case where spice is no longer available for the distro, like certain RHEL versions. So we strip out all spice-dependent devices like `qxl`, `spicevmc` bits, etc. Cockpit is already opencoding a limited version of this, but they would prefer if virt-xml handles it. Their code is here: https://github.com/cockpit-project/cockpit-machines/blob/main/src/libvirt-xml-update.js#L309

This also establishes a new pattern with `--convert-to-X` style compound operations for virt-xml, which we can follow for future `--convert-to-q35` for example. We could add suboptions if users need to opt out of certain behaviors of the command. There's one mostly demo option added, `qemu-vdagent=on|off` which defaults to `off`.