### PR TITLE
Add Ctrl+Alt+Shift+Esc key command for logind's SecureAttentionKey

### DIFF
--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -120,6 +120,7 @@ def build_keycombo_menu(on_send_key_fn):
 
     make_item("<Control><Alt>BackSpace", ["Control_L", "Alt_L", "BackSpace"])
     make_item("<Control><Alt>Delete", ["Control_L", "Alt_L", "Delete"])
+    make_item("<Control><Alt><Shift>Escape", ["Control_L", "Alt_L", "Shift_L", "Escape"])
     menu.add(Gtk.SeparatorMenuItem())
 
     for i in range(1, 13):


### PR DESCRIPTION
logind now supports a new key binding https://github.com/systemd/systemd/pull/29542 Ctrl+Alt+Shift+Esc that emits SecureAttentionKey to allow login managers to start or switch back to the greeter