### PR TITLE
Add support to get cloud-init config file from URL

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -897,10 +897,12 @@ Sub options are:
 ``meta-data=``
     Specify a cloud-init meta-data file to add directly to the iso. All other
     meta-data configuration options on the --cloud-init command line are ignored.
+    Can be path to local file or URL.
 
 ``user-data=``
     Specify a cloud-init user-data file to add directly to the iso. All other
     user-data configuration options on the --cloud-init command line are ignored.
+    Can be path to local file or URL.
 
 ``root-ssh-key=``
     Specify a public key to inject into the guest, providing ssh access to the
@@ -914,6 +916,7 @@ Sub options are:
 
 ``network-config=``
     Specify a cloud-init network-config file to add directly to the iso.
+    Can be path to local file or URL.
 
 
 

--- a/tests/data/cli/compare/virt-install-cloud-init-options6.xml
+++ b/tests/data/cli/compare/virt-install-cloud-init-options6.xml
@@ -1,0 +1,107 @@
+<domain type="test">
+  <name>fedora28</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/28"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <smbios mode="sysinfo"/>
+  </os>
+  <features>
+    <pae/>
+  </features>
+  <clock offset="utc"/>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/test-hv</emulator>
+    <disk type="file" device="disk">
+      <source file="/pool-dir/testvol1.img"/>
+      <target dev="hda" bus="ide"/>
+    </disk>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <interface type="user">
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000"/>
+    </interface>
+    <console type="pty"/>
+    <disk type="file" device="cdrom">
+      <source file="/VIRTINST-TESTSUITE/cloudinit.iso"/>
+      <target dev="hdb" bus="ide"/>
+      <readonly/>
+    </disk>
+  </devices>
+  <sysinfo type="smbios">
+    <system>
+      <entry name="serial">ds=nocloud</entry>
+    </system>
+  </sysinfo>
+  <on_reboot>destroy</on_reboot>
+</domain>
+<domain type="test">
+  <name>fedora28</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/28"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="i686">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <pae/>
+  </features>
+  <clock offset="utc"/>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/test-hv</emulator>
+    <disk type="file" device="disk">
+      <source file="/pool-dir/testvol1.img"/>
+      <target dev="hda" bus="ide"/>
+    </disk>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <interface type="user">
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000"/>
+    </interface>
+    <console type="pty"/>
+    <disk type="file" device="cdrom">
+      <target dev="hdb" bus="ide"/>
+      <readonly/>
+    </disk>
+  </devices>
+</domain>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1348,6 +1348,16 @@ c.add_compare(
     "cloud-init-options5",
     env={"VIRTINST_TEST_SUITE_PRINT_CLOUDINIT": "1"},
 )  # --cloud-init user-data=,meta-data=,network-config=
+c.add_compare(
+    "--disk %(EXISTIMG1)s --os-variant fedora28 --cloud-init user-data=https://example.com,meta-data=http://example.com,network-config=ftp://foobar.com",
+    "cloud-init-options6",
+    env={"VIRTINST_TEST_SUITE_PRINT_CLOUDINIT": "1"},
+)  # --cloud-init network URLs
+c.add_invalid(
+    "--disk none --osinfo fedora28 --cloud-init user-data=badurl://example.com",
+    env={"VIRTINST_TEST_SUITE_PRINT_CLOUDINIT": "1"},
+    grep="Couldn't acquire file.*badurl",
+)  # --cloud-init confirm bad URL fails
 c.add_valid(
     "--panic help --disk=? --check=help", grep="path_in_use"
 )  # Make sure introspection doesn't blow up

--- a/virtinst/install/cloudinit.py
+++ b/virtinst/install/cloudinit.py
@@ -13,15 +13,16 @@ from ..logger import log
 
 
 class CloudInitData:
-    disable = None
-    root_password_generate = None
-    root_password_file = None
-    generated_root_password = None
-    root_ssh_key = None
-    clouduser_ssh_key = None
-    user_data = None
-    meta_data = None
-    network_config = None
+    def __init__(self):
+        self.disable = None
+        self.root_password_generate = None
+        self.root_password_file = None
+        self.generated_root_password = None
+        self.root_ssh_key = None
+        self.clouduser_ssh_key = None
+        self.user_data = None
+        self.meta_data = None
+        self.network_config = None
 
     def _generate_password(self):
         if not self.generated_root_password:

--- a/virtinst/install/installer.py
+++ b/virtinst/install/installer.py
@@ -8,7 +8,6 @@
 
 import os
 
-from . import cloudinit
 from . import unattended
 from . import volumeupload
 from .installertreemedia import InstallerTreeMedia
@@ -385,7 +384,7 @@ class Installer(object):
 
     def _prepare_cloudinit(self, guest, meter):
         scratchdir = InstallerTreeMedia.make_scratchdir(guest)
-        filepairs = cloudinit.create_files(scratchdir, self._cloudinit_data)
+        filepairs = self._cloudinit_data.create_files(scratchdir)
         for filepair in filepairs:
             self._tmpfiles.append(filepair[0])
 


### PR DESCRIPTION
This allows users to specify `meta-data`, `user-data` and `network-config` using URL in addition to local file.