### PR TITLE
Better error message for inactive networks

### DIFF
--- a/virtManager/asyncjob.py
+++ b/virtManager/asyncjob.py
@@ -76,6 +76,16 @@ def cb_wrapper(callback, asyncjob, *args, **kwargs):
             asyncjob.job_canceled):
             return  # pragma: no cover
 
+        # If network is inactive, show a different error message
+        if (isinstance(e, libvirt.libvirtError) and
+                e.get_error_code() == libvirt.VIR_ERR_OPERATION_INVALID and
+                e.get_error_domain() == libvirt.VIR_FROM_NETWORK):
+            asyncjob.set_error(
+                str(e) + "\n\n" +
+                _("Go to: Edit -> Connection Details -> Network Interfaces to activate the network."),
+                "".join(traceback.format_exc()))
+            return # pragma: no cover
+
         asyncjob.set_error(str(e), "".join(traceback.format_exc()))
 
 

--- a/virtManager/manager.py
+++ b/virtManager/manager.py
@@ -171,6 +171,13 @@ class vmmManager(vmmGObjectUI):
         for conn in connmanager.conns.values():
             self._conn_added(connmanager, conn)
 
+        # Select the first item in the list if it exists
+        vmlist = self.widget("vm-list")
+        model = vmlist.get_model()
+        if len(model) > 0:
+            selection = vmlist.get_selection()
+            selection.select_path(Gtk.TreePath.new_first())
+
 
     ##################
     # Common methods #


### PR DESCRIPTION
It's very confusing for beginners when they start a VM and an error occurs that it won't work because the network is inactive. That's why I've added a solution to this problem in the error message.

The best variant would probably be to ask if the network should be activated, but unfortunately, I don't have enough knowledge and time for that yet.