### PR TITLE
snapshots: Add order combobox in snapshot page

### DIFF
--- a/ui/snapshots.ui
+++ b/ui/snapshots.ui
@@ -365,6 +365,56 @@
           </packing>
         </child>
         <child>
+          <object class="GtkBox" id="snapshot-order-box">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkBox" id="hbox11">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="snapshot-order">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Order by:</property>
+                    <property name="use-underline">True</property>
+                    <property name="mnemonic-widget">snapshot-orderby</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="snapshot-orderby">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <signal name="changed" handler="on_snapshot_orderby_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkBox" id="box2">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -528,7 +578,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
The "model.set_sort_column_id(4, Gtk.SortType.ASCENDING)" in snapshots.py makes ascend order by column 4(snapshot name column). This patch added a combobox for soring, The default one is descending order by creation time of snapshots, So the latest one is always on the top.

E.g:
root@localhost:~ # virsh snapshot-list --domain tumbleweed
 Name            Creation Time               State
------------------------------------------------------
 desktop_ready   2025-03-03 14:26:23 +0000   running
 paused1         2025-03-03 14:56:57 +0000   paused
 poweroff1       2025-03-03 14:45:17 +0000   shutoff
 snapshot1       2025-03-03 14:23:17 +0000   running
 youtube         2025-03-03 14:42:19 +0000   running

We can see the snapshot list in snapshot page via UI:
 desktop_ready
 paused1
 poweroff1
 snapshot1
 youtube

After the patch, The default order option in the combobox is by creation time, So we can see the snapshot list in snapshot page via UI:
 paused1
 poweroff1
 youtube
 desktop_ready
 snapshot1

Fixes #847

It's sure thing that tree view/tree structure is the best solution, But it take times. 
Here is a simple workaround: A sorting combobox as a short-term solution. Once we got a fully functional tree structure for snapshot UI, We can remove/improve this combobox.