### PR TITLE
fix: set default start_folder value to None

### DIFF
--- a/virtManager/storagebrowse.py
+++ b/virtManager/storagebrowse.py
@@ -176,6 +176,7 @@ class vmmStorageBrowser(vmmGObjectUI):
         data = _BrowseReasonMetadata(self._browse_reason)
         gsettings_key = data.gsettings_key
 
+        start_folder = None
         if gsettings_key:
             start_folder = self.config.get_default_directory(gsettings_key)
 


### PR DESCRIPTION
#901

Error:
```
DEBUG (cli:195) Uncaught exception:
Traceback (most recent call last):
  File "/nix/store/f4iw4ran3xbfxqfcqmc0l69gj33pq3lq-virt-manager-5.0.0/share/virt-manager/virtManager/storagebrowse.py", line 162, in _browse_clicked
    return self._browse_local()
           ^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/f4iw4ran3xbfxqfcqmc0l69gj33pq3lq-virt-manager-5.0.0/share/virt-manager/virtManager/storagebrowse.py", line 190, in _browse_local
    start_folder=start_folder,
                 ^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'start_folder' where it is not associated with a value
```