### PR TITLE
tests: Increase virtio-mem block size

### DIFF
--- a/tests/data/cli/compare/virt-install-memory-hotplug.xml
+++ b/tests/data/cli/compare/virt-install-memory-hotplug.xml
@@ -126,7 +126,7 @@
       <target dynamicMemslots="yes">
         <size>524288</size>
         <node>0</node>
-        <block>2048</block>
+        <block>524288</block>
         <requested>524288</requested>
         <address base="0x180000000"/>
       </target>
@@ -270,7 +270,7 @@
       <target dynamicMemslots="yes">
         <size>524288</size>
         <node>0</node>
-        <block>2048</block>
+        <block>524288</block>
         <requested>524288</requested>
         <address base="0x180000000"/>
       </target>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -942,7 +942,7 @@ c.add_compare("--pxe "
 "address.type=dimm,address.base=0x100000000,address.slot=1,"
 "source.pmem=on,source.alignsize=2048,target.readonly=on "
 
-"--memdev virtio-mem,target_node=0,target.block=2048,target.dynamicMemslots=yes,"
+"--memdev virtio-mem,target_node=0,target.block=524288,target.dynamicMemslots=yes,"
 "target_size=512,target.requested=524288,target.address_base=0x180000000 "
 
 "--memdev virtio-pmem,source.path=/tmp/virtio_pmem,"


### PR DESCRIPTION
virtio-mem block size must be equal to or greater than the transparent huge page size; otherwise, libvirt raises an error and a test will fail. For example, on Asahi Linux, the transparent huge page size is 32 MiB, which is greater than 2 MiB, the specified virtio-mem block size.

On Linux 6.13, the configuration with the maximum transparent huge page size is Arm64 with 64 KiB, and it has 512 MiB transparent huge pages. Increase the block size to 512 MiB so that the test passes on every Linux configuration.