### PR TITLE
snapshots: Don't save outdated screenshot data

### DIFF
--- a/ui/snapshotsnew.ui
+++ b/ui/snapshotsnew.ui
@@ -89,7 +89,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <child>
-                  <!-- n-columns=2 n-rows=6 -->
+                  <!-- n-columns=2 n-rows=5 -->
                   <object class="GtkGrid" id="snapshot-new-box">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -201,31 +201,6 @@
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label6">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="valign">start</property>
-                        <property name="label" translatable="yes">Screenshot:</property>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">5</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkImage" id="snapshot-new-screenshot">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="icon-name">image-missing</property>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">5</property>
                       </packing>
                     </child>
                     <child>

--- a/virtManager/details/snapshots.py
+++ b/virtManager/details/snapshots.py
@@ -165,12 +165,6 @@ class vmmSnapshotNew(vmmGObjectUI):
         self.widget("snapshot-new-status-icon").set_from_icon_name(
             self.vm.run_status_icon_name(), Gtk.IconSize.BUTTON)
 
-        sn = self._get_screenshot()
-        uiutil.set_grid_row_visible(
-            self.widget("snapshot-new-screenshot"), bool(sn))
-        if sn:
-            self.widget("snapshot-new-screenshot").set_from_pixbuf(sn)
-
         self._reset_snapshot_mode()
 
         self._reset_snapshot_memory_path()
@@ -265,10 +259,7 @@ class vmmSnapshotNew(vmmGObjectUI):
         if not ext:
             return  # pragma: no cover
 
-        newpix = _make_screenshot_pixbuf(mime, sdata)
-        setattr(newpix, "vmm_mimetype", mime)
-        setattr(newpix, "vmm_sndata", sdata)
-        return newpix
+        return mime, sdata
 
     def _get_mode(self):
         mode_external = self.widget("snapshot-new-mode-external")
@@ -308,19 +299,6 @@ class vmmSnapshotNew(vmmGObjectUI):
         except Exception as e:
             return self.err.val_err(_("Error validating snapshot: %s") % e)
 
-    def _get_screenshot_data_for_save(self):
-        snwidget = self.widget("snapshot-new-screenshot")
-        if not snwidget.is_visible():
-            return None, None
-
-        sn = snwidget.get_pixbuf()
-        if not sn:  # pragma: no cover
-            return None, None
-
-        mime = getattr(sn, "vmm_mimetype", None)
-        sndata = getattr(sn, "vmm_sndata", None)
-        return mime, sndata
-
     def _do_create_snapshot(self, asyncjob, xml, name, mime, sndata, diskOnly):
         ignore = asyncjob
 
@@ -352,7 +330,7 @@ class vmmSnapshotNew(vmmGObjectUI):
 
         xml = snap.get_xml()
         name = snap.name
-        mime, sndata = self._get_screenshot_data_for_save()
+        mime, sndata = (self._get_screenshot() or (None, None))
         diskOnly = not self.vm.is_active() and self._get_mode() == "external"
 
         self.set_finish_cursor()


### PR DESCRIPTION
Current code will take a screenshot when the 'New Snapshot' dialog is initially launched, and then use that cached content as the screenshot for the snapshot... which may be totally out of date by the time the user enters all the snapshot info.

Instead, drop the snapshot preview UI in the 'New Snapshot' wizard entirely, and use a screenshot that is fetched after the user actually clicks 'Finish'