### PR TITLE
Update setup.py to allow PEP 517 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,5 @@
 
 /data/gschemas.compiled
 
-/man/virt-manager.1
-/man/virt-install.1
-/man/virt-clone.1
-/man/virt-xml.1
-
 /virt-manager.spec
 /virtinst/build.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.pyc
 *.gmo
+*.egg-info
 
 /build
 /dist

--- a/setup.py
+++ b/setup.py
@@ -251,14 +251,6 @@ from %(pkgname)s import %(filename)s
         super().run()
 
 
-class my_egg_info(setuptools.command.install_egg_info.install_egg_info):
-    """
-    Disable egg_info installation, seems pointless for a non-library
-    """
-    def run(self):
-        pass
-
-
 class my_install(setuptools.command.install.install):
     user_options = setuptools.command.install.install.user_options + [
         ("no-update-icon-cache", None, "Don't run gtk-update-icon-cache"),
@@ -497,7 +489,6 @@ setuptools.setup(
         'build_i18n': my_build_i18n,
 
         'install': my_install,
-        'install_egg_info': my_egg_info,
 
         'pylint': CheckPylint,
         'rpm': my_rpm,

--- a/setup.py
+++ b/setup.py
@@ -178,11 +178,14 @@ from %(pkgname)s import %(filename)s
         if not rstbin:
             sys.exit("Didn't find rst2man or rst2man.py")
 
+        mandir = os.path.join(self.build_base, "man")
+        if not os.path.exists(mandir):
+            os.mkdir(mandir)
+
         for path in glob.glob("man/*.rst"):
             base = os.path.basename(path)
             appname = os.path.splitext(base)[0]
-            newpath = os.path.join(os.path.dirname(path),
-                                   appname + ".1")
+            newpath = os.path.join(mandir, appname + ".1")
 
             print("Generating %s" % newpath)
             out = subprocess.check_output([rstbin, "--strict", path])
@@ -456,10 +459,10 @@ setuptools.setup(
         ("share/virt-manager/ui", glob.glob("ui/*.ui")),
 
         ("share/man/man1", [
-            "man/virt-manager.1",
-            "man/virt-install.1",
-            "man/virt-clone.1",
-            "man/virt-xml.1"
+            "build/man/virt-manager.1",
+            "build/man/virt-install.1",
+            "build/man/virt-clone.1",
+            "build/man/virt-xml.1"
         ]),
 
         ("share/virt-manager/virtManager", glob.glob("virtManager/*.py")),

--- a/setup.py
+++ b/setup.py
@@ -260,15 +260,25 @@ class my_egg_info(setuptools.command.install_egg_info.install_egg_info):
 
 
 class my_install(setuptools.command.install.install):
+    user_options = setuptools.command.install.install.user_options + [
+        ("no-update-icon-cache", None, "Don't run gtk-update-icon-cache"),
+        ("no-compile-schemas", None, "Don't compile gsettings schemas"),
+    ]
+
+    def initialize_options(self):
+        super().initialize_options()
+        self.no_update_icon_cache = False
+        self.no_compile_schemas = False
+
     def run(self):
         super().run()
 
-        if not self.distribution.no_update_icon_cache:
+        if not self.no_update_icon_cache:
             print("running gtk-update-icon-cache")
             icon_path = os.path.join(self.install_data, "share/icons/hicolor")
             self.spawn(["gtk-update-icon-cache", "-q", "-t", icon_path])
 
-        if not self.distribution.no_compile_schemas:
+        if not self.no_compile_schemas:
             print("compiling gsettings schemas")
             gschema_install = os.path.join(self.install_data,
                 "share/glib-2.0/schemas")
@@ -381,18 +391,6 @@ class CheckPylint(setuptools.Command):
             pylint_opts += ["--jobs=%d" % self.jobs]
 
         pylint.lint.Run(lintfiles + pylint_opts)
-
-
-class VMMDistribution(setuptools.dist.Distribution):
-    global_options = setuptools.dist.Distribution.global_options + [
-        ("no-update-icon-cache", None, "Don't run gtk-update-icon-cache"),
-        ("no-compile-schemas", None, "Don't compile gsettings schemas"),
-    ]
-
-    def __init__(self, *args, **kwargs):
-        self.no_update_icon_cache = False
-        self.no_compile_schemas = False
-        super().__init__(*args, **kwargs)
 
 
 class ExtractMessages(setuptools.Command):
@@ -508,6 +506,5 @@ setuptools.setup(
         'extract_messages': ExtractMessages,
     },
 
-    distclass=VMMDistribution,
     packages=[],
 )

--- a/setup.py
+++ b/setup.py
@@ -138,19 +138,17 @@ class my_build(BUILD_COMMAND_CLASS):
 
 import os
 import sys
-sys.path.insert(0, "%(sharepath)s")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "share", "virt-manager")))
 from %(pkgname)s import %(filename)s
 
 %(filename)s.runcli()
 """
         if not os.path.exists("build"):
             os.mkdir("build")
-        sharepath = os.path.join(BuildConfig.prefix, "share", "virt-manager")
 
         def make_script(pkgname, filename, toolname):
             assert os.path.exists(pkgname + "/" + filename + ".py")
             content = template % {
-                "sharepath": sharepath,
                 "pkgname": pkgname,
                 "filename": filename}
 

--- a/virt-manager.spec
+++ b/virt-manager.spec
@@ -114,8 +114,8 @@ machine).
 
 %install
 ./setup.py \
-    --no-update-icon-cache --no-compile-schemas \
-    install -O1 --root=%{buildroot}
+    install -O1 --root=%{buildroot} \
+    --no-update-icon-cache --no-compile-schemas
 %find_lang %{name}
 
 %if 0%{?py_byte_compile:1}

--- a/virt-manager.spec
+++ b/virt-manager.spec
@@ -108,7 +108,7 @@ machine).
 %global _default_hvs --default-hvs %{default_hvs}
 %endif
 
-./setup.py configure \
+./setup.py build \
     %{?_default_hvs}
 
 

--- a/virt-manager.spec
+++ b/virt-manager.spec
@@ -147,6 +147,7 @@ machine).
 
 %dir %{_datadir}/%{name}
 %{_datadir}/%{name}/virtinst
+%{python3_sitelib}/*
 
 
 %files -n virt-install

--- a/virtinst/buildconfig.py
+++ b/virtinst/buildconfig.py
@@ -31,6 +31,10 @@ _istest = "VIRTINST_TEST_SUITE" in os.environ
 _running_from_srcdir = os.path.exists(
     os.path.join(_srcdir, "tests", "test_cli.py"))
 
+# we know that this file is installed into $prefix/share/virt-manager/virtinst
+# so we can figure use do $prefix/share/virt-manager/../..
+_prefix = os.path.abspath(os.path.join(_srcdir, "..", ".."))
+
 
 def _split_list(commastr):
     return [d for d in commastr.split(",") if d]
@@ -56,28 +60,27 @@ class _BuildConfig(object):
         self.default_graphics = _get_param("default_graphics", "spice")
         self.default_hvs = _split_list(_get_param("default_hvs", ""))
 
-        self.prefix = None
+        self.prefix = _prefix
         self.gettext_dir = None
         self.ui_dir = None
         self.icon_dir = None
         self.gsettings_dir = None
         self.running_from_srcdir = _running_from_srcdir
-        self._set_paths_by_prefix(_get_param("prefix", "/usr"))
+        self._set_paths_by_prefix()
 
 
-    def _set_paths_by_prefix(self, prefix):
-        self.prefix = prefix
-        self.gettext_dir = os.path.join(prefix, "share", "locale")
+    def _set_paths_by_prefix(self):
+        self.gettext_dir = os.path.join(self.prefix, "share", "locale")
 
         if self.running_from_srcdir:
             self.ui_dir = os.path.join(_srcdir, "ui")
             self.icon_dir = os.path.join(_srcdir, "data")
             self.gsettings_dir = self.icon_dir
         else:  # pragma: no cover
-            self.ui_dir = os.path.join(prefix, "share", "virt-manager", "ui")
-            self.icon_dir = os.path.join(prefix, "share", "virt-manager",
+            self.ui_dir = os.path.join(self.prefix, "share", "virt-manager", "ui")
+            self.icon_dir = os.path.join(self.prefix, "share", "virt-manager",
                 "icons")
-            self.gsettings_dir = os.path.join(prefix, "share",
+            self.gsettings_dir = os.path.join(self.prefix, "share",
                 "glib-2.0", "schemas")
 
 


### PR DESCRIPTION
This implements smallest possible changes to current setuptools build system in order allow PEP 517 builds.

Key changes with the new python build system:
- We cannot figure out prefix when building/installing virt-manager due to the fact how the build system works and packages are installed using pip. Now it will always create a wheel which contains installed data and during installation it is simply unpacked to the destination so we need to figure out prefix during runtime.
- I did not made the changes but according to documentation we must not use `setup.py` directly which means we would have to drop our custom commands and implement it some other way.

Because of the limitation and IMHO backwards step in the python build system I've also created PR https://github.com/virt-manager/virt-manager/pull/742 that introduces Meson instead of setuptools.

Fixes: https://github.com/virt-manager/virt-manager/issues/652