### PR TITLE
virt-install: Make --cloud-init reboot by default (again)

### DIFF
--- a/virtManager/createvm.py
+++ b/virtManager/createvm.py
@@ -2031,7 +2031,7 @@ class vmmCreateVM(vmmGObjectUI):
             # Probably means guest had no 'install' phase, as in
             # for live cds. Try to restart the domain.
             vm.startup()  # pragma: no cover
-        elif installer.has_install_phase():
+        elif installer.requires_postboot_xml_changes():
             # Register a status listener, which will restart the
             # guest after the install has finished
             def cb():

--- a/virtinst/install/installer.py
+++ b/virtinst/install/installer.py
@@ -507,6 +507,8 @@ class Installer(object):
         into the guest. Things like LiveCDs, Import, or a manually specified
         bootorder do not have an install phase.
         """
+        if self.has_cloudinit() or self.has_unattended():
+            return True
         if self._no_install:
             return False
         return bool(self._cdrom or

--- a/virtinst/install/installer.py
+++ b/virtinst/install/installer.py
@@ -501,11 +501,11 @@ class Installer(object):
             search_paths.append(self._cdrom_path())
         return search_paths
 
-    def has_install_phase(self):
+    def requires_postboot_xml_changes(self):
         """
-        Return True if the requested setup is actually installing an OS
-        into the guest. Things like LiveCDs, Import, or a manually specified
-        bootorder do not have an install phase.
+        Return True if the install operation has 2 XML phases, and
+        requires a hard VM poweroff to ensure the second stage is
+        used for subsequent boots.
         """
         if self.has_cloudinit() or self.has_unattended():
             return True
@@ -515,18 +515,13 @@ class Installer(object):
                     self._install_bootdev or
                     self._treemedia)
 
-    def _requires_postboot_xml_changes(self):
-        if self.has_cloudinit() or self.has_unattended():
-            return True
-        return self.has_install_phase()
-
     def options_specified(self):
         """
         Return True if some explicit install option was actually passed in
         """
         if self._no_install:
             return True
-        return self.has_install_phase()
+        return self.requires_postboot_xml_changes()
 
     def detect_distro(self, guest):
         """
@@ -614,7 +609,7 @@ class Installer(object):
     def _build_xml(self, guest, meter):
         initial_xml = None
         final_xml = guest.get_xml()
-        if self._requires_postboot_xml_changes():
+        if self.requires_postboot_xml_changes():
             initial_xml, final_xml = self._build_postboot_xml(
                     guest, final_xml, meter)
         final_xml = self._pre_reinstall_xml or final_xml

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -870,7 +870,7 @@ def _wait_for_domain(installer, instdomain, autoconsole, waithandler):
         # User either:
         #   used --noautoconsole
         #   killed console and guest is still running
-        if not installer.has_install_phase():
+        if not installer.requires_postboot_xml_changes():
             return
 
         msg += "\n"
@@ -921,7 +921,7 @@ def _process_domain(domain, guest, installer, waithandler, autoconsole,
     if domain.isActive():
         return
 
-    if noreboot or not installer.has_install_phase():
+    if noreboot or not installer.requires_postboot_xml_changes():
         print_stdout(  # pragma: no cover
             _("You can restart your domain by running:\n  %s") %
             cli.virsh_start_cmd(guest))

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -438,10 +438,6 @@ def build_installer(options, guest, installdata):
         no_install = True
     elif options.boot_was_set:
         no_install = True
-    elif options.cloud_init:
-        no_install = True
-    elif options.unattended:
-        no_install = True
 
     installer = virtinst.Installer(guest.conn,
             cdrom=cdrom,


### PR DESCRIPTION
Patch 1 comment is below. Patch 2 is a cleanup on top.

This basically reverts this commit from virt-manager 4.0.0

```
commit https://github.com/virt-manager/virt-manager/commit/825ec644b859b99d6f9f155b04ef3ac07eca1fc2
Author: Cole Robinson <crobinso@redhat.com>
Date:   Tue Mar 1 10:32:01 2022 -0500

    installer: Do not force reboot with --cloud-init

    Resolves: https://github.com/virt-manager/virt-manager/issues/189
```

After that commit, using `--cloud-init` or `--unattended` would
basically imply `--noreboot`

For some usage of `--cloud-init`, like in the initial report, this
makes sense to do. virt-install will drop you into the cloud image,
you mess without, run `poweroff`, and are surprised when virt-install
reboots the VM. I agreed, and made the change

But changing this was a bad idea.

cloud-init and unattended VMs have 2 XML phases. First XML is booting
off temporary media (the generated cloudinit iso), second XML is the
permanent boot config (booting off disk). We need to force the VM
to fully poweroff, so that the second XML config takes effect. We
make that happen with `<on_reboot>destroy</on_reboot>`, which tells
libvirt/qemu to poweroff the VM when it receives a guest reboot
notification. virt-install then defaults to restarting the VM when
it detects shutdown, to manually replicate the VM requested reboot,
but still get the second XML config to take effect.

The perennial problem with this is that, from outside the VM, we
don't know if the user inside the VM requested `poweroff` or `reboot`.
virt-install emulates the reboot behavior, and provides `--noreboot`
to override it. It's still confusing if a user puts a `poweroff`
command at the end of an anaconda kickstart file, and sees the VM
reboot, but it's been that way forever.

Except with that commit above, we flipped it for --cloud-init and
--unattended. Now, users who do `poweroff` are getting expected
behavior, but users who request `reboot` are not.

We could go further and add a `--yesreboot` option or similar. But
for consistency sake I think we should just revert that behavior,
and tell users to use --noreboot like usual.

Resolves: https://github.com/virt-manager/virt-manager/issues/497