### PR TITLE
virt-xml: add `--edit --convert-to-q35`

### DIFF
--- a/man/virt-xml.rst
+++ b/man/virt-xml.rst
@@ -197,6 +197,31 @@ GUEST OS OPTIONS
     See virt-install(1) documentation for more details about ``--os-variant/--osinfo``
 
 
+CONVERSION OPTIONS
+==================
+
+``--convert-to-q35``
+^^^^^^^^^^^^^^^^^^^^
+
+**Syntax:** ``--convert-to-q35`` [OPTIONS]
+
+Convert an existing VM config from PC/i440FX to Q35 machine type.
+This largely consists of:
+
+* Convert device topology from PCI to PCIe
+* Convert any IDE storage to SATA
+
+You may need to make config changes inside the VM to handle this as well.
+For example, Windows 10 may not find the boot device after IDE to SATA conversion.
+But booting into safe mode once may fix it.
+
+Sub options are:
+
+``num_pcie_root_ports=NUM``
+    Control the number of default ``pcie-root-port`` controller devices
+    we add to the VM by default.
+
+
 XML OPTIONS
 ===========
 

--- a/tests/data/cli/compare/virt-xml-convert-to-q35-numports.xml
+++ b/tests/data/cli/compare/virt-xml-convert-to-q35-numports.xml
@@ -1,0 +1,72 @@
+   <currentMemory unit="KiB">4194304</currentMemory>
+   <vcpu placement="static">2</vcpu>
+   <os>
+-    <type arch="x86_64" machine="pc-i440fx-8.2">hvm</type>
++    <type arch="x86_64" machine="q35">hvm</type>
+     <boot dev="hd"/>
+   </os>
+   <devices>
+@@
+     <disk type="file" device="disk">
+       <driver name="qemu" type="raw"/>
+       <source file="/my/fake/disk"/>
+-      <target dev="hda" bus="ide"/>
+-      <address type="drive" controller="0" bus="0" target="0" unit="0"/>
++      <target dev="sda" bus="sata"/>
+     </disk>
+-    <controller type="usb" index="0" model="qemu-xhci" ports="15">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x05" function="0x0"/>
+-    </controller>
+-    <controller type="pci" index="0" model="pci-root"/>
+-    <controller type="ide" index="0">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x1"/>
+-    </controller>
+-    <controller type="virtio-serial" index="0">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x06" function="0x0"/>
+-    </controller>
++    <controller type="usb" index="0" model="qemu-xhci" ports="15"/>
++    <controller type="virtio-serial" index="0"/>
+     <interface type="network">
+       <mac address="52:54:00:0f:b2:90"/>
+       <source network="default"/>
+-      <model type="e1000"/>
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x03" function="0x0"/>
++      <model type="e1000e"/>
+     </interface>
+     <serial type="pty">
+       <target type="isa-serial" port="0">
+@@
+       <listen type="address"/>
+       <image compression="off"/>
+     </graphics>
+-    <sound model="ich6">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x04" function="0x0"/>
+-    </sound>
++    <sound model="ich9"/>
+     <audio id="1" type="spice"/>
+     <video>
+       <model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x02" function="0x0"/>
+     </video>
+     <redirdev bus="usb" type="spicevmc">
+       <address type="usb" bus="0" port="2"/>
+@@
+     <redirdev bus="usb" type="spicevmc">
+       <address type="usb" bus="0" port="3"/>
+     </redirdev>
+-    <memballoon model="virtio">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x07" function="0x0"/>
+-    </memballoon>
++    <memballoon model="virtio"/>
++    <controller type="pci" model="pcie-root"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
+   </devices>
+ </domain>
+
+Domain 'convert-me' defined successfully.

--- a/tests/data/cli/compare/virt-xml-convert-to-q35.xml
+++ b/tests/data/cli/compare/virt-xml-convert-to-q35.xml
@@ -1,0 +1,79 @@
+   <currentMemory unit="KiB">4194304</currentMemory>
+   <vcpu placement="static">2</vcpu>
+   <os>
+-    <type arch="x86_64" machine="pc-i440fx-8.2">hvm</type>
++    <type arch="x86_64" machine="q35">hvm</type>
+     <boot dev="hd"/>
+   </os>
+   <devices>
+@@
+     <disk type="file" device="disk">
+       <driver name="qemu" type="raw"/>
+       <source file="/my/fake/disk"/>
+-      <target dev="hda" bus="ide"/>
+-      <address type="drive" controller="0" bus="0" target="0" unit="0"/>
++      <target dev="sda" bus="sata"/>
+     </disk>
+-    <controller type="usb" index="0" model="qemu-xhci" ports="15">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x05" function="0x0"/>
+-    </controller>
+-    <controller type="pci" index="0" model="pci-root"/>
+-    <controller type="ide" index="0">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x1"/>
+-    </controller>
+-    <controller type="virtio-serial" index="0">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x06" function="0x0"/>
+-    </controller>
++    <controller type="usb" index="0" model="qemu-xhci" ports="15"/>
++    <controller type="virtio-serial" index="0"/>
+     <interface type="network">
+       <mac address="52:54:00:0f:b2:90"/>
+       <source network="default"/>
+-      <model type="e1000"/>
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x03" function="0x0"/>
++      <model type="e1000e"/>
+     </interface>
+     <serial type="pty">
+       <target type="isa-serial" port="0">
+@@
+       <listen type="address"/>
+       <image compression="off"/>
+     </graphics>
+-    <sound model="ich6">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x04" function="0x0"/>
+-    </sound>
++    <sound model="ich9"/>
+     <audio id="1" type="spice"/>
+     <video>
+       <model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x02" function="0x0"/>
+     </video>
+     <redirdev bus="usb" type="spicevmc">
+       <address type="usb" bus="0" port="2"/>
+@@
+     <redirdev bus="usb" type="spicevmc">
+       <address type="usb" bus="0" port="3"/>
+     </redirdev>
+-    <memballoon model="virtio">
+-      <address type="pci" domain="0x0000" bus="0x00" slot="0x07" function="0x0"/>
+-    </memballoon>
++    <memballoon model="virtio"/>
++    <controller type="pci" model="pcie-root"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
++    <controller type="pci" model="pcie-root-port"/>
+   </devices>
+ </domain>
+
+Domain 'convert-me' defined successfully.

--- a/tests/data/cli/virtxml/convert-to-q35-win10-in.xml
+++ b/tests/data/cli/virtxml/convert-to-q35-win10-in.xml
@@ -1,0 +1,79 @@
+<domain type='kvm'>
+  <name>convert-me</name>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://microsoft.com/win/10"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory unit='KiB'>4194304</memory>
+  <currentMemory unit='KiB'>4194304</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-8.2'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source file='/my/fake/disk'/>
+      <target dev='hda' bus='ide'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <controller type='usb' index='0' model='qemu-xhci' ports='15'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <controller type='ide' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:0f:b2:90'/>
+      <source network='default'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='spice' autoport='yes'>
+      <listen type='address'/>
+      <image compression='off'/>
+    </graphics>
+    <sound model='ich6'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </sound>
+    <audio id='1' type='spice'/>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+    </memballoon>
+  </devices>
+</domain>
+

--- a/tests/data/xmlparse/convert-to-q35-f39-in.xml
+++ b/tests/data/xmlparse/convert-to-q35-f39-in.xml
@@ -1,0 +1,84 @@
+<domain type='kvm'>
+  <name>convert-me</name>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/39"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory unit='KiB'>8388608</memory>
+  <currentMemory unit='KiB'>8388608</currentMemory>
+  <vcpu placement='static'>8</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-8.2'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' discard='unmap'/>
+      <source file='/mnt/data/devel/images/f39-pc.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+    </disk>
+    <controller type='usb' index='0' model='qemu-xhci' ports='15'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <controller type='virtio-serial' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:92:f9:7b'/>
+      <source network='default'/>
+      <model type='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <channel type='unix'>
+      <target type='virtio' name='org.qemu.guest_agent.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='2'/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='spice' autoport='yes'>
+      <listen type='address'/>
+      <image compression='off'/>
+    </graphics>
+    <sound model='ich6'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </sound>
+    <audio id='1' type='spice'/>
+    <video>
+      <model type='virtio' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
+    </rng>
+  </devices>
+</domain>
+

--- a/tests/data/xmlparse/convert-to-q35-f39-out.xml
+++ b/tests/data/xmlparse/convert-to-q35-f39-out.xml
@@ -1,0 +1,76 @@
+<domain type="kvm">
+  <name>convert-me</name>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/39"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory unit="KiB">8388608</memory>
+  <currentMemory unit="KiB">8388608</currentMemory>
+  <vcpu placement="static">8</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/mnt/data/devel/images/f39-pc.qcow2"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" index="0" model="qemu-xhci" ports="15"/>
+    <controller type="virtio-serial" index="0"/>
+    <interface type="network">
+      <mac address="52:54:00:92:f9:7b"/>
+      <source network="default"/>
+      <model type="virtio"/>
+    </interface>
+    <serial type="pty">
+      <target type="isa-serial" port="0">
+        <model name="isa-serial"/>
+      </target>
+    </serial>
+    <console type="pty">
+      <target type="serial" port="0"/>
+    </console>
+    <channel type="unix">
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+      <address type="virtio-serial" controller="0" bus="0" port="1"/>
+    </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+      <address type="virtio-serial" controller="0" bus="0" port="2"/>
+    </channel>
+    <input type="tablet" bus="usb">
+      <address type="usb" bus="0" port="1"/>
+    </input>
+    <input type="mouse" bus="ps2"/>
+    <input type="keyboard" bus="ps2"/>
+    <graphics type="spice" autoport="yes">
+      <listen type="address"/>
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <audio id="1" type="spice"/>
+    <video>
+      <model type="virtio" heads="1" primary="yes"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc">
+      <address type="usb" bus="0" port="2"/>
+    </redirdev>
+    <redirdev bus="usb" type="spicevmc">
+      <address type="usb" bus="0" port="3"/>
+    </redirdev>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+  </devices>
+</domain>

--- a/tests/data/xmlparse/convert-to-q35-win10-in.xml
+++ b/tests/data/xmlparse/convert-to-q35-win10-in.xml
@@ -1,0 +1,79 @@
+<domain type='kvm'>
+  <name>convert-me</name>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://microsoft.com/win/10"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory unit='KiB'>4194304</memory>
+  <currentMemory unit='KiB'>4194304</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-8.2'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source file='/my/fake/disk'/>
+      <target dev='hda' bus='ide'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <controller type='usb' index='0' model='qemu-xhci' ports='15'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <controller type='ide' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x0'/>
+    </controller>
+    <interface type='network'>
+      <mac address='52:54:00:0f:b2:90'/>
+      <source network='default'/>
+      <model type='e1000'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <serial type='pty'>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+    <channel type='spicevmc'>
+      <target type='virtio' name='com.redhat.spice.0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='spice' autoport='yes'>
+      <listen type='address'/>
+      <image compression='off'/>
+    </graphics>
+    <sound model='ich6'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </sound>
+    <audio id='1' type='spice'/>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='2'/>
+    </redirdev>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='3'/>
+    </redirdev>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
+    </memballoon>
+  </devices>
+</domain>
+

--- a/tests/data/xmlparse/convert-to-q35-win10-out.xml
+++ b/tests/data/xmlparse/convert-to-q35-win10-out.xml
@@ -1,0 +1,78 @@
+<domain type="kvm">
+  <name>convert-me</name>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://microsoft.com/win/10"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory unit="KiB">4194304</memory>
+  <currentMemory unit="KiB">4194304</currentMemory>
+  <vcpu placement="static">2</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="raw"/>
+      <source file="/my/fake/disk"/>
+      <target dev="sda" bus="sata"/>
+    </disk>
+    <controller type="usb" index="0" model="qemu-xhci" ports="15"/>
+    <controller type="virtio-serial" index="0"/>
+    <interface type="network">
+      <mac address="52:54:00:0f:b2:90"/>
+      <source network="default"/>
+      <model type="e1000e"/>
+    </interface>
+    <serial type="pty">
+      <target type="isa-serial" port="0">
+        <model name="isa-serial"/>
+      </target>
+    </serial>
+    <console type="pty">
+      <target type="serial" port="0"/>
+    </console>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+      <address type="virtio-serial" controller="0" bus="0" port="1"/>
+    </channel>
+    <input type="tablet" bus="usb">
+      <address type="usb" bus="0" port="1"/>
+    </input>
+    <input type="mouse" bus="ps2"/>
+    <input type="keyboard" bus="ps2"/>
+    <graphics type="spice" autoport="yes">
+      <listen type="address"/>
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <audio id="1" type="spice"/>
+    <video>
+      <model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc">
+      <address type="usb" bus="0" port="2"/>
+    </redirdev>
+    <redirdev bus="usb" type="spicevmc">
+      <address type="usb" bus="0" port="3"/>
+    </redirdev>
+    <memballoon model="virtio"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+  </devices>
+</domain>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1436,6 +1436,10 @@ c.add_compare("--connect %(URI-KVM-X86)s test-many-devices --build-xml --disk so
 c.add_compare("test --add-device --network default --update --confirm", "update-succeed", env={"VIRTXML_TESTSUITE_UPDATE_IGNORE_FAIL": "1", "VIRTINST_TEST_SUITE_INCREMENT_MACADDR": "1"}, input_text="yes\nyes\n")  # test hotplug success
 c.add_compare("test --add-device --network default --update --confirm --no-define", "update-nodefine-succeed", env={"VIRTXML_TESTSUITE_UPDATE_IGNORE_FAIL": "1"}, input_text="yes\n")  # test hotplug success without define
 
+# --convert-* tests
+c.add_compare("--connect %(URI-KVM-X86)s --print-diff --define --edit --convert-to-q35", "convert-to-q35", input_file=(_VIRTXMLDIR + "convert-to-q35-win10-in.xml"))
+c.add_compare("--connect %(URI-KVM-X86)s --print-diff --define --edit --convert-to-q35 num_pcie_root_ports=7", "convert-to-q35-numports", input_file=(_VIRTXMLDIR + "convert-to-q35-win10-in.xml"))
+
 # Regression testing for historical --add-device/--remove-device/--edit multi option handling
 # Single `--edit` with multiple options are processed in sequence
 c.add_compare("test --print-diff --define --edit --boot emulator=/foo --boot bootmenu.enable=yes", "multi-edit-boot-backcompat")

--- a/tests/test_xmlparse.py
+++ b/tests/test_xmlparse.py
@@ -1203,3 +1203,15 @@ def testUnknownEmulatorDomcapsLookup(monkeypatch):
     assert guest.lookup_domcaps()
     assert guest.lookup_domcaps()
     assert seen
+
+
+def testConvertToQ35():
+    conn = utils.URIs.openconn(utils.URIs.kvm_x86)
+
+    def _test(filename_base, **kwargs):
+        guest, outfile = _get_test_content(conn, filename_base)
+        guest.convert_to_q35(**kwargs)
+        _alter_compare(conn, guest.get_xml(), outfile)
+
+    _test("convert-to-q35-win10")
+    _test("convert-to-q35-f39", num_pcie_root_ports=5)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -1324,6 +1324,8 @@ class VirtCLIParser(metaclass=_InitClass):
     @cli_arg_name: The command line argument this maps to, so
         "hostdev" for --hostdev
     """
+    OPTSTR_EMPTY = 1
+
     guest_propname = None
     remove_first = None
     stub_none = True
@@ -1419,6 +1421,8 @@ class VirtCLIParser(metaclass=_InitClass):
         self.optstr = optstr
         self.guest = guest
         self.editing = editing
+        if self.optstr == self.OPTSTR_EMPTY:
+            self.optstr = ""
         self.optdict = _parse_optstr_to_dict(self.optstr,
                 self._virtargs, xmlutil.listify(self.remove_first)[:])
 
@@ -1649,6 +1653,29 @@ def _add_xpath_args(cls):
             can_comma=True, lookup_cb=None, find_inst_cb=find_xpath_cb)
     _add_arg("xpath[0-9]*.value", "xpath_value",
             can_comma=True, lookup_cb=None, find_inst_cb=find_xpath_cb)
+
+
+############################
+# --convert-to-q35 parsing #
+############################
+
+class ParserConvertToQ35(VirtCLIParser):
+    cli_arg_name = "convert_to_q35"
+    supports_clearxml = False
+
+    @classmethod
+    def _virtcli_class_init(cls):
+        VirtCLIParser._virtcli_class_init_common(cls)
+        cls.add_arg("num_pcie_root_ports", "num_pcie_root_ports")
+
+
+    def parse(self, inst):
+        class ConvertToQ35Data:
+            num_pcie_root_ports = None
+
+        inst = ConvertToQ35Data()
+        super().parse(inst)
+        self.guest.convert_to_q35(**inst.__dict__)
 
 
 ########################

--- a/virtinst/virtxml.py
+++ b/virtinst/virtxml.py
@@ -485,6 +485,12 @@ def parse_args():
 
     cli.add_os_variant_option(parser, virtinstall=False)
 
+    conv = parser.add_argument_group(_("Conversion options"))
+    cli.ParserConvertToQ35.register()
+    conv.add_argument("--convert-to-q35", nargs="?",
+        const=cli.VirtCLIParser.OPTSTR_EMPTY,
+        help=_("Convert an existing VM from PC/i440FX to Q35."))
+
     g = parser.add_argument_group(_("XML options"))
     cli.add_disk_option(g, editexample=True)
     cli.add_net_option(g)


### PR DESCRIPTION
This PR is on top of https://github.com/virt-manager/virt-manager/pull/727 since they overlap

This adds `virt-xml --edit --convert-to-q35`. The XML bits we actually edit are layed out in https://github.com/virt-manager/virt-manager/issues/720 plus converting ich6 -> ich9 sound, and clearing disk `<address>` blocks.

In my limited testing, VMs handle this mostly OK:

* Fedora 39 reboots fine and everything works. Even manually converting virtio storage to `sata` config and Fedora doesn't mind.
* Win10 will fail to boot. After a couple reboots it drops you to the repair menu. If you boot once into safe mode, it seems to figure everything out, and subsequent reboots boot fine.
* Win11 rejects machine=pc in the first place, so we shouldn't need to worry about that.