### PR TITLE
Add support for maximum CPU mode (cli, gui) and prefer it

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -438,6 +438,11 @@ Some examples:
 ``--cpu host-passthrough,cache.mode=passthrough``
     Example of passing through the host cpu's cache information.
 
+``--cpu maximum``
+    Expose the most feature-rich CPU possible. Useful when running a foreign
+    architecture guest, for example a riscv64 guest on an x86_64 host. Not
+    recommended when using KVM to run a same-architecture guest.
+
 Use --cpu=? to see a list of all available sub options.
 Complete details at https://libvirt.org/formatdomain.html#cpu-model-and-topology
 

--- a/tests/data/cli/compare/virt-install-aarch64-machdefault.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-machdefault.xml
@@ -18,9 +18,7 @@
   <features>
     <acpi/>
   </features>
-  <cpu mode="custom" match="exact">
-    <model>cortex-a57</model>
-  </cpu>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-aarch64</emulator>

--- a/tests/data/cli/compare/virt-install-aarch64-machvirt.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-machvirt.xml
@@ -18,9 +18,7 @@
   <features>
     <acpi/>
   </features>
-  <cpu mode="custom" match="exact">
-    <model>cortex-a57</model>
-  </cpu>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-aarch64</emulator>

--- a/tests/data/cli/compare/virt-install-arm-defaultmach-f20.xml
+++ b/tests/data/cli/compare/virt-install-arm-defaultmach-f20.xml
@@ -15,6 +15,7 @@
     <initrd>/f19-arm.initrd</initrd>
     <cmdline>foo</cmdline>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-arm</emulator>

--- a/tests/data/cli/compare/virt-install-arm-virt-f20.xml
+++ b/tests/data/cli/compare/virt-install-arm-virt-f20.xml
@@ -15,6 +15,7 @@
     <initrd>/f19-arm.initrd</initrd>
     <cmdline>console=ttyAMA0,1234 rw root=/dev/vda3</cmdline>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-arm</emulator>

--- a/tests/data/cli/compare/virt-install-linux2020.xml
+++ b/tests/data/cli/compare/virt-install-linux2020.xml
@@ -19,7 +19,7 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-passthrough"/>
+  <cpu mode="maximum"/>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>
@@ -102,7 +102,7 @@
     <apic/>
     <vmport state="off"/>
   </features>
-  <cpu mode="host-passthrough"/>
+  <cpu mode="maximum"/>
   <clock offset="utc">
     <timer name="rtc" tickpolicy="catchup"/>
     <timer name="pit" tickpolicy="delay"/>

--- a/tests/data/cli/compare/virt-install-riscv64-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-cdrom.xml
@@ -14,6 +14,7 @@
     <boot dev="cdrom"/>
     <boot dev="hd"/>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>
@@ -92,6 +93,7 @@
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>

--- a/tests/data/cli/compare/virt-install-riscv64-cloud-init.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-cloud-init.xml
@@ -12,6 +12,7 @@
   <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>
@@ -87,6 +88,7 @@
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>

--- a/tests/data/cli/compare/virt-install-riscv64-graphics.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-graphics.xml
@@ -13,6 +13,7 @@
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>

--- a/tests/data/cli/compare/virt-install-riscv64-headless.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-headless.xml
@@ -13,6 +13,7 @@
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>

--- a/tests/data/cli/compare/virt-install-riscv64-kernel-boot.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-kernel-boot.xml
@@ -15,6 +15,7 @@
     <initrd>/initrd.img</initrd>
     <cmdline>root=/dev/vda2</cmdline>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>

--- a/tests/data/cli/compare/virt-install-riscv64-unattended.xml
+++ b/tests/data/cli/compare/virt-install-riscv64-unattended.xml
@@ -12,6 +12,7 @@
   <os firmware="efi">
     <type arch="riscv64" machine="virt">hvm</type>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>
@@ -90,6 +91,7 @@
     <type arch="riscv64" machine="virt">hvm</type>
     <boot dev="hd"/>
   </os>
+  <cpu mode="maximum"/>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-riscv64</emulator>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1153,7 +1153,7 @@ c.add_compare("--os-variant http://fedoraproject.org/fedora/20 --disk %(EXISTIMG
 c.add_compare("--cdrom %(EXISTIMG2)s --file %(EXISTIMG1)s --os-variant win2k3 --sound --controller usb", "kvm-win2k3-cdrom")  # HVM windows install with disk
 c.add_compare("--os-variant name=ubuntusaucy --nodisks --boot cdrom --virt-type qemu --cpu Penryn --input tablet --boot uefi --graphics vnc", "qemu-plain")  # plain qemu
 c.add_compare("--os-variant fedora20 --nodisks --boot network --graphics default --arch i686 --rng none", "qemu-32-on-64", prerun_check=has_old_osinfo)  # 32 on 64
-c.add_compare("--osinfo linux2020 --pxe", "linux2020", prerun_check=no_osinfo_linux2020_virtio)
+c.add_compare("--osinfo linux2020 --pxe --cpu maximum", "linux2020", prerun_check=no_osinfo_linux2020_virtio) # also --cpu maximum
 c.add_compare("--check disk_size=off --osinfo win11 --cdrom %(EXISTIMG1)s", "win11", prerun_check=no_osinfo_win11)
 c.add_compare("--check disk_size=off --osinfo win11 --cdrom %(EXISTIMG1)s --boot uefi=off", "win11-no-uefi")
 c.add_compare("--osinfo generic --disk none --location %(ISO-NO-OS)s,kernel=frib.img,initrd=/frob.img", "location-manual-kernel", prerun_check=missing_xorriso)  # --location with an unknown ISO but manually specified kernel paths

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1247,7 +1247,7 @@ c.add_compare("--connect %(URI-KVM-ARMV7L)s --disk %(EXISTIMG1)s --import --os-v
 
 c.add_valid("--arch aarch64 --osinfo fedora19 --nodisks --pxe --connect " + utils.URIs.kvm_x86_nodomcaps, grep="Libvirt version does not support UEFI")  # attempt to default to aarch64 UEFI, but it fails, but should only print warnings
 c.add_invalid("--arch aarch64 --nodisks --pxe --connect " + utils.URIs.kvm_x86, grep="OS name is required")  # catch missing osinfo for non-x86
-c.add_compare("--arch aarch64 --osinfo fedora19 --machine virt --boot kernel=/f19-arm.kernel,initrd=/f19-arm.initrd,kernel_args=\"console=ttyAMA0,1234 rw root=/dev/vda3\" --disk %(EXISTIMG1)s", "aarch64-machvirt")
+c.add_compare("--arch aarch64 --osinfo fedora19 --machine virt --cpu default --boot kernel=/f19-arm.kernel,initrd=/f19-arm.initrd,kernel_args=\"console=ttyAMA0,1234 rw root=/dev/vda3\" --disk %(EXISTIMG1)s", "aarch64-machvirt")
 c.add_compare("--arch aarch64 --osinfo fedora19 --boot kernel=/f19-arm.kernel,initrd=/f19-arm.initrd,kernel_args=\"console=ttyAMA0,1234 rw root=/dev/vda3\" --disk %(EXISTIMG1)s", "aarch64-machdefault")
 c.add_compare("--arch aarch64 --cdrom %(ISO-F26-NETINST)s --boot loader=CODE.fd,nvram.template=VARS.fd --disk %(EXISTIMG1)s --cpu none --events on_crash=preserve,on_reboot=destroy,on_poweroff=restart", "aarch64-cdrom")  # cdrom test, but also --cpu none override, --events override, and headless
 c.add_compare("--connect %(URI-KVM-AARCH64)s --disk %(EXISTIMG1)s --import --os-variant fedora21 --panic default --graphics vnc", "aarch64-kvm-import")  # --import test, but also test --panic no-op, and --graphics

--- a/virtManager/details/details.py
+++ b/virtManager/details/details.py
@@ -775,6 +775,8 @@ class vmmDetails(vmmGObjectUI):
             virtinst.DomainCpu.SPECIAL_MODE_HOST_MODEL, False])
         model.append(["host-passthrough", "05",
             virtinst.DomainCpu.SPECIAL_MODE_HOST_PASSTHROUGH, False])
+        model.append(["maximum", "06",
+            virtinst.DomainCpu.SPECIAL_MODE_MAXIMUM, False])
         model.append([None, None, None, True])
         for name in domcaps.get_cpu_models():
             model.append([name, name, name, False])
@@ -1915,7 +1917,8 @@ class vmmDetails(vmmGObjectUI):
         # CPU model config
         model = cpu.model or None
         is_host = (cpu.mode in ["host-model", "host-passthrough"])
-        if not model and is_host:
+        is_special_mode = (cpu.mode in virtinst.DomainCpu.SPECIAL_MODES)
+        if not model and is_special_mode:
             model = cpu.mode
 
         if model:

--- a/virtManager/preferences.py
+++ b/virtManager/preferences.py
@@ -172,7 +172,8 @@ class vmmPreferences(vmmGObjectUI):
             [DomainCpu.SPECIAL_MODE_HOST_MODEL_ONLY,
                 _("Nearest host CPU model")],
             [DomainCpu.SPECIAL_MODE_HOST_MODEL, "host-model"],
-            [DomainCpu.SPECIAL_MODE_HOST_PASSTHROUGH, "host-passthrough"]]:
+            [DomainCpu.SPECIAL_MODE_HOST_PASSTHROUGH, "host-passthrough"],
+            [DomainCpu.SPECIAL_MODE_MAXIMUM, "maximum"]]:
             model.append(row)
         combo.set_model(model)
         uiutil.init_combo_text_column(combo, 1)

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -267,12 +267,13 @@ class DomainCpu(XMLBuilder):
     SPECIAL_MODE_HOST_COPY = "host-copy"
     SPECIAL_MODE_HOST_MODEL = "host-model"
     SPECIAL_MODE_HOST_PASSTHROUGH = "host-passthrough"
+    SPECIAL_MODE_MAXIMUM = "maximum"
     SPECIAL_MODE_CLEAR = "clear"
     SPECIAL_MODE_APP_DEFAULT = "default"
     SPECIAL_MODES = [SPECIAL_MODE_HOST_MODEL_ONLY, SPECIAL_MODE_HV_DEFAULT,
                      SPECIAL_MODE_HOST_COPY, SPECIAL_MODE_HOST_MODEL,
-                     SPECIAL_MODE_HOST_PASSTHROUGH, SPECIAL_MODE_CLEAR,
-                     SPECIAL_MODE_APP_DEFAULT]
+                     SPECIAL_MODE_HOST_PASSTHROUGH, SPECIAL_MODE_MAXIMUM,
+                     SPECIAL_MODE_CLEAR, SPECIAL_MODE_APP_DEFAULT]
 
     def _get_app_default_mode(self, guest):
         # Depending on if libvirt+qemu is new enough, we prefer
@@ -295,7 +296,8 @@ class DomainCpu(XMLBuilder):
             log.debug("Using default cpu mode=%s", val)
 
         if (val == self.SPECIAL_MODE_HOST_MODEL or
-            val == self.SPECIAL_MODE_HOST_PASSTHROUGH):
+            val == self.SPECIAL_MODE_HOST_PASSTHROUGH or
+            val == self.SPECIAL_MODE_MAXIMUM):
             self.model = None
             self.vendor = None
             self.model_fallback = None

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -382,6 +382,10 @@ class DomainCapabilities(XMLBuilder):
         return (m and m.supported and
                 "on" in m.get_enum("hostPassthroughMigratable").get_values())
 
+    def supports_maximum_cpu_mode(self):
+        m = self.cpu.get_mode("maximum")
+        return (m and m.supported)
+
     def get_cpu_models(self):
         models = []
 


### PR DESCRIPTION
This makes the experience of running emulated guests (e.g. riscv64 on x86_64) a lot nicer.