### PR TITLE
virt-manager: list virtual networks when creating new QEMU Session VM

### DIFF
--- a/virtManager/device/netlist.py
+++ b/virtManager/device/netlist.py
@@ -148,7 +148,6 @@ class vmmNetworkList(vmmGObjectUI):
         add_usermode = False
         if self.conn.is_qemu_unprivileged():
             log.debug("Using unprivileged qemu, adding usermode net")
-            vnets = []
             default_bridge = None
             add_usermode = True
 


### PR DESCRIPTION
Using qemu-bridge-helper QEMU Session VMs are now able to use host bridge interfaces. Currently only interface named virbr0 is allowed by default but it is possible to change it in `/etc/qemu/bridge.conf`.

We will still keep the usermode network as default.

Resolves: https://github.com/virt-manager/virt-manager/issues/863