### PR TITLE
virt-install: use default `--cpu` mode more often

### DIFF
--- a/tests/data/cli/compare/virt-install-memory-hotplug.xml
+++ b/tests/data/cli/compare/virt-install-memory-hotplug.xml
@@ -18,7 +18,7 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu>
+  <cpu mode="host-passthrough">
     <numa>
       <cell cpus="0" memory="1048576"/>
     </numa>
@@ -162,7 +162,7 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu>
+  <cpu mode="host-passthrough">
     <numa>
       <cell cpus="0" memory="1048576"/>
     </numa>

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -450,9 +450,9 @@ class DomainCpu(XMLBuilder):
     def set_defaults(self, guest):
         if not self.conn.is_test() and not self.conn.is_qemu():
             return
-        if (self.get_xml().strip() or
-            self.special_mode_was_set):
-            # User already configured CPU
+        if self.special_mode_was_set:
+            return
+        if self.model or self.mode:
             return
 
         if guest.os.is_arm_machvirt() and guest.type == "kvm":


### PR DESCRIPTION
Currently we will only apply the default `--cpu mode=host-passthrough` config when _no_ `--cpu` config is passed. But this means if a user configures ex. cpu `<topology>`, we don't set `host-passthrough` and they get the libvirt/qemu default baseline CPU.

Instead, only skip the default config if the user manually specified a `mode` or `model` value directly

https://issues.redhat.com/browse/RHEL-65371