### PR TITLE
Tweak `--osinfo require=off` behavior to print more warnings

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1023,6 +1023,7 @@ c.add_compare("--location https://foobar.com --os-variant detect=yes,name=win7",
 c.add_compare("--pxe --os-variant detect=yes,name=win7", "os-detect-fail-fallback")  # os detection succeeds, so fallback should be ignored
 c.add_compare("--connect %(URI-KVM-X86)s --install fedora26", "osinfo-url")  # getting URL from osinfo
 c.add_invalid("--pxe --os-variant detect=yes,require=yes", grep="--os-variant/--osinfo OS name is required")  # No os-variant detected, but require=yes
+c.add_valid("--pxe --osinfo detect=yes")  # --osinfo detect=on failed, but with implied require=no
 c.add_invalid("--pxe --virt-type foobar", grep="Host does not support domain type")
 c.add_invalid("--pxe --os-variant farrrrrrrge", grep="Unknown OS name")
 c.add_invalid("--pxe --boot menu=foobar", grep="menu must be 'yes' or 'no'")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1024,6 +1024,7 @@ c.add_compare("--pxe --os-variant detect=yes,name=win7", "os-detect-fail-fallbac
 c.add_compare("--connect %(URI-KVM-X86)s --install fedora26", "osinfo-url")  # getting URL from osinfo
 c.add_valid("--location https://foobar.com --os-variant detect=yes,name=win7", nogrep="Please file a bug against virt-install")  # os detection succeeds, the fallback warning shouldn't be printed
 c.add_valid("--pxe --os-variant detect=yes,name=win7", grep="Please file a bug against virt-install")  # os detection fails, so fallback warning should be printed
+c.add_valid("--cdrom http://example.com/path/to/some.iso --os-variant detect=yes,require=no", grep="Please file a bug against virt-install")  # detection fails with require=no, we should print the error about using fallback name=
 c.add_invalid("--pxe --os-variant detect=yes,require=yes", grep="--os-variant/--osinfo OS name is required")  # No os-variant detected, but require=yes
 c.add_invalid("--pxe --osinfo detect=yes", grep="--os-variant/--osinfo OS name is required")  # --osinfo detect=on failed, but with implied require=yes
 c.add_invalid("--pxe --virt-type foobar", grep="Host does not support domain type")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1020,8 +1020,10 @@ c.add_compare("--pxe --print-step all --os-variant none", "simple-pxe")  # Diskl
 c.add_compare("--location ftp://example.com --os-variant auto", "fake-ftp")  # fake ftp:// install using urlfetcher.py mocking
 c.add_compare("--location https://foobar.com --os-variant detect=no,require=no", "fake-http")  # fake https:// install using urlfetcher.py mocking, but also hit --os-variant detect=no
 c.add_compare("--location https://foobar.com --os-variant detect=yes,name=win7", "os-detect-success-fallback")  # os detection succeeds, so fallback should be ignored
-c.add_compare("--pxe --os-variant detect=yes,name=win7", "os-detect-fail-fallback")  # os detection succeeds, so fallback should be ignored
+c.add_compare("--pxe --os-variant detect=yes,name=win7", "os-detect-fail-fallback")  # os detection fails, so we use fallback name=
 c.add_compare("--connect %(URI-KVM-X86)s --install fedora26", "osinfo-url")  # getting URL from osinfo
+c.add_valid("--location https://foobar.com --os-variant detect=yes,name=win7", nogrep="Please file a bug against virt-install")  # os detection succeeds, the fallback warning shouldn't be printed
+c.add_valid("--pxe --os-variant detect=yes,name=win7", grep="Please file a bug against virt-install")  # os detection fails, so fallback warning should be printed
 c.add_invalid("--pxe --os-variant detect=yes,require=yes", grep="--os-variant/--osinfo OS name is required")  # No os-variant detected, but require=yes
 c.add_invalid("--pxe --osinfo detect=yes", grep="--os-variant/--osinfo OS name is required")  # --osinfo detect=on failed, but with implied require=yes
 c.add_invalid("--pxe --virt-type foobar", grep="Host does not support domain type")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1023,7 +1023,7 @@ c.add_compare("--location https://foobar.com --os-variant detect=yes,name=win7",
 c.add_compare("--pxe --os-variant detect=yes,name=win7", "os-detect-fail-fallback")  # os detection succeeds, so fallback should be ignored
 c.add_compare("--connect %(URI-KVM-X86)s --install fedora26", "osinfo-url")  # getting URL from osinfo
 c.add_invalid("--pxe --os-variant detect=yes,require=yes", grep="--os-variant/--osinfo OS name is required")  # No os-variant detected, but require=yes
-c.add_valid("--pxe --osinfo detect=yes")  # --osinfo detect=on failed, but with implied require=no
+c.add_invalid("--pxe --osinfo detect=yes", grep="--os-variant/--osinfo OS name is required")  # --osinfo detect=on failed, but with implied require=yes
 c.add_invalid("--pxe --virt-type foobar", grep="Host does not support domain type")
 c.add_invalid("--pxe --os-variant farrrrrrrge", grep="Unknown OS name")
 c.add_invalid("--pxe --boot menu=foobar", grep="menu must be 'yes' or 'no'")

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -1919,9 +1919,6 @@ class OSVariantData(object):
         if osobj:
             self._name = osobj.name
 
-        if self._require_from_cli is None and not self._require:
-            self._require_from_cli = False
-
         if self._require_from_cli is False:
             self._require = self._REQUIRE_OFF
         elif self._require_from_cli is True:

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -1886,7 +1886,6 @@ def parse_location(optstr):
 
 class OSVariantData(object):
     _REQUIRE_ON = 1
-    _REQUIRE_OFF = 2
     _REQUIRE_AUTO = 3
 
     def __init__(self):
@@ -1920,7 +1919,10 @@ class OSVariantData(object):
             self._name = osobj.name
 
         if self._require_from_cli is False:
-            self._require = self._REQUIRE_OFF
+            if not self._name:
+                log.debug(
+                    "Converting `require=off` to fallback `name=generic`")
+                self._name = "generic"
         elif self._require_from_cli is True:
             self._require = self._REQUIRE_ON
         else:
@@ -1930,8 +1932,6 @@ class OSVariantData(object):
         return self._detect
     def is_require_on(self):
         return self._require == self._REQUIRE_ON
-    def is_require_off(self):
-        return self._require == self._REQUIRE_OFF
     def get_name(self):
         return self._name
 

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -1885,17 +1885,22 @@ def parse_location(optstr):
 ########################
 
 class OSVariantData(object):
+    _REQUIRE_ON = 1
+    _REQUIRE_OFF = 2
+    _REQUIRE_AUTO = 3
+
     def __init__(self):
         self._name = None
         self._id = None
         self._detect = False
-        self._require = False
+        self._require_from_cli = None
+        self._require = None
 
     def set_compat_str(self, rawstr):
         if rawstr is None or rawstr == "auto":
             # The default behavior
             self._detect = True
-            self._require = "auto"
+            self._require = self._REQUIRE_AUTO
             return
 
         if rawstr == "none":
@@ -1914,12 +1919,22 @@ class OSVariantData(object):
         if osobj:
             self._name = osobj.name
 
+        if self._require_from_cli is None and not self._require:
+            self._require_from_cli = False
+
+        if self._require_from_cli is False:
+            self._require = self._REQUIRE_OFF
+        elif self._require_from_cli is True:
+            self._require = self._REQUIRE_ON
+        else:
+            self._require = self._REQUIRE_AUTO
+
     def is_detect(self):
         return self._detect
     def is_require_on(self):
-        return not self.is_require_default() and bool(self._require)
-    def is_require_default(self):
-        return self._require == "auto"
+        return self._require == self._REQUIRE_ON
+    def is_require_off(self):
+        return self._require == self._REQUIRE_OFF
     def get_name(self):
         return self._name
 
@@ -1935,7 +1950,7 @@ class ParserOSVariant(VirtCLIParser):
         cls.add_arg("short-id", "_name")
         cls.add_arg("id", "_id")
         cls.add_arg("detect", "_detect", is_onoff=True)
-        cls.add_arg("require", "_require", is_onoff=True)
+        cls.add_arg("require", "_require_from_cli", is_onoff=True)
 
     def parse(self, inst):
         if "=" not in str(self.optstr):

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -580,8 +580,6 @@ def installer_detect_distro(guest, installer, osdata):
         return
     if osdata.is_require_on():
         fail(msg)
-    if osdata.is_require_off():
-        return
 
     if not _needs_accurate_osinfo(guest):
         return

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -551,15 +551,25 @@ def installer_detect_distro(guest, installer, osdata):
         # OS name has to be set firstly whenever --osinfo is passed,
         # otherwise it won't be respected when the installer creates the
         # Distro Store.
+        fallback_name = None
         if osdata.get_name():
+            fallback_name = osdata.get_name()
             os_set = True
-            guest.set_os_name(osdata.get_name())
+            guest.set_os_name(fallback_name)
 
         # This also validates the install location
         autodistro = installer.detect_distro(guest)
-        if osdata.is_detect() and autodistro:
-            os_set = True
-            guest.set_os_name(autodistro)
+        if osdata.is_detect():
+            if autodistro:
+                os_set = True
+                guest.set_os_name(autodistro)
+            elif fallback_name:
+                msg = _(
+                    "Failed to detect osinfo OS name from install media."
+                    "Using fallback name=%s.") % fallback_name
+                msg += _("\nPlease file a bug against virt-install if "
+                         "you expected detection to succeed.")
+                log.warning(msg)
     except ValueError as e:
         fail(_("Error validating install location: %s") % str(e))
 

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -570,7 +570,7 @@ def installer_detect_distro(guest, installer, osdata):
         return
     if osdata.is_require_on():
         fail(msg)
-    if not osdata.is_require_default():
+    if osdata.is_require_off():
         return
 
     if not _needs_accurate_osinfo(guest):


### PR DESCRIPTION
Recently there was a case internally where someone was using `--osinfo detect=on,require=off`, media detection was failing, but the user didn't notice. In this case, virt-install will warn that `generic` OS is being used, so there was already a warning. But this changes things to make warnings more explicit that detection failed, and if that's unexpected to the user, they should file a bug.

This also changes `--osinfo detect=on` to imply `require=on` instead of `require=off`. That was a bug