### PR TITLE
virt-manager fork + ssh changes

### DIFF
--- a/man/virt-manager.rst
+++ b/man/virt-manager.rst
@@ -58,6 +58,11 @@ The following options are accepted when running ``virt-manager``
     current terminal. Useful for seeing possible errors dumped to stdout/stderr.
 
 
+``--fork``
+    Force forking ``virt-manager`` off into the background.
+    This is the default behavior.
+
+
 DIALOG WINDOW OPTIONS
 =====================
 

--- a/man/virt-manager.rst
+++ b/man/virt-manager.rst
@@ -108,13 +108,10 @@ manual ``--connect`` URI. But it supports ``--connect`` URI as well:
 VIRT-MANAGER, SSH, AND FORKING
 ==============================
 
-On startup virt-manager will detach from the running
-terminal and fork into the background. This is to force any usage of
-ssh to call ssh-askpass when it needs a password, rather than silently
+Historically, on startup virt-manager would detach from the running
+terminal and fork into the background. This was to force any usage of
+ssh to call ssh-askpass when it needed a password, rather than silently
 asking on a terminal the user probably isn't watching.
-
-Users can opt out of this forking behavior with ``--no-fork``, or
-by setting the ``VIRT_MANAGER_DEFAULT_FORK=no`` environment variable.
 
 openssh 8.4p1 released in Sep 2020 added the SSH_ASKPASS_REQUIRE
 environment variable that saves us from having to do the fork dance.
@@ -124,9 +121,10 @@ virt-manager now sets SSH_ASKPASS_REQUIRE=force.
 However to get this to work with libvirt ssh connections, you'll need
 libvirt 10.8.0 released in October 1st 2024.
 
-In the future, virt-manager will likely stop forking by default.
-You can future proof request forking with ``--fork`` or by
-settings the ``VIRT_MANAGER_DEFAULT_FORK=yes`` environment variable.
+virt-manager no longer forks by defaults.
+
+You can get the old forking behavior with the ``--fork`` option,
+or by setting the ``VIRT_MANAGER_DEFAULT_FORK=yes`` environment variable.
 
 However if you find you need forking for a usecase other than temporarily
 working around libvirt version issues, please let the virt-manager developers

--- a/man/virt-manager.rst
+++ b/man/virt-manager.rst
@@ -54,13 +54,14 @@ The following options are accepted when running ``virt-manager``
 
 
 ``--no-fork``
-    Don't fork ``virt-manager`` off into the background: run it blocking the
-    current terminal. Useful for seeing possible errors dumped to stdout/stderr.
+    Don't fork ``virt-manager`` off into the background.
+    See ``VIRT-MANAGER, SSH, AND FORKING`` section for more info.
 
 
 ``--fork``
     Force forking ``virt-manager`` off into the background.
     This is the default behavior.
+    See ``VIRT-MANAGER, SSH, AND FORKING`` section for more info.
 
 
 DIALOG WINDOW OPTIONS
@@ -102,6 +103,34 @@ manual ``--connect`` URI. But it supports ``--connect`` URI as well:
 
 ``--show-systray``
     Launch virt-manager only in system tray
+
+
+VIRT-MANAGER, SSH, AND FORKING
+==============================
+
+On startup virt-manager will detach from the running
+terminal and fork into the background. This is to force any usage of
+ssh to call ssh-askpass when it needs a password, rather than silently
+asking on a terminal the user probably isn't watching.
+
+Users can opt out of this forking behavior with ``--no-fork``, or
+by setting the ``VIRT_MANAGER_DEFAULT_FORK=no`` environment variable.
+
+openssh 8.4p1 released in Sep 2020 added the SSH_ASKPASS_REQUIRE
+environment variable that saves us from having to do the fork dance.
+https://man.openbsd.org/ssh.1#SSH_ASKPASS_REQUIRE
+
+virt-manager now sets SSH_ASKPASS_REQUIRE=force.
+However to get this to work with libvirt ssh connections, you'll need
+libvirt 10.8.0 released in October 1st 2024.
+
+In the future, virt-manager will likely stop forking by default.
+You can future proof request forking with ``--fork`` or by
+settings the ``VIRT_MANAGER_DEFAULT_FORK=yes`` environment variable.
+
+However if you find you need forking for a usecase other than temporarily
+working around libvirt version issues, please let the virt-manager developers
+know by filing a bug report.
 
 
 BUGS

--- a/tests/uitests/lib/app.py
+++ b/tests/uitests/lib/app.py
@@ -296,13 +296,13 @@ class VMMDogtailApp(object):
     def open(self, uri=None,
             extra_opts=None, check_already_running=True, use_uri=True,
             window_name=None, xmleditor_enabled=False, keyfile=None,
-            break_setfacl=False, first_run=True, no_fork=True,
+            break_setfacl=False, first_run=True,
             will_fail=False, enable_libguestfs=False,
-            firstrun_uri=None, show_console=None):
+            firstrun_uri=None, show_console=None, allow_debug=True):
         extra_opts = extra_opts or []
         uri = uri or self.uri
 
-        if tests.utils.TESTCONFIG.debug and no_fork:
+        if allow_debug and tests.utils.TESTCONFIG.debug:
             stdout = sys.stdout
             stderr = sys.stderr
             extra_opts.append("--debug")
@@ -312,8 +312,6 @@ class VMMDogtailApp(object):
 
         cmd = [sys.executable]
         cmd += [os.path.join(tests.utils.TOPDIR, "virt-manager")]
-        if no_fork:
-            cmd += ["--no-fork"]
         if use_uri:
             cmd += ["--connect", uri]
         if show_console:

--- a/tests/uitests/test_cli.py
+++ b/tests/uitests/test_cli.py
@@ -188,18 +188,31 @@ def testCLINoFirstRun(app):
     lib.utils.check(lambda: app.topwin.showing)
 
 
-def testCLINoFork(app):
-    # Test app without forking
+def _testCLIFork(app, opts):
     app.open(first_run=False, enable_libguestfs=None,
-            use_uri=False, no_fork=False)
+            use_uri=False, allow_debug=False,
+            extra_opts=opts)
     app.wait_for_exit()
+    lib.utils.check(lambda: app.has_dbus())
     app.topwin.window_close()
     lib.utils.check(lambda: not app.has_dbus())
 
 
+def testCLIFork(app):
+    # Test app with --fork
+    _testCLIFork(app, ["--fork"])
+
+
+@unittest.mock.patch.dict('os.environ', {"VIRT_MANAGER_DEFAULT_FORK": "yes"})
+def testCLIForkEnv(app):
+    # Test with fork via env
+    _testCLIFork(app, [])
+
+
 def testCLIGTKArgs(app):
     # Ensure gtk arg passthrough works
-    app.open(extra_opts=["--gtk-debug=misc"])
+    # Also test --no-fork is a no-op
+    app.open(extra_opts=["--gtk-debug=misc", "--no-fork"])
     lib.utils.check(lambda: app.topwin.showing)
 
 

--- a/virtManager/virtmanager.py
+++ b/virtManager/virtmanager.py
@@ -185,6 +185,12 @@ def main():
     # With F27 gnome+wayland we need to set these before GTK import
     os.environ["GSETTINGS_SCHEMA_DIR"] = BuildConfig.gsettings_dir
 
+    # Force SSH to use askpass if a password is required,
+    # rather than possibly prompting on a terminal the user isn't looking at.
+    os.environ.setdefault("SSH_ASKPASS_REQUIRE", "force")
+    log.debug("Using SSH_ASKPASS_REQUIRE=%s",
+              os.environ["SSH_ASKPASS_REQUIRE"])
+
     # Now we've got basic environment up & running we can fork
     do_drop_stdio = False
     if not options.no_fork and not options.debug:

--- a/virtManager/virtmanager.py
+++ b/virtManager/virtmanager.py
@@ -124,6 +124,17 @@ def do_we_fork(options):
     if options.fork:
         return True
 
+    key = "VIRT_MANAGER_DEFAULT_FORK"
+    val = os.environ.get(key, None)
+    if val == "yes":
+        log.debug("%s=%s, defaulting to --fork", key, val)
+        return True
+    if val == "no":
+        log.debug("%s=%s, defaulting to --no-fork", key, val)
+        return False
+    if val:
+        log.warning("Unknown %s=%s, expected 'yes' or 'no'", key, val)
+
     # Default is `--fork`
     return True
 

--- a/virtManager/virtmanager.py
+++ b/virtManager/virtmanager.py
@@ -135,8 +135,8 @@ def do_we_fork(options):
     if val:
         log.warning("Unknown %s=%s, expected 'yes' or 'no'", key, val)
 
-    # Default is `--fork`
-    return True
+    # Default is `--no-fork`
+    return False
 
 
 def parse_commandline():

--- a/virtManager/virtmanager.py
+++ b/virtManager/virtmanager.py
@@ -129,10 +129,10 @@ def do_we_fork(options):
     if val == "yes":
         log.debug("%s=%s, defaulting to --fork", key, val)
         return True
-    if val == "no":
+    if val == "no":  # pragma: no cover
         log.debug("%s=%s, defaulting to --no-fork", key, val)
         return False
-    if val:
+    if val:  # pragma: no cover
         log.warning("Unknown %s=%s, expected 'yes' or 'no'", key, val)
 
     # Default is `--no-fork`


### PR DESCRIPTION
This changes some of the bits I discussed in https://github.com/virt-manager/virt-manager/issues/731

* Add `SSH_ASKPASS_REQUIRE=force` by default
* Add a stub `--fork` option
* Add `VIRT_MANAGER_DEFAULT_FORK=yes|no` env variable to opt into specific forking behavior
* Document it all in the man page
* Switch the default from `--fork` to `--no-fork`

Everything before the default switch is a no brainer. Question is do we want to switch the fork default now, or hold off. 

I think the only people that may be unknowingly depending on fork behavior are users who 1) use ssh-askpass and 2) launch virt-manager from the terminal. That may in fact be zero users.

The argument against switching the default is 1) I might have missed a usecase and this will generate unexpected complaints, 2) the SSH_ASKPASS_REQUIRE workaround requires brand spanking new libvirt. Neither of those really bother me because again I think in practice there's very few users this will matter for, and there's a relatively easy escape hatch with the VIRT_MANAGER_DEFAULT_FORK env variable.

@phrdina @berrange thoughts?