### PR TITLE
Add `--boot uefi=off`

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -956,11 +956,14 @@ Some examples:
     has been specified, virt-install will default to /sbin/init, otherwise
     will default to /bin/sh.
 
-``--boot uefi``
+``--boot uefi``, ``--boot uefi=on``
     Configure the VM to boot from UEFI. In order for virt-install to know the
     correct UEFI parameters, libvirt needs to be advertising known UEFI binaries
     via domcapabilities XML, so this will likely only work if using properly
     configured distro packages. This is the recommended UEFI setup.
+
+``--boot uefi=off``
+    Do not use UEFI if the VM would normally default to it.
 
 ``--boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=yes,firmware.feature1.name=enrolled-keys,firmware.feature1.enabled=yes``
     Configure the VM to boot from UEFI with Secure Boot support enabled.

--- a/tests/data/cli/compare/virt-install-win11-no-uefi.xml
+++ b/tests/data/cli/compare/virt-install-win11-no-uefi.xml
@@ -1,0 +1,192 @@
+<domain type="kvm">
+  <name>win11</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://microsoft.com/win/11"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>4</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="cdrom"/>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <hyperv>
+      <relaxed state="on"/>
+      <vapic state="on"/>
+      <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
+    </hyperv>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="localtime">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+    <timer name="hypervclock" present="yes"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/var/lib/libvirt/images/win11.qcow2"/>
+      <target dev="sda" bus="sata"/>
+    </disk>
+    <disk type="file" device="cdrom">
+      <driver name="qemu" type="qcow2"/>
+      <source file="/pool-dir/testvol1.img"/>
+      <target dev="sdb" bus="sata"/>
+      <readonly/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000e"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="qxl"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+  <on_reboot>destroy</on_reboot>
+</domain>
+<domain type="kvm">
+  <name>win11</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://microsoft.com/win/11"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>4</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <hyperv>
+      <relaxed state="on"/>
+      <vapic state="on"/>
+      <spinlocks state="on" retries="8191"/>
+      <vpindex state="on"/>
+      <runtime state="on"/>
+      <synic state="on"/>
+      <stimer state="on"/>
+      <frequencies state="on"/>
+      <tlbflush state="on"/>
+      <ipi state="on"/>
+      <evmcs state="on"/>
+      <avic state="on"/>
+    </hyperv>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="localtime">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+    <timer name="hypervclock" present="yes"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/var/lib/libvirt/images/win11.qcow2"/>
+      <target dev="sda" bus="sata"/>
+    </disk>
+    <disk type="file" device="cdrom">
+      <driver name="qemu" type="qcow2"/>
+      <source file="/pool-dir/testvol1.img"/>
+      <target dev="sdb" bus="sata"/>
+      <readonly/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000e"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="qxl"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-xml-edit-boot-uefi-off.xml
+++ b/tests/data/cli/compare/virt-xml-edit-boot-uefi-off.xml
@@ -1,0 +1,20 @@
+   <memory unit="KiB">134217728</memory>
+   <currentMemory unit="KiB">67108864</currentMemory>
+   <vcpu placement="static">2</vcpu>
+-  <os firmware="efi">
++  <os>
+     <type arch="i686">hvm</type>
+-    <firmware>
+-      <feature enabled="yes" name="enrolled-keys"/>
+-      <feature enabled="yes" name="secure-boot"/>
+-    </firmware>
+-    <loader readonly="yes" secure="yes" type="pflash" format="qcow2">/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd.qcow2</loader>
+-    <nvram template="/usr/share/OVMF/OVMF_VARS.fd.qcow2" type="file" format="qcow2">
+-      <source file="/var/lib/libvirt/nvram/guest_VARS.fd"/>
+-    </nvram>
+     <boot dev="hd"/>
+   </os>
+   <cpu mode="host-model"/>
+
+Domain 'test-alternate-devs' defined successfully.
+Changes will take effect after the domain is fully powered off.

--- a/tests/data/testdriver/testdriver.xml
+++ b/tests/data/testdriver/testdriver.xml
@@ -718,7 +718,15 @@ test-many-devices, like an alternate RNG, EOL OS ID, title field
   <vcpu>2</vcpu>
   <cpu mode='host-model'/>
   <os firmware='efi'>
+    <firmware>
+      <feature enabled='yes' name='enrolled-keys'/>
+      <feature enabled='yes' name='secure-boot'/>
+    </firmware>
     <type arch='i686'>hvm</type>
+    <loader format="qcow2" readonly='yes' secure='yes' type='pflash'>/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd.qcow2</loader>
+    <nvram type='file' format='qcow2' template='/usr/share/OVMF/OVMF_VARS.fd.qcow2'>
+      <source file='/var/lib/libvirt/nvram/guest_VARS.fd'/>
+    </nvram>
     <boot dev='hd'/>
   </os>
   <clock offset='utc'/>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1446,7 +1446,7 @@ c.add_compare("--confirm 1 --edit --cpu host-passthrough", "prompt-response", in
 c.add_compare("--edit --print-diff --qemu-commandline clearxml=yes", "edit-clearxml-qemu-commandline", input_file=(_VIRTXMLDIR + "virtxml-qemu-commandline-clear.xml"))
 c.add_compare("--print-diff --remove-device --serial 1", "remove-console-dup", input_file=(_VIRTXMLDIR + "virtxml-console-dup.xml"))
 c.add_compare("--print-diff --define --connect %(URI-KVM-X86)s test --edit --boot uefi", "edit-boot-uefi")
-c.add_invalid("--print-diff --define --connect %(URI-KVM-X86)s test-alternate-devs --edit --boot uefi=off", grep="NotImplementedError")
+c.add_compare("--print-diff --define --connect %(URI-KVM-X86)s test-alternate-devs --edit --boot uefi=off", "edit-boot-uefi-off")
 c.add_compare("--print-diff --define --connect %(URI-KVM-X86)s test-many-devices --edit --cpu host-copy", "edit-cpu-host-copy", precompare_check="10.1.0")
 c.add_compare("--connect %(URI-KVM-X86)s test-many-devices --build-xml --disk source.pool=pool-disk,source.volume=sdfg1", "build-pool-logical-disk")
 c.add_compare("test --add-device --network default --update --confirm", "update-succeed", env={"VIRTXML_TESTSUITE_UPDATE_IGNORE_FAIL": "1", "VIRTINST_TEST_SUITE_INCREMENT_MACADDR": "1"}, input_text="yes\nyes\n")  # test hotplug success

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1151,7 +1151,7 @@ c.add_compare("--os-variant name=ubuntusaucy --nodisks --boot cdrom --virt-type 
 c.add_compare("--os-variant fedora20 --nodisks --boot network --graphics default --arch i686 --rng none", "qemu-32-on-64", prerun_check=has_old_osinfo)  # 32 on 64
 c.add_compare("--osinfo linux2020 --pxe", "linux2020", prerun_check=no_osinfo_linux2020_virtio)
 c.add_compare("--check disk_size=off --osinfo win11 --cdrom %(EXISTIMG1)s", "win11", prerun_check=no_osinfo_win11)
-c.add_invalid("--check disk_size=off --osinfo win11 --cdrom %(EXISTIMG1)s --boot uefi=off", grep="NotImplementedError")
+c.add_compare("--check disk_size=off --osinfo win11 --cdrom %(EXISTIMG1)s --boot uefi=off", "win11-no-uefi")
 c.add_compare("--osinfo generic --disk none --location %(ISO-NO-OS)s,kernel=frib.img,initrd=/frob.img", "location-manual-kernel", prerun_check=missing_xorriso)  # --location with an unknown ISO but manually specified kernel paths
 c.add_compare("--disk %(EXISTIMG1)s --location %(ISOTREE)s --nonetworks", "location-iso", prerun_check=missing_xorriso)  # Using --location iso mounting
 c.add_compare("--disk %(EXISTIMG1)s --location %(ISOTREE)s --nonetworks --cloud-init user-data=%(XMLDIR)s/cloudinit/user-data.txt,meta-data=%(XMLDIR)s/cloudinit/meta-data.txt", "location-iso-and-cloud-init", prerun_check=missing_xorriso)  # Using --location iso mounting and --cloud-init at the same time

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1151,6 +1151,7 @@ c.add_compare("--os-variant name=ubuntusaucy --nodisks --boot cdrom --virt-type 
 c.add_compare("--os-variant fedora20 --nodisks --boot network --graphics default --arch i686 --rng none", "qemu-32-on-64", prerun_check=has_old_osinfo)  # 32 on 64
 c.add_compare("--osinfo linux2020 --pxe", "linux2020", prerun_check=no_osinfo_linux2020_virtio)
 c.add_compare("--check disk_size=off --osinfo win11 --cdrom %(EXISTIMG1)s", "win11", prerun_check=no_osinfo_win11)
+c.add_invalid("--check disk_size=off --osinfo win11 --cdrom %(EXISTIMG1)s --boot uefi=off", grep="NotImplementedError")
 c.add_compare("--osinfo generic --disk none --location %(ISO-NO-OS)s,kernel=frib.img,initrd=/frob.img", "location-manual-kernel", prerun_check=missing_xorriso)  # --location with an unknown ISO but manually specified kernel paths
 c.add_compare("--disk %(EXISTIMG1)s --location %(ISOTREE)s --nonetworks", "location-iso", prerun_check=missing_xorriso)  # Using --location iso mounting
 c.add_compare("--disk %(EXISTIMG1)s --location %(ISOTREE)s --nonetworks --cloud-init user-data=%(XMLDIR)s/cloudinit/user-data.txt,meta-data=%(XMLDIR)s/cloudinit/meta-data.txt", "location-iso-and-cloud-init", prerun_check=missing_xorriso)  # Using --location iso mounting and --cloud-init at the same time
@@ -1170,7 +1171,7 @@ c.add_compare("--connect " + utils.URIs.kvm_x86_remote + " --import --disk %(EXI
 c.add_compare("--connect %(URI-KVM-X86)s --os-variant fedora26 --graphics spice --controller usb,model=none", "graphics-usb-disable")
 c.add_compare("--osinfo generic --boot uefi --disk size=1", "boot-uefi")
 c.add_compare("--osinfo generic --boot uefi --disk size=1 --tpm none --connect " + utils.URIs.kvm_x86_oldfirmware, "boot-uefi-oldcaps")
-c.add_compare("--osinfo linux2020 --boot uefi --launchSecurity sev --connect " + utils.URIs.kvm_amd_sev, "amd-sev", prerun_check=no_osinfo_linux2020_virtio)
+c.add_compare("--osinfo linux2020 --boot uefi=on --launchSecurity sev --connect " + utils.URIs.kvm_amd_sev, "amd-sev", prerun_check=no_osinfo_linux2020_virtio)
 
 c.add_invalid("--disk none --location nfs:example.com/fake --nonetworks", grep="NFS URL installs are no longer supported")
 c.add_invalid("--disk none --boot network --machine foobar", grep="domain type None with machine 'foobar'")
@@ -1445,6 +1446,7 @@ c.add_compare("--confirm 1 --edit --cpu host-passthrough", "prompt-response", in
 c.add_compare("--edit --print-diff --qemu-commandline clearxml=yes", "edit-clearxml-qemu-commandline", input_file=(_VIRTXMLDIR + "virtxml-qemu-commandline-clear.xml"))
 c.add_compare("--print-diff --remove-device --serial 1", "remove-console-dup", input_file=(_VIRTXMLDIR + "virtxml-console-dup.xml"))
 c.add_compare("--print-diff --define --connect %(URI-KVM-X86)s test --edit --boot uefi", "edit-boot-uefi")
+c.add_invalid("--print-diff --define --connect %(URI-KVM-X86)s test-alternate-devs --edit --boot uefi=off", grep="NotImplementedError")
 c.add_compare("--print-diff --define --connect %(URI-KVM-X86)s test-many-devices --edit --cpu host-copy", "edit-cpu-host-copy", precompare_check="10.1.0")
 c.add_compare("--connect %(URI-KVM-X86)s test-many-devices --build-xml --disk source.pool=pool-disk,source.volume=sdfg1", "build-pool-logical-disk")
 c.add_compare("test --add-device --network default --update --confirm", "update-succeed", env={"VIRTXML_TESTSUITE_UPDATE_IGNORE_FAIL": "1", "VIRTINST_TEST_SUITE_INCREMENT_MACADDR": "1"}, input_text="yes\nyes\n")  # test hotplug success

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -711,11 +711,7 @@ class vmmDomain(vmmLibvirtObject):
                 # preserve NVRAM paths, so skip clearing all the properties
                 # and let libvirt do it for us.
                 if firmware is None:
-                    # Implies 'default', so clear everything
-                    guest.os.loader_ro = None
-                    guest.os.loader_type = None
-                    guest.os.nvram = None
-                    guest.os.nvram_template = None
+                    guest.disable_uefi()
             else:
                 # Implies UEFI
                 guest.set_uefi_path(loader)

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2825,8 +2825,8 @@ class ParserBoot(VirtCLIParser):
         self._convert_boot_order(inst)
 
         # Back compat to allow uefi to have no cli value specified
-        if "uefi" in self.optdict:
-            self.optdict["uefi"] = True
+        if self.optdict.get("uefi", -1) is None:
+            self.optdict["uefi"] = "on"
 
         return super()._parse(inst)
 
@@ -2840,6 +2840,10 @@ class ParserBoot(VirtCLIParser):
             self.guest.refresh_machine_type()
 
     def set_uefi_cb(self, inst, val, virtarg):
+        val = _on_off_convert("uefi", val)
+        if not val:
+            raise NotImplementedError()
+
         if not self.editing:
             # From virt-install, we just set this flag, and set_defaults()
             # will fill in everything for us, otherwise we have a circular

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2841,15 +2841,15 @@ class ParserBoot(VirtCLIParser):
 
     def set_uefi_cb(self, inst, val, virtarg):
         val = _on_off_convert("uefi", val)
-        if not val:
-            raise NotImplementedError()
 
         if not self.editing:
             # From virt-install, we just set this flag, and set_defaults()
             # will fill in everything for us, otherwise we have a circular
             # dep on determining arch/machine info
-            self.guest.uefi_requested = True
+            self.guest.uefi_requested = val
         else:
+            if not val:
+                raise NotImplementedError()
             self.guest.enable_uefi()
 
     def set_initargs_cb(self, inst, val, virtarg):

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2849,8 +2849,9 @@ class ParserBoot(VirtCLIParser):
             self.guest.uefi_requested = val
         else:
             if not val:
-                raise NotImplementedError()
-            self.guest.enable_uefi()
+                self.guest.disable_uefi()
+            else:
+                self.guest.enable_uefi()
 
     def set_initargs_cb(self, inst, val, virtarg):
         inst.set_initargs_string(val)

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -221,7 +221,7 @@ class Guest(XMLBuilder):
         self.num_pcie_root_ports = 14
 
         self.skip_default_osinfo = False
-        self.uefi_requested = False
+        self.uefi_requested = None
         self.__osinfo = None
         self._capsinfo = None
         self._domcaps = None
@@ -1038,6 +1038,9 @@ class Guest(XMLBuilder):
         return path
 
     def _set_default_uefi(self):
+        if self.uefi_requested is False:
+            return
+
         use_default_uefi = (self.prefers_uefi() and
             not self.os.kernel and
             not self.os.loader and

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -600,6 +600,22 @@ class Guest(XMLBuilder):
         log.debug("Setting default UEFI path=%s", path)
         self.set_uefi_path(path)
 
+    def disable_uefi(self):
+        self.os.firmware = None
+        self.os.loader = None
+        self.os.loader_ro = None
+        self.os.loader_type = None
+        self.os.loader_secure = None
+        self.os.nvram = None
+        self.os.nvram_template = None
+        for feature in self.os.firmware_features:
+            self.os.remove_child(feature)
+
+        # Force remove any properties we don't know about
+        self._xmlstate.xmlapi.node_force_remove("./os/firmware")
+        self._xmlstate.xmlapi.node_force_remove("./os/nvram")
+        self._xmlstate.xmlapi.node_force_remove("./os/loader")
+
     def has_spice(self):
         for gfx in self.devices.graphics:
             if gfx.type == gfx.TYPE_SPICE:


### PR DESCRIPTION
Add `--boot uefi=off` for opting out of uefi when virt-install would default to it, and for virt-xml to clear out all UEFI config for an existing VM

Resolves: https://github.com/virt-manager/virt-manager/issues/692