### PR TITLE
cli: add `--network portForward=8080:80` convenience syntax

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -1338,6 +1338,20 @@ Some example suboptions:
 
     For ``HOSTDEV`` format, see ``--hostdev`` documentation
 
+``portForward=[ADDRESS:]HOSTPORT[:GUESTPORT][/PROTO]``
+    Simpler option for specifying port forwarding with
+    ``--network passt`` networks. Roughly matches ``podman run -p``
+    syntax. HOSTPORT can be a represented as a range like ``7000-8000``, but
+    GUESTPORT can only be a single port. If GUESTPORT is not provided, host
+    and guest ports are assumed to match.
+
+    Examples:
+
+    .. code-block::
+
+           --network passt,portForward=8080:80 \
+           --network passt,portForward0=7000-8000/udp,portForward1=127.0.0.1:2222:22 \
+
 
 GRAPHICS OPTIONS
 ================

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -632,6 +632,44 @@
         <range start="2022" to="22"/>
       </portForward>
     </interface>
+    <interface type="user">
+      <backend type="passt"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+      <portForward proto="tcp">
+        <range start="8080" to="80"/>
+      </portForward>
+    </interface>
+    <interface type="user">
+      <backend type="passt"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+      <portForward proto="tcp">
+        <range start="8080"/>
+      </portForward>
+    </interface>
+    <interface type="user">
+      <backend type="passt"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+      <portForward proto="udp">
+        <range start="7000" end="8000"/>
+      </portForward>
+      <portForward proto="tcp" address="127.0.0.1">
+        <range start="2222" to="22"/>
+      </portForward>
+    </interface>
+    <interface type="user">
+      <backend type="passt"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+      <portForward proto="tcp" address="2001:db8:ac10:fd01::1:10">
+        <range start="3000" end="4000" to="30"/>
+      </portForward>
+      <portForward proto="tcp" address="127.0.0.1">
+        <range start="5000" end="6000" to="5"/>
+      </portForward>
+    </interface>
     <interface type="hostdev">
       <mac address="00:11:22:33:44:55"/>
       <model type="virtio"/>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,6 +653,10 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --network user,address.type=ccw,address.cssid=0xfe,address.ssid=0,address.devno=01,boot.order=15,boot.loadparm=SYSTEM1
 --network model=vmxnet3
 --network backend.type=passt,backend.logFile=/tmp/foo.log,portForward0.proto=tcp,portForward0.address=192.168.10.10,portForward0.dev=eth0,portForward0.range0.start=4000,portForward0.range0.end=5000,portForward0.range0.to=10000,portForward0.range0.exclude=no,portForward0.range1.start=6000,portForward1.proto=tcp,portForward1.range0.start=2022,portForward1.range0.to=22
+--network passt,portForward=8080:80
+--network passt,portForward=8080
+--network passt,portForward0=7000-8000/udp,portForward1=127.0.0.1:2222:22
+--network passt,portForward0=2001:db8:ac10:fd01::1:10:3000-4000:30,portForward1=127.0.0.1:5000-6000:5
 --network type=hostdev,source.address.type=pci,source.address.domain=0x0,source.address.bus=0x00,source.address.slot=0x07,source.address.function=0x0
 --network hostdev=pci_0000_00_09_0
 --network hostdev=0:0:4.0


### PR DESCRIPTION
Roughly mirroring `podman run -p` syntax. Example:

--network backend.type=passt,portForward=123:456,portForward1=127.0.0.1:8080:80/udp

Resolves: https://github.com/virt-manager/virt-manager/issues/751