### PR TITLE
switch console default to Scale Display->Always

### DIFF
--- a/data/org.virt-manager.virt-manager.gschema.xml
+++ b/data/org.virt-manager.virt-manager.gschema.xml
@@ -206,7 +206,7 @@
   <schema id="org.virt-manager.virt-manager.console"
           path="/org/virt-manager/virt-manager/console/">
     <key name="scaling" type="i">
-      <default>1</default>
+      <default>2</default>
       <summary>When to scale the VM graphical console</summary>
       <description>When to scale the VM graphical console. 0 = never, 1 = only when in full screen mode, 2 = Always</description>
     </key>

--- a/tests/uitests/test_livetests.py
+++ b/tests/uitests/test_livetests.py
@@ -113,6 +113,10 @@ def _checkConsoleStandard(app, dom):
     # 'Resize to VM' testing
     oldsize = win.size
     win.find("^View$", "menu").click()
+    scalemenu = win.find("Scale Display", "menu")
+    scalemenu.point()
+    scalemenu.find("Never", "radio menu item").click()
+    win.find("^View$", "menu").click()
     win.find("Resize to VM", "menu item").click()
     newsize = win.size
     lib.utils.check(lambda: oldsize != newsize)
@@ -149,10 +153,6 @@ def _checkConsoleStandard(app, dom):
 
     # Tweak scaling
     win.window_maximize()
-    win.find("^View$", "menu").click()
-    scalemenu = win.find("Scale Display", "menu")
-    scalemenu.point()
-    scalemenu.find("Never", "radio menu item").click()
     win.find("^View$", "menu").click()
     scalemenu = win.find("Scale Display", "menu")
     scalemenu.point()

--- a/tests/uitests/test_prefs.py
+++ b/tests/uitests/test_prefs.py
@@ -50,7 +50,7 @@ def testPrefsAll(app):
     tab.check_onscreen()
     tab.combo_select("SPICE USB", "Manual redirect")
     tab.combo_select("Resize guest", "On")
-    tab.combo_select("Graphical console scaling", "Always")
+    tab.combo_select("Graphical console scaling", "Never")
     tab.find("Console autoconnect", "check box").click()
 
     tab.find("Change...", "push button").click()


### PR DESCRIPTION
I think this is a better default than the current `Only when Fullscreen`, which is the same as `Never` for VM windowed mode.

I wrote my reasoning here:
https://github.com/virt-manager/virt-manager/issues/747
