### PR TITLE
cli, man: Always list --osinfo before --os-variant

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -1017,7 +1017,7 @@ GUEST OS OPTIONS
 ================
 
 
-``--os-variant``, ``--osinfo``
+``--osinfo``, ``--os-variant``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Syntax:** ``--osinfo`` [OSNAME|OPT1=VAL1,...]
@@ -1026,7 +1026,7 @@ Optimize the guest configuration for a specific operating system.
 For most cases, an OS must be specified or detected from the install
 media so performance critical features like virtio can be enabled.
 
-The simplest usage is ``--os-variant OSNAME`` or ``--osinfo OSNAME``,
+The simplest usage is ``--osinfo OSNAME`` or ``--os-variant OSNAME``,
 for example ``--osinfo fedora32``. The supported suboptions are:
 
 ``name=``, ``short-id=``
@@ -1071,7 +1071,7 @@ VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1.
 Use the command ``virt-install --osinfo list`` to get the list of the
 accepted OS variants. See ``osinfo-query os`` for even more output.
 
-Note: ``--os-variant`` and ``--osinfo`` are aliases for one another.
+Note: ``--osinfo`` and ``--os-variant`` are aliases for one another.
 ``--osinfo`` is the preferred new style naming.
 
 

--- a/man/virt-xml.rst
+++ b/man/virt-xml.rst
@@ -180,7 +180,7 @@ These options decide what action to take after altering the XML. In the common c
 GUEST OS OPTIONS
 ================
 
-``--os-variant``, ``--osinfo`` OS_VARIANT
+``--osinfo``, ``--os-variant`` OS_VARIANT
     Optimize the guest configuration for a specific operating system (ex.
     'fedora29', 'rhel7', 'win10'). While not required, specifying this
     options is HIGHLY RECOMMENDED, as it can greatly increase performance
@@ -194,7 +194,7 @@ GUEST OS OPTIONS
     Use the command ``virt-xml --osinfo list`` to get the list of the
     accepted OS variants. See ``osinfo-query os`` for even more output.
 
-    See virt-install(1) documentation for more details about ``--os-variant/--osinfo``
+    See virt-install(1) documentation for more details about ``--osinfo/--os-variant``
 
 
 CONVERSION OPTIONS

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1039,8 +1039,8 @@ c.add_compare("--connect %(URI-KVM-X86)s --install fedora26", "osinfo-url")  # g
 c.add_valid("--location https://foobar.com --os-variant detect=yes,name=win7", nogrep="Please file a bug against virt-install")  # os detection succeeds, the fallback warning shouldn't be printed
 c.add_valid("--pxe --os-variant detect=yes,name=win7", grep="Please file a bug against virt-install")  # os detection fails, so fallback warning should be printed
 c.add_valid("--cdrom http://example.com/path/to/some.iso --os-variant detect=yes,require=no", grep="Please file a bug against virt-install")  # detection fails with require=no, we should print the error about using fallback name=
-c.add_invalid("--pxe --os-variant detect=yes,require=yes", grep="--os-variant/--osinfo OS name is required")  # No os-variant detected, but require=yes
-c.add_invalid("--pxe --osinfo detect=yes", grep="--os-variant/--osinfo OS name is required")  # --osinfo detect=on failed, but with implied require=yes
+c.add_invalid("--pxe --os-variant detect=yes,require=yes", grep="--osinfo/--os-variant OS name is required")  # No os-variant detected, but require=yes
+c.add_invalid("--pxe --osinfo detect=yes", grep="--osinfo/--os-variant OS name is required")  # --osinfo detect=on failed, but with implied require=yes
 c.add_invalid("--pxe --virt-type foobar", grep="Host does not support domain type")
 c.add_invalid("--pxe --os-variant farrrrrrrge", grep="Unknown OS name")
 c.add_invalid("--pxe --boot menu=foobar", grep="menu must be 'yes' or 'no'")
@@ -1409,9 +1409,9 @@ c.add_valid("test-for-virtxml --edit --cpu host-passthrough --no-define --start 
 c.add_valid("test-for-virtxml --edit --metadata name=test-for-virtxml", grep="requested changes will have no effect")
 c.add_valid("--print-diff test-for-virtxml --remove-device --disk boot.order=5", grep="boot order=\"5")
 c.add_invalid("test --edit 2 --events on_poweroff=destroy", grep="'--edit 2' doesn't make sense with --events")
-c.add_invalid("test --os-variant fedora26 --edit --cpu host-passthrough", grep="--os-variant/--osinfo is not supported")
-c.add_invalid("test-for-virtxml --os-variant fedora26 --remove-device --disk 1", grep="--os-variant/--osinfo is not supported")
-c.add_invalid("--build-xml --os-variant fedora26 --disk path=foo", grep="--os-variant/--osinfo is not supported")
+c.add_invalid("test --os-variant fedora26 --edit --cpu host-passthrough", grep="--osinfo/--os-variant is not supported")
+c.add_invalid("test-for-virtxml --os-variant fedora26 --remove-device --disk 1", grep="--osinfo/--os-variant is not supported")
+c.add_invalid("--build-xml --os-variant fedora26 --disk path=foo", grep="--osinfo/--os-variant is not supported")
 c.add_invalid("domain-idontexist --edit --cpu host-passthrough --start", grep="Could not find domain")
 c.add_invalid("test-state-shutoff --edit --update --boot menu=on --start", grep="Cannot use --update")
 c.add_invalid("test --edit --update --events on_poweroff=destroy", grep="Don't know how to --update for --events")

--- a/virtManager/createvm.py
+++ b/virtManager/createvm.py
@@ -103,7 +103,7 @@ class _GuestData:
         self.init = None
 
         self.machine = None
-        self.os_variant = None
+        self.osinfo = None
         self.uefi_requested = None
         self.name = None
 
@@ -138,8 +138,8 @@ class _GuestData:
             # If no machine was explicitly selected, we don't overwrite
             # it, because we want to
             guest.os.machine = self.machine
-        if self.os_variant:
-            guest.set_os_name(self.os_variant)
+        if self.osinfo:
+            guest.set_os_name(self.osinfo)
         if self.uefi_requested:
             guest.uefi_requested = self.uefi_requested
 
@@ -1578,7 +1578,7 @@ class vmmCreateVM(vmmGObjectUI):
             self._gdata.cdrom = cdrom
             self._gdata.extra_args = extra
             self._gdata.livecd = False
-            self._gdata.os_variant = osobj and osobj.name or None
+            self._gdata.osinfo = osobj and osobj.name or None
             guest = self._gdata.build_guest()
             installer = self._gdata.build_installer()
         except Exception as e:

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -494,7 +494,7 @@ def fail_conflicting(option1, option2):
 def _get_completer_parsers():
     return VIRT_PARSERS + [ParserCheck, ParserLocation,
             ParserUnattended, ParserInstall, ParserCloudInit,
-            ParserOSVariant]
+            ParserOSInfo]
 
 
 def _virtparser_completer(prefix, **kwargs):
@@ -930,7 +930,7 @@ def add_disk_option(stog, editexample=False):
                "--disk=?") + editmsg)
 
 
-def add_os_variant_option(parser, virtinstall):
+def add_osinfo_option(parser, virtinstall):
     osg = parser.add_argument_group(_("OS options"))
 
     if virtinstall:
@@ -942,7 +942,7 @@ def add_os_variant_option(parser, virtinstall):
              "Example values: fedora29, rhel7.0, win10, ...\n"
              "Use '--osinfo list' to see a full list.")
 
-    osg.add_argument("--os-variant", "--osinfo", help=msg)
+    osg.add_argument("--osinfo", "--os-variant", help=msg)
     return osg
 
 
@@ -1880,11 +1880,11 @@ def parse_location(optstr):
     return parsedata.location, parsedata.kernel, parsedata.initrd
 
 
-########################
-# --os-variant parsing #
-########################
+####################
+# --osinfo parsing #
+####################
 
-class OSVariantData(object):
+class OSInfoData(object):
     _REQUIRE_ON = 1
     _REQUIRE_AUTO = 3
 
@@ -1936,8 +1936,8 @@ class OSVariantData(object):
         return self._name
 
 
-class ParserOSVariant(VirtCLIParser):
-    cli_arg_name = "os_variant"
+class ParserOSInfo(VirtCLIParser):
+    cli_arg_name = "osinfo"
     supports_clearxml = False
 
     @classmethod
@@ -1956,9 +1956,9 @@ class ParserOSVariant(VirtCLIParser):
         return super().parse(inst)
 
 
-def parse_os_variant(optstr):
-    data = OSVariantData()
-    parser = ParserOSVariant(optstr)
+def parse_osinfo(optstr):
+    data = OSInfoData()
+    parser = ParserOSInfo(optstr)
     parser.parse(data)
     data.validate()
     return data
@@ -5051,7 +5051,7 @@ def check_option_introspection(options):
 
 
 def check_osinfo_list(options):
-    if options.os_variant != "list":
+    if options.osinfo != "list":
         return False
 
     for osobj in OSDB.list_os():

--- a/virtinst/install/installertreemedia.py
+++ b/virtinst/install/installertreemedia.py
@@ -29,15 +29,15 @@ def _is_url(url):
 
 
 class _LocationData(object):
-    def __init__(self, os_variant, kernel_pairs, os_media, os_tree):
-        self.os_variant = os_variant
+    def __init__(self, osinfo, kernel_pairs, os_media, os_tree):
+        self.osinfo = osinfo
         self.kernel_pairs = kernel_pairs
         self.os_media = os_media
         self.os_tree = os_tree
 
         self.kernel_url_arg = None
-        if self.os_variant:
-            osobj = OSDB.lookup_os(self.os_variant)
+        if self.osinfo:
+            osobj = OSDB.lookup_os(self.osinfo)
             self.kernel_url_arg = osobj.get_kernel_url_arg()
 
 
@@ -171,7 +171,7 @@ class InstallerTreeMedia(object):
             return self._cached_data
 
         store = None
-        os_variant = None
+        osinfo = None
         os_media = None
         os_tree = None
         kernel_paths = []
@@ -187,14 +187,14 @@ class InstallerTreeMedia(object):
 
         if store:
             kernel_paths = store.get_kernel_paths()
-            os_variant = store.get_osdict_info()
+            osinfo = store.get_osdict_info()
             os_media = store.get_os_media()
             os_tree = store.get_os_tree()
         if has_location_kernel:
             kernel_paths = [
                     (self._location_kernel, self._location_initrd)]
 
-        self._cached_data = _LocationData(os_variant, kernel_paths,
+        self._cached_data = _LocationData(osinfo, kernel_paths,
                 os_media, os_tree)
         return self._cached_data
 
@@ -236,8 +236,8 @@ class InstallerTreeMedia(object):
             self._initrd_injections.append((scriptpath, expected_filename))
 
     def _prepare_kernel_url_arg(self, guest, cache):
-        os_variant = cache.os_variant or guest.osinfo.name
-        osobj = OSDB.lookup_os(os_variant)
+        osinfo = cache.osinfo or guest.osinfo.name
+        osobj = OSDB.lookup_os(osinfo)
         return osobj.get_kernel_url_arg()
 
     def _prepare_kernel_args(self, guest, cache, unattended_scripts):
@@ -304,7 +304,7 @@ class InstallerTreeMedia(object):
     def detect_distro(self, guest):
         fetcher = self._get_fetcher(guest, None)
         cache = self._get_cached_data(guest, fetcher)
-        return cache.os_variant
+        return cache.osinfo
 
     def get_os_media(self, guest, meter):
         fetcher = self._get_fetcher(guest, meter)

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -571,7 +571,7 @@ def installer_detect_distro(guest, installer, osdata):
         fail(_("Error validating install location: %s") % str(e))
 
     msg = _(
-        "--os-variant/--osinfo OS name is required, but no value was\n"
+        "--osinfo/--os-variant OS name is required, but no value was\n"
         "set or detected.")
     if os_set:
         return
@@ -650,7 +650,7 @@ def _build_options_guest(conn, options):
 
 def build_guest_instance(conn, options):
     installdata = cli.parse_install(options.install)
-    osdata = cli.parse_os_variant(options.os_variant or installdata.os)
+    osdata = cli.parse_osinfo(options.osinfo or installdata.os)
     options.boot_was_set = bool(options.boot)
 
     if options.reinstall:
@@ -1076,7 +1076,7 @@ def parse_args():
     cli.add_boot_options(insg)
     insg.add_argument("--init", help=argparse.SUPPRESS)
 
-    osg = cli.add_os_variant_option(parser, virtinstall=True)
+    osg = cli.add_osinfo_option(parser, virtinstall=True)
     osg.add_argument("--os-type", dest="old_os_type", help=argparse.SUPPRESS)
 
     devg = parser.add_argument_group(_("Device Options"))
@@ -1188,8 +1188,8 @@ def set_test_stub_options(options):  # pragma: no cover
         options.disk = "none"
     if not options.graphics:
         options.graphics = "none"
-    if not options.os_variant:
-        options.os_variant = "fedora27"
+    if not options.osinfo:
+        options.osinfo = "fedora27"
 
 
 def main(conn=None):

--- a/virtinst/virtxml.py
+++ b/virtinst/virtxml.py
@@ -44,11 +44,11 @@ def get_diff(origxml, newxml):
     return diff
 
 
-def set_os_variant(guest, os_variant):
-    if os_variant is None:
+def set_osinfo(guest, osinfo):
+    if osinfo is None:
         return
 
-    osdata = cli.parse_os_variant(os_variant)
+    osdata = cli.parse_osinfo(osinfo)
     if osdata.get_name():
         guest.set_os_name(osdata.get_name())
 
@@ -97,13 +97,13 @@ class Action:
 
 
 def validate_action(action, conn, options):
-    if options.os_variant is not None:
+    if options.osinfo is not None:
         if action.is_edit:
-            fail(_("--os-variant/--osinfo is not supported with --edit"))
+            fail(_("--osinfo/--os-variant is not supported with --edit"))
         if action.is_remove_device:
-            fail(_("--os-variant/--osinfo is not supported with --remove-device"))
+            fail(_("--osinfo/--os-variant is not supported with --remove-device"))
         if action.is_build_xml:
-            fail(_("--os-variant/--osinfo is not supported with --build-xml"))
+            fail(_("--osinfo/--os-variant is not supported with --build-xml"))
 
     if not action.parserclass.guest_propname and action.is_build_xml:
         fail(_("--build-xml not supported for {cli_flag}").format(
@@ -251,11 +251,11 @@ def action_edit(action, guest):
     return devs
 
 
-def action_add_device(action, guest, os_variant, input_devs):
+def action_add_device(action, guest, osinfo, input_devs):
     parserclass = action.parserclass
     parservalue = action.parservalue
 
-    set_os_variant(guest, os_variant)
+    set_osinfo(guest, osinfo)
 
     if input_devs:
         for dev in input_devs:
@@ -294,7 +294,7 @@ def action_build_xml(action, guest):
 
 def perform_action(action, guest, options, input_devs):
     if action.is_add_device:
-        return action_add_device(action, guest, options.os_variant, input_devs)
+        return action_add_device(action, guest, options.osinfo, input_devs)
     if action.is_remove_device:
         return action_remove_device(action, guest)
     if action.is_edit:
@@ -483,7 +483,7 @@ def parse_args():
     outg.add_argument("--confirm", action="store_true",
         help=_("Require confirmation before saving any results."))
 
-    cli.add_os_variant_option(parser, virtinstall=False)
+    cli.add_osinfo_option(parser, virtinstall=False)
 
     conv = parser.add_argument_group(_("Conversion options"))
     cli.ParserConvertToQ35.register()


### PR DESCRIPTION
The former is the preferred spelling and it should always be presented first to the user.