### PR TITLE
Allow space and disallow slash in validation

### DIFF
--- a/tests/test_xmlparse.py
+++ b/tests/test_xmlparse.py
@@ -1021,7 +1021,9 @@ def testXMLBuilderCoverage():
         virtinst.DeviceDisk.validate_generic_name("objtype", None)
 
     with pytest.raises(ValueError):
-        virtinst.DeviceDisk.validate_generic_name("objtype", "foo bar")
+        virtinst.DeviceDisk.validate_generic_name("objtype", "foo/bar")
+
+    assert virtinst.DeviceDisk.validate_generic_name("objtype", "foo bar") is None
 
     # Test property __repr__ for code coverage
     assert "DeviceAddress" in str(virtinst.DeviceDisk.address)

--- a/virtinst/xmlbuilder.py
+++ b/virtinst/xmlbuilder.py
@@ -510,9 +510,8 @@ class XMLBuilder(object):
 
     @staticmethod
     def validate_generic_name(name_label, val):
-        # Rather than try and match libvirt's regex, just forbid things we
-        # know don't work
-        forbid = [" "]
+        # Only character that shouldn't work is '/', matching QEMU
+        forbid = ["/"]
         if not val:
             # translators: value is a generic object type name
             raise ValueError(_("A name must be specified for the %s") % name_label)


### PR DESCRIPTION
This PR updates the name validation to allow spaces and disallow `/`, matching QEMU validation.

It also adds test coverage to ensure:
- Names with spaces pass validation
- Names with `/` raise `ValueError`

In response to #740