### PR TITLE
virt-install: detect wayland in order to start virt-viewer

### DIFF
--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -2185,6 +2185,14 @@ def _determine_default_autoconsole_type(guest, installer):
         log.debug("No viewer to launch for graphics type '%s'", gtype)
         return None
 
+    if (
+        not os.environ.get("DISPLAY", "")
+        and not os.environ.get("DISPLAY_WAYLAND")
+        and not xmlutil.in_testsuite()
+    ):  # pragma: no cover
+        log.warning(_("No display detected. Not running virt-viewer."))
+        return None
+
     if not HAS_VIRTVIEWER and not xmlutil.in_testsuite():  # pragma: no cover
         log.warning(
             _(
@@ -2193,10 +2201,6 @@ def _determine_default_autoconsole_type(guest, installer):
                 "the 'virt-viewer' package."
             )
         )
-        return None
-
-    if not os.environ.get("DISPLAY", "") and not xmlutil.in_testsuite():  # pragma: no cover
-        log.warning(_("Graphics requested but DISPLAY is not set. Not running virt-viewer."))
         return None
 
     return "graphical"


### PR DESCRIPTION
When running virt-install using waypipe the DISPLAY variable is not defined and virt-install will complain that it cannot start virt-viewer.

Check for WAYLAND_DISPLAY as well, DISPLAY is defined only when xwayland is used. In case of waypipe it configures only WAYLAND_DISPLAY.

Move the check before we check for virt-viewer as without display there is no point to check if virt-viewer is installed or not.

Fixes: https://github.com/virt-manager/virt-manager/issues/884