### PR TITLE
Fix for Windows on Arm64

### DIFF
--- a/tests/data/cli/compare/virt-install-aarch64-kvm-gic.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-kvm-gic.xml
@@ -69,7 +69,7 @@
     </graphics>
     <sound model="ich9"/>
     <video>
-      <model type="virtio"/>
+      <model type="ramfb"/>
     </video>
     <memballoon model="virtio"/>
     <rng model="virtio">

--- a/tests/data/cli/compare/virt-install-aarch64-kvm-import.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-kvm-import.xml
@@ -58,7 +58,7 @@
     </tpm>
     <graphics type="vnc" port="-1"/>
     <video>
-      <model type="virtio"/>
+      <model type="ramfb"/>
     </video>
     <memballoon model="virtio"/>
     <rng model="virtio">

--- a/tests/data/cli/compare/virt-install-aarch64-machdefault.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-machdefault.xml
@@ -63,7 +63,7 @@
     </graphics>
     <sound model="ich9"/>
     <video>
-      <model type="virtio"/>
+      <model type="vga"/>
     </video>
     <memballoon model="virtio"/>
     <rng model="virtio">

--- a/tests/data/cli/compare/virt-install-aarch64-machvirt.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-machvirt.xml
@@ -63,7 +63,7 @@
     </graphics>
     <sound model="ich9"/>
     <video>
-      <model type="virtio"/>
+      <model type="vga"/>
     </video>
     <memballoon model="virtio"/>
     <rng model="virtio">

--- a/tests/data/cli/compare/virt-install-aarch64-win11.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-win11.xml
@@ -1,0 +1,70 @@
+<domain type="kvm">
+  <name>win11</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://microsoft.com/win/11"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os firmware="efi">
+    <type arch="aarch64" machine="virt">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="localtime"/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-aarch64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2"/>
+      <source file="/pool-dir/testvol1.img"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <tpm>
+      <backend type="emulator"/>
+    </tpm>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="virtio"/>
+    </video>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-aarch64-win11.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-win11.xml
@@ -23,7 +23,7 @@
     <disk type="file" device="disk">
       <driver name="qemu" type="qcow2"/>
       <source file="/pool-dir/testvol1.img"/>
-      <target dev="vda" bus="virtio"/>
+      <target dev="sda" bus="usb"/>
     </disk>
     <controller type="usb" model="qemu-xhci" ports="15"/>
     <controller type="pci" model="pcie-root"/>
@@ -44,13 +44,8 @@
     <interface type="bridge">
       <source bridge="testsuitebr0"/>
       <mac address="00:11:22:33:44:55"/>
-      <model type="virtio"/>
     </interface>
     <console type="pty"/>
-    <channel type="unix">
-      <source mode="bind"/>
-      <target type="virtio" name="org.qemu.guest_agent.0"/>
-    </channel>
     <channel type="spicevmc">
       <target type="virtio" name="com.redhat.spice.0"/>
     </channel>
@@ -64,7 +59,7 @@
     </graphics>
     <sound model="ich9"/>
     <video>
-      <model type="virtio"/>
+      <model type="ramfb"/>
     </video>
   </devices>
 </domain>

--- a/tests/data/cli/compare/virt-install-arm-defaultmach-f20.xml
+++ b/tests/data/cli/compare/virt-install-arm-defaultmach-f20.xml
@@ -60,7 +60,7 @@
     </graphics>
     <sound model="ich9"/>
     <video>
-      <model type="virtio"/>
+      <model type="vga"/>
     </video>
     <memballoon model="virtio"/>
     <rng model="virtio">

--- a/tests/data/cli/compare/virt-install-arm-kvm-import.xml
+++ b/tests/data/cli/compare/virt-install-arm-kvm-import.xml
@@ -58,7 +58,7 @@
     </graphics>
     <sound model="ich9"/>
     <video>
-      <model type="virtio"/>
+      <model type="ramfb"/>
     </video>
     <memballoon model="virtio"/>
     <rng model="virtio">

--- a/tests/data/cli/compare/virt-install-arm-virt-f20.xml
+++ b/tests/data/cli/compare/virt-install-arm-virt-f20.xml
@@ -54,7 +54,7 @@
     <input type="keyboard" bus="usb"/>
     <graphics type="vnc" port="-1"/>
     <video>
-      <model type="virtio"/>
+      <model type="vga"/>
     </video>
     <memballoon model="virtio"/>
     <rng model="virtio">

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1772,6 +1772,10 @@ c.add_compare(
     "--connect %(URI-KVM-AARCH64)s --disk %(EXISTIMG1)s --os-variant fedora28 --cloud-init",
     "aarch64-cloud-init",
 )
+c.add_compare(
+    "--connect %(URI-KVM-AARCH64)s --disk %(EXISTIMG1)s --os-variant win11",
+    "aarch64-win11",
+)
 
 
 #####################

--- a/virtinst/devices/disk.py
+++ b/virtinst/devices/disk.py
@@ -1025,19 +1025,21 @@ class DeviceDisk(Device):
             return "ide"
         if self.is_disk() and guest.supports_virtiodisk():
             return "virtio"
-        if self.is_cdrom() and guest.supports_virtioscsi() and not guest.os.is_x86():
+        if guest.os.is_q35():
+            return "sata"
+        if self.conn.is_bhyve():
+            # IDE bus is not supported by bhyve
+            return "sata"
+        if guest.os.is_x86():
+            return "ide"
+        if self.is_cdrom() and guest.supports_virtioscsi():
             # x86 long time default has been IDE CDROM, stick with that to
             # avoid churn, but every newer virt arch that supports virtio-scsi
             # should use it
             return "scsi"
         if guest.os.is_arm():
             return "sd"
-        if guest.os.is_q35():
-            return "sata"
-        if self.conn.is_bhyve():
-            # IDE bus is not supported by bhyve
-            return "sata"
-        return "ide"
+        return "usb"
 
     def set_defaults(self, guest):
         if not self._device:

--- a/virtinst/devices/disk.py
+++ b/virtinst/devices/disk.py
@@ -1037,7 +1037,7 @@ class DeviceDisk(Device):
             # avoid churn, but every newer virt arch that supports virtio-scsi
             # should use it
             return "scsi"
-        if guest.os.is_arm():
+        if str(guest.os.machine).startswith("vexpress"):
             return "sd"
         return "usb"
 

--- a/virtinst/devices/video.py
+++ b/virtinst/devices/video.py
@@ -46,9 +46,6 @@ class DeviceVideo(Device):
             return "vga"
         if guest.os.is_loongarch64():
             return "virtio"
-        if guest.os.is_arm_machvirt():
-            # For all cases here the hv and guest are new enough for virtio
-            return "virtio"
         if guest.os.is_riscv_virt():
             # For all cases here the hv and guest are new enough for virtio
             return "virtio"

--- a/virtinst/devices/video.py
+++ b/virtinst/devices/video.py
@@ -66,8 +66,11 @@ class DeviceVideo(Device):
             # qxl is only beneficial over regular vga when paired with spice.
             # The device still may not be available though
             return "qxl"
-        if guest.is_uefi() and guest.lookup_domcaps().supports_video_bochs():
-            return "bochs"
+        if guest.is_uefi():
+            if guest.os.is_arm():
+                return "ramfb"
+            if guest.lookup_domcaps().supports_video_bochs():
+                return "bochs"
         return "vga"
 
     def set_defaults(self, guest):

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -414,8 +414,7 @@ class Guest(XMLBuilder):
 
         # These _only_ support virtio so don't check the OS
         if (
-            self.os.is_arm_machvirt()
-            or self.os.is_riscv_virt()
+            self.os.is_riscv_virt()
             or self.os.is_s390x()
             or self.os.is_pseries()
             or self.os.is_loongarch64()

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -422,13 +422,7 @@ class Guest(XMLBuilder):
         ):
             return True
 
-        if not os_support:
-            return False
-
-        if self.os.is_x86():
-            return True
-
-        return False  # pragma: no cover
+        return os_support
 
     def supports_virtionet(self):
         return self._supports_virtio(self.osinfo.supports_virtionet(self._extra_drivers))


### PR DESCRIPTION
Broadly speaking, this pull request addresses the following two problems:
1. It was assumed virtio is supported on the Arm virt machine, but Windows does not.
2. Hyper-V features are assumed to be available on every architecture, but they are specific to x86.

Note that there are remaining problems that need to be addressed in libvirt or libosinfo. Please see commit 6621e736d64e0e9838a6d906d7841e627f4838e6 for details.
Linaro provides concrete instructions to test Windows on Arm64: https://linaro.atlassian.net/wiki/spaces/WOAR/pages/28914909194/windows-arm64+VM+using+qemu-system