### PR TITLE
createvm: prioritize riscv64

### DIFF
--- a/virtManager/createvm.py
+++ b/virtManager/createvm.py
@@ -792,7 +792,7 @@ class vmmCreateVM(vmmGObjectUI):
         archs.sort()
 
         prios = ["x86_64", "i686", "aarch64", "armv7l", "ppc64", "ppc64le",
-            "s390x"]
+            "riscv64", "s390x"]
         if self.conn.caps.host.cpu.arch not in prios:
             prios = []  # pragma: no cover
         for p in prios[:]:


### PR DESCRIPTION
As all major distros support the riscv64 architecture, add it to the list of prioritized architectures. This will move it up in the architecture drop-down menu and thereby easier to find when creating a new VM.