### PR TITLE
virt-xml: cleanup action handling in preparation for multi --edit support

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1413,7 +1413,7 @@ c.add_invalid("test-for-virtxml --remove-device --host-device 1 --update --confi
 c.add_invalid("test-for-virtxml --edit --graphics password=foo,keymap= --update --confirm", input_text="yes", grep="(not supported by the connection driver: virDomainUpdateDeviceFlags|persistent update of device 'graphics' is not supported)")
 c.add_invalid("--build-xml --memory 10,maxmemory=20", grep="--build-xml not supported for --memory")
 c.add_invalid("test-state-shutoff --edit sparse=no --disk path=blah", grep="Don't know how to match device type 'disk' property 'sparse'")
-c.add_invalid("test --add-device --xml ./@foo=bar", grep="--xml can only be used with --edit")
+c.add_invalid("test --add-device --xml ./@foo=bar", grep="Cannot use --add-device with --xml")
 c.add_invalid("test-for-virtxml --edit --boot refresh-machine-type=yes", grep="Don't know how to refresh")
 c.add_compare("test --print-xml --edit --vcpus 7", "print-xml")  # test --print-xml
 c.add_compare("--edit --cpu host-passthrough", "stdin-edit", input_file=(_VIRTXMLDIR + "virtxml-stdin-edit.xml"))  # stdin test

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -1616,12 +1616,12 @@ class ParserXML(VirtCLIParser):
         super()._parse(inst)
 
 
-def parse_xmlcli(guest, options):
+def parse_xmlcli(guest, parservalue):
     """
     Parse --xml option string into XMLManualAction instances and append
     to guest.xml_actions.
     """
-    for optstr in options.xml:
+    for optstr in parservalue:
         inst = guest.xml_actions.new()
         ParserXML(optstr).parse(inst)
         guest.xml_actions.append(inst)
@@ -4876,16 +4876,15 @@ class ParserLaunchSecurity(VirtCLIParser):
 # Public virt parser APIs #
 ###########################
 
-def run_parser(options, guest, parserclass, editinst=None):
+def run_parser(guest, parserclass, parservalue, editinst=None):
     """
     Lookup the cli options.* string associated with the passed in Parser*
     class, and parse its values into the passed guest instance, or editinst
     for some virt-xml usage.
     """
     ret = []
-    optstr_list = xmlutil.listify(getattr(options, parserclass.cli_arg_name))
 
-    for optstr in optstr_list:
+    for optstr in xmlutil.listify(parservalue):
         parserobj = parserclass(optstr, guest=guest, editing=bool(editinst))
         parseret = parserobj.parse(editinst)
         ret += xmlutil.listify(parseret)
@@ -4896,7 +4895,8 @@ def run_parser(options, guest, parserclass, editinst=None):
 def run_all_parsers(options, guest):
     ret = []
     for parserclass in VIRT_PARSERS:
-        ret += run_parser(options, guest, parserclass)
+        parservalue = getattr(options, parserclass.cli_arg_name)
+        ret += run_parser(guest, parserclass, parservalue)
     return ret
 
 

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -664,7 +664,6 @@ def build_guest_instance(conn, options):
         # default disk paths are generated based on VM name
         set_cli_default_name(guest)
         cli.run_all_parsers(options, guest)
-        cli.parse_xmlcli(guest, options.xml)
         set_cli_defaults(options, guest)
 
     installer.set_install_defaults(guest)

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -631,10 +631,8 @@ def _build_options_guest(conn, options):
     # We do these two parser bit early, since Installer setup will
     # depend on them, but delay the rest to later, since things like
     # disk naming can depend on Installer operations
-    cli.run_parser(options, guest, cli.ParserBoot)
-    options.boot = None
-    cli.run_parser(options, guest, cli.ParserMetadata)
-    options.metadata = None
+    cli.run_parser(guest, cli.ParserBoot, options.boot)
+    cli.run_parser(guest, cli.ParserMetadata, options.metadata)
 
     # Call set_capabilities_defaults explicitly here rather than depend
     # on set_defaults calling it. Installer setup needs filled in values.
@@ -666,7 +664,7 @@ def build_guest_instance(conn, options):
         # default disk paths are generated based on VM name
         set_cli_default_name(guest)
         cli.run_all_parsers(options, guest)
-        cli.parse_xmlcli(guest, options)
+        cli.parse_xmlcli(guest, options.xml)
         set_cli_defaults(options, guest)
 
     installer.set_install_defaults(guest)

--- a/virtinst/virtxml.py
+++ b/virtinst/virtxml.py
@@ -106,21 +106,21 @@ def validate_action(action, conn, options):
             fail(_("--os-variant/--osinfo is not supported with --build-xml"))
 
     if not action.parserclass.guest_propname and action.is_build_xml:
-        fail(_("--build-xml not supported for --%s") %
-             action.parserclass.cli_arg_name)
+        fail(_("--build-xml not supported for {cli_flag}").format(
+             cli_flag=action.parserclass.cli_flag_name()))
 
     stub_guest = Guest(conn)
     if not action.parserclass.prop_is_list(stub_guest):
         if action.is_remove_device:
-            fail(_("Cannot use --remove-device with --%s") %
-                 action.parserclass.cli_arg_name)
+            fail(_("Cannot use --remove-device with {cli_flag}").format(
+                 cli_flag=action.parserclass.cli_flag_name()))
         if action.is_add_device:
-            fail(_("Cannot use --add-device with --%s") %
-                 action.parserclass.cli_arg_name)
+            fail(_("Cannot use --add-device with {cli_flag}").format(
+                 cli_flag=action.parserclass.cli_flag_name()))
 
     if options.update and not action.parserclass.guest_propname:
-        fail(_("Don't know how to --update for --%s") %
-             (action.parserclass.cli_arg_name))
+        fail(_("Don't know how to --update for {cli_flag}").format(
+             cli_flag=action.parserclass.cli_flag_name()))
 
 
 def check_action_collision(options):
@@ -198,16 +198,16 @@ def _find_objects_to_edit(guest, action_name, editval, parserclass):
             fail(_("Invalid --edit option '%s'") % editval)
 
         if not objlist:
-            fail(_("No --%s objects found in the XML") %
-                parserclass.cli_arg_name)
+            fail(_("No {cli_flag} objects found in the XML").format(
+                cli_flag=parserclass.cli_flag_name()))
         if len(objlist) < abs(idx):
-            fail(ngettext("'--edit %(number)s' requested but there's only "
-                          "%(max)s --%(type)s object in the XML",
-                          "'--edit %(number)s' requested but there are only "
-                          "%(max)s --%(type)s objects in the XML",
-                          len(objlist)) %
-                {"number": idx, "max": len(objlist),
-                 "type": parserclass.cli_arg_name})
+            fail(ngettext("'--edit {number}' requested but there's only "
+                          "{maxnum} {cli_flag} object in the XML",
+                          "'--edit {number}' requested but there are only "
+                          "{maxnum} {cli_flag} objects in the XML",
+                          len(objlist)).format(
+                number=idx, maxnum=len(objlist),
+                cli_flag=parserclass.cli_flag_name()))
 
         if idx > 0:
             idx -= 1
@@ -239,10 +239,10 @@ def action_edit(action, guest):
     else:
         inst = guest
         if (selector and selector != '1' and selector != 'all'):
-            fail(_("'--edit %(option)s' doesn't make sense with "
-                   "--%(objecttype)s, just use empty '--edit'") %
-                 {"option": selector,
-                  "objecttype": parserclass.cli_arg_name})
+            fail(_("'--edit {option}' doesn't make sense with "
+                   "{cli_flag}, just use empty '--edit'").format(
+                   option=selector,
+                   cli_flag=parserclass.cli_flag_name()))
 
     devs = []
     for editinst in xmlutil.listify(inst):

--- a/virtinst/virtxml.py
+++ b/virtinst/virtxml.py
@@ -109,9 +109,6 @@ def validate_action(action, conn, options):
         fail(_("--build-xml not supported for --%s") %
              action.parserclass.cli_arg_name)
 
-    if action.parserclass is cli.ParserXML and not action.is_edit:
-        fail(_("--xml can only be used with --edit"))
-
     stub_guest = Guest(conn)
     if not action.parserclass.prop_is_list(stub_guest):
         if action.is_remove_device:
@@ -148,7 +145,7 @@ def check_action_collision(options):
 
 def check_xmlopt_collision(options):
     collisions = []
-    for parserclass in cli.VIRT_PARSERS + [cli.ParserXML]:
+    for parserclass in cli.VIRT_PARSERS:
         value = getattr(options, parserclass.cli_arg_name)
         if value:
             collisions.append((parserclass, value))
@@ -235,10 +232,6 @@ def action_edit(action, guest):
     parserclass = action.parserclass
     parservalue = action.parservalue
     selector = action.selector
-
-    if parserclass is cli.ParserXML:
-        cli.parse_xmlcli(guest, parservalue)
-        return []
 
     if parserclass.guest_propname:
         inst = _find_objects_to_edit(guest, "edit",


### PR DESCRIPTION
This series cleans up a bunch of miscellaneous things with virt-xml option processing.

The main bit it adds a `Action` class, which contains all the data to describe a single XML operation like `--edit 1 --disk path=/foo` or `--add-device --network default`, etc. This does not add any new functionality, but it cleans up a lot of mess that would prevent adding proper multi action support in the future.

Commits that follow on from that are small bugfixes and code improvements in the same area.