### PR TITLE
ci: tweak Packit configuration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,8 +12,4 @@ jobs:
     trigger: pull_request
     # Defaults to x86_64 unless architecture is explicitly specified
     targets:
-      - fedora-rawhide-aarch64
-      - fedora-rawhide-i386
-      - fedora-rawhide-ppc64le
-      - fedora-rawhide-s390x
-      - fedora-rawhide-x86_64
+      - fedora-all


### PR DESCRIPTION
- drop all the architectures (and thus building only on x86_64): virt-manager has no architecture-specific installation bits, and thus it builds in the same way on every architecture; hence no need to explicitly test on various architectures
- test on all the supported Fedora versions (Rawhide included): this way it is possible to check that older versions are still supported, at least when building