### PR TITLE
Add `pre-commit`, use it to run `black` in CI

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,17 @@
+name: Check code formatting with black
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: black --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-    repo: https://github.com/pre-commit/pre-commit-hooks
+     rev: v5.0.0
+     hooks:
+     -    id: check-yaml
+
+-    repo: https://github.com/psf/black
+     rev: 25.1.0
+     hooks:
+     -    id: black

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,30 +1,3 @@
-[pycodestyle]
-
-# List of error codes:
-# https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
-
-
-# E122: Continuation line missing indentation or outdented
-# E123: Closing bracket does not match indentation of opening
-#       bracket's line
-# E126: Continuation line over-indented for hanging indent
-# E127: Continuation line over-indented for visual indent
-# E128: Continuation line under-indented for visual indent
-# E129: Visually indented line with same indent as next logical line
-# E221: Multiple spaces before operator
-# E241: Multiple spaces after comma
-# E301: Expected 1 blank line, found 0
-# E303: Too many blank lines
-# E305: Expected 2 blank lines after end of function or class
-# E306: Expected 1 blank line before a nested definition
-# E402: Module level import not at top of file
-# E501: Line too long (82 > 79 characters)
-# W504: line break after binary operator
-# E741: Do not use simply named variables
-
-
-ignore = E122, E123, E126, E127, E128, E129, E221, E241, E301, E303, E305, E306, E402, E501, W504, E741
-
 [tool:pytest]
 testpaths=tests/
 norecursedirs=data

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -37,18 +37,6 @@ test(
   timeout: 300,
 )
 
-pycodestyle_prog = find_program(['pycodestyle', 'pycodestyle-3'])
-test(
-  'pycodestyle',
-  pycodestyle_prog,
-  args: [
-    '--config', 'setup.cfg',
-    '--format', 'pylint',
-    lint_files,
-  ],
-  workdir: meson.project_source_root(),
-)
-
 codespell_prog = find_program('codespell', required:false)
 if codespell_prog.found()
   test(


### PR DESCRIPTION
This adds a basic `pre-commit` config to run `black`, and uses it for code validation in CI

`pre-commit` isn't a requirement here, but it's a simple platform that we can plug in additional code tools and the dev workflow remains the same: like `codespell` in current git, or future things like `flake8` or `ruff`. As a dev, it helps me ensure I don't forget to run tools like `black` before submitting code.

This PR is very bare, just the minimum to get CI to prevent virt-manager.git formatting
from regressing. Things I will do in a follow up PR:

* update HACKING.md etc
* use .git-blame-ignore-revs
* move codespell to pre-commit
* combine codespell and black github actions into one

@pinotree @phrdina any objections?
