### PR TITLE
urlfetcher: add riscv64 architecture for Debian

### DIFF
--- a/virtinst/install/urldetect.py
+++ b/virtinst/install/urldetect.py
@@ -692,7 +692,7 @@ class _DebianDistro(_DistroTree):
 
         # Check for standard arch strings which will be
         # in the URI name for --location $ISO mounts
-        for arch in ["i386", "amd64", "x86_64", "arm64"]:
+        for arch in ["i386", "amd64", "x86_64", "arm64", "riscv64"]:
             if arch in self.uri:
                 log.debug("Found treearch=%s in uri", arch)
                 if arch == "x86_64":


### PR DESCRIPTION
Add riscv64 to the list of Debian architectures.