### PR TITLE
Various flake8 fixes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2686,7 +2686,7 @@ def test_virtinstall_no_testsuite():
     some code paths like proper logging etc.
     """
     cmd = Command(
-        "virt-install --connect %s " "--test-stub-command --noautoconsole" % (utils.URIs.test_suite)
+        "virt-install --connect %s --test-stub-command --noautoconsole" % (utils.URIs.test_suite)
     )
     cmd.run()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -185,7 +185,7 @@ class SkipChecks:
         self._check(conn, self.predefine_check)
 
 
-class Command(object):
+class Command:
     """
     Instance of a single cli command to test
     """
@@ -371,7 +371,7 @@ class Command(object):
         self._run()
 
 
-class _CategoryProxy(object):
+class _CategoryProxy:
     """
     Category of an App. Let's us register chunks of suboptions per logical
     grouping of tests. So we may have a virt-install 'storage' group which
@@ -396,7 +396,7 @@ class _CategoryProxy(object):
         return self._app.add_compare(self._name, *args, **kwargs)
 
 
-class App(object):
+class App:
     """
     Represents a top level app test suite, like virt-install or virt-xml
     """

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -26,7 +26,7 @@ KSNEW = "tests/data/inject/new-kickstart.ks"
 PRESEED = "tests/data/inject/preseed.cfg"
 
 
-class Distro(object):
+class Distro:
     def __init__(self, name, url, filename, warntype=WARN_FEDORA):
         self.name = name
         self.url = url

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -20,7 +20,7 @@ from virtinst import log
 os.environ.pop("VIRTINST_TEST_SUITE", None)
 
 
-class _URLTestData(object):
+class _URLTestData:
     """
     Class that tracks all data needed for a single URL test case.
     Data is stored in data/test_urls.ini

--- a/tests/uitests/lib/app.py
+++ b/tests/uitests/lib/app.py
@@ -16,7 +16,7 @@ import tests.utils
 from . import utils
 
 
-class VMMDogtailApp(object):
+class VMMDogtailApp:
     """
     Wrapper class to simplify dogtail app handling
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -146,7 +146,7 @@ class _URIs(object):
                 if not is_testdriver_xml:
                     raise
                 self._testdriver_error = (
-                    "error opening testdriver.xml: %s\n" "libvirt is probably too old" % str(e)
+                    "error opening testdriver.xml: %s\nlibvirt is probably too old" % str(e)
                 )
                 print(self._testdriver_error, file=sys.stderr)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,7 @@ from virtinst import xmlutil
 # pylint: disable=protected-access
 
 
-class _TestConfig(object):
+class _TestConfig:
     """
     Class containing any bits passed in from setup.py
     """
@@ -51,7 +51,7 @@ def has_old_osinfo():
     return not virtinst.OSDB.lookup_os(osname).supports_chipset_q35()
 
 
-class _URIs(object):
+class _URIs:
     def __init__(self):
         self._conn_cache = {}
         self._testdriver_cache = None

--- a/virt-clone
+++ b/virt-clone
@@ -6,6 +6,6 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from virtinst import virtclone
+from virtinst import virtclone  # noqa: E402
 
 virtclone.runcli()

--- a/virt-install
+++ b/virt-install
@@ -6,6 +6,6 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from virtinst import virtinstall
+from virtinst import virtinstall  # noqa: E402
 
 virtinstall.runcli()

--- a/virt-manager
+++ b/virt-manager
@@ -6,6 +6,6 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from virtManager import virtmanager
+from virtManager import virtmanager  # noqa: E402
 
 virtmanager.runcli()

--- a/virt-xml
+++ b/virt-xml
@@ -6,6 +6,6 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from virtinst import virtxml
+from virtinst import virtxml  # noqa: E402
 
 virtxml.runcli()

--- a/virtManager/addhardware.py
+++ b/virtManager/addhardware.py
@@ -386,7 +386,7 @@ class vmmAddHardware(vmmGObjectUI):
                 # Guest XML editing
                 define_func(**define_args)
         except Exception as e:
-            err.show_err((_("Error changing VM configuration: %s") % str(e)))
+            err.show_err(_("Error changing VM configuration: %s") % str(e))
             return False
 
         if not vm.is_active():

--- a/virtManager/config.py
+++ b/virtManager/config.py
@@ -37,7 +37,7 @@ CSSDATA = """
 """
 
 
-class _SettingsWrapper(object):
+class _SettingsWrapper:
     """
     Wrapper class to simplify interacting with gsettings APIs.
     Basically it allows simple get/set of gconf style paths, and
@@ -131,7 +131,7 @@ class _SettingsWrapper(object):
         return settings.set_value(key, GLib.Variant(fmt, value), *args, **kwargs)
 
 
-class vmmConfig(object):
+class vmmConfig:
     CONSOLE_SCALE_NEVER = 0
     CONSOLE_SCALE_FULLSCREEN = 1
     CONSOLE_SCALE_ALWAYS = 2

--- a/virtManager/createnet.py
+++ b/virtManager/createnet.py
@@ -335,7 +335,7 @@ class vmmCreateNetwork(vmmGObjectUI):
             net.conn.networkLookupByName(net.name)
         except libvirt.libvirtError:
             return
-        raise ValueError(_("Name '%s' already in use by another network." % net.name))
+        raise ValueError(_("Name '%s' already in use by another network.") % net.name)
 
     def _build_xmlobj_from_xmleditor(self):
         xml = self._xmleditor.get_xml()

--- a/virtManager/createvm.py
+++ b/virtManager/createvm.py
@@ -1713,7 +1713,7 @@ class vmmCreateVM(vmmGObjectUI):
         log.debug("Starting OS detection thread for cdrom=%s location=%s", cdrom, location)
         self.widget("create-forward").set_sensitive(False)
 
-        class ThreadResults(object):
+        class ThreadResults:
             """
             Helper object to track results from the detection thread
             """

--- a/virtManager/details/details.py
+++ b/virtManager/details/details.py
@@ -970,7 +970,7 @@ class vmmDetails(vmmGObjectUI):
 
             self.addhw.show(self.topwin)
         except Exception as e:  # pragma: no cover
-            self.err.show_err((_("Error launching hardware dialog: %s") % str(e)))
+            self.err.show_err(_("Error launching hardware dialog: %s") % str(e))
 
     def _remove_non_disk(self, devobj):
         if not self.err.chkbox_helper(
@@ -1435,7 +1435,7 @@ class vmmDetails(vmmGObjectUI):
             try:
                 self.vm.set_autostart(auto.get_active())
             except Exception as e:  # pragma: no cover
-                self.err.show_err((_("Error changing autostart value: %s") % str(e)))
+                self.err.show_err(_("Error changing autostart value: %s") % str(e))
                 return False
 
         if self._edited(EDIT_BOOTORDER):

--- a/virtManager/details/details.py
+++ b/virtManager/details/details.py
@@ -2028,7 +2028,7 @@ class vmmDetails(vmmGObjectUI):
         target_port = chardev.target_port
         dev_type = chardev.type or "pty"
         primary = self.vm.serial_is_console_dup(chardev)
-        show_target_type = not (char_type in ["serial", "parallel"])
+        show_target_type = char_type not in ["serial", "parallel"]
         is_qemuga = chardev.target_name == chardev.CHANNEL_NAME_QEMUGA
         show_clipboard = chardev.type == chardev.TYPE_QEMUVDAGENT
 

--- a/virtManager/details/details.py
+++ b/virtManager/details/details.py
@@ -1779,7 +1779,7 @@ class vmmDetails(vmmGObjectUI):
 
     def _refresh_stats_page(self):
         def _multi_color(text1, text2):
-            return '<span color="#82003B">%s</span> ' '<span color="#295C45">%s</span>' % (
+            return '<span color="#82003B">%s</span> <span color="#295C45">%s</span>' % (
                 text1,
                 text2,
             )

--- a/virtManager/details/sshtunnels.py
+++ b/virtManager/details/sshtunnels.py
@@ -76,11 +76,14 @@ class ConnectionInfo(object):
             and self._is_listen_localhost()
             and not self._is_listen_localhost(self._connhost)
         ):
-            return _(
-                "Guest is on a remote host with transport '%s' "
-                "but is only configured to listen locally. "
-                "To connect remotely you will need to change the guest's "
-                "listen address." % self.transport
+            return (
+                _(
+                    "Guest is on a remote host with transport '%s' "
+                    "but is only configured to listen locally. "
+                    "To connect remotely you will need to change the guest's "
+                    "listen address."
+                )
+                % self.transport
             )
 
     def get_conn_host(self):

--- a/virtManager/details/sshtunnels.py
+++ b/virtManager/details/sshtunnels.py
@@ -16,7 +16,7 @@ from virtinst import log
 from ..baseclass import vmmGObject
 
 
-class ConnectionInfo(object):
+class ConnectionInfo:
     """
     Holds all the bits needed to make a connection to a graphical console
     """
@@ -122,7 +122,7 @@ class ConnectionInfo(object):
         )
 
 
-class _TunnelScheduler(object):
+class _TunnelScheduler:
     """
     If the user is using Spice + SSH URI + no SSH keys, we need to
     serialize connection opening otherwise ssh-askpass gets all angry.
@@ -167,7 +167,7 @@ class _TunnelScheduler(object):
 _tunnel_scheduler = _TunnelScheduler()
 
 
-class _Tunnel(object):
+class _Tunnel:
     def __init__(self):
         self._pid = None
         self._closed = False
@@ -281,7 +281,7 @@ def _make_ssh_command(ginfo):
     return argv
 
 
-class SSHTunnels(object):
+class SSHTunnels:
     def __init__(self, ginfo):
         self._tunnels = []
         self._sshcommand = _make_ssh_command(ginfo)

--- a/virtManager/hoststorage.py
+++ b/virtManager/hoststorage.py
@@ -50,7 +50,7 @@ def _get_pool_size_percent(pool):
     alloc = pool.get_allocation()
     per = 0
     if cap and alloc is not None:
-        per = int(((float(alloc) / float(cap)) * 100))
+        per = int((float(alloc) / float(cap)) * 100)
     return "<span size='small'>%s%%</span>" % int(per)
 
 

--- a/virtManager/lib/connectauth.py
+++ b/virtManager/lib/connectauth.py
@@ -189,7 +189,7 @@ def connect_error(conn, errmsg, tb, warnconsole):
             hint += _("Verify that an appropriate libvirt daemon is running.")
             show_errmsg = False
 
-    msg = _("Unable to connect to libvirt %s." % conn.get_uri())
+    msg = _("Unable to connect to libvirt %s.") % conn.get_uri()
     if show_errmsg:
         msg += "\n\n%s" % errmsg
     if hint:

--- a/virtManager/lib/graphwidgets.py
+++ b/virtManager/lib/graphwidgets.py
@@ -197,7 +197,7 @@ class CellRendererSparkline(Gtk.CellRenderer):
 
         points = []
         for index in range(0, len(self.data_array)):
-            x = int(((index * pixels_per_point) + graph_x))
+            x = int((index * pixels_per_point) + graph_x)
             y = int(get_y(index))
 
             points.append((x, y))

--- a/virtManager/lib/keyring.py
+++ b/virtManager/lib/keyring.py
@@ -177,7 +177,7 @@ class vmmKeyring(vmmGObject):
     ##############
 
     def is_available(self):
-        return not (self._collection is None)
+        return self._collection is not None
 
     def _get_secret_name(self, vm):
         return "vm-console-" + vm.get_uuid()

--- a/virtManager/lib/keyring.py
+++ b/virtManager/lib/keyring.py
@@ -12,7 +12,7 @@ from virtinst import log
 from ..baseclass import vmmGObject
 
 
-class _vmmSecret(object):
+class _vmmSecret:
     def __init__(self, name, secret=None, attributes=None):
         self.name = name
         self.secret = secret

--- a/virtManager/lib/libvirtenummap.py
+++ b/virtManager/lib/libvirtenummap.py
@@ -10,7 +10,7 @@ import libvirt
 from virtinst import log
 
 
-class _LibvirtEnumMap(object):
+class _LibvirtEnumMap:
     """
     Helper for mapping libvirt event int values to their API names
     """

--- a/virtManager/lib/statsmanager.py
+++ b/virtManager/lib/statsmanager.py
@@ -13,7 +13,7 @@ from virtinst import log
 from ..baseclass import vmmGObject
 
 
-class _VMStatsRecord(object):
+class _VMStatsRecord:
     """
     Tracks a set of VM stats for a single timestamp
     """

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -23,7 +23,7 @@ from ..lib.libvirtenummap import LibvirtEnumMap
 from ..lib import testmock
 
 
-class _SENTINEL(object):
+class _SENTINEL:
     pass
 
 
@@ -140,7 +140,7 @@ class _IPFetcher:
         return None, None
 
 
-class vmmInspectionApplication(object):
+class vmmInspectionApplication:
     def __init__(self):
         self.name = None
         self.display_name = None
@@ -151,7 +151,7 @@ class vmmInspectionApplication(object):
         self.description = None
 
 
-class vmmInspectionData(object):
+class vmmInspectionData:
     def __init__(self):
         self.os_type = None
         self.distro = None

--- a/virtManager/object/network.py
+++ b/virtManager/object/network.py
@@ -17,8 +17,8 @@ def _make_addr_str(addrStr, prefix, netmaskStr):
     if prefix:
         return str(ipaddress.ip_network(str("{}/{}").format(addrStr, prefix), strict=False))
     elif netmaskStr:
-        netmask = ipaddress.ip_address(str((netmaskStr)))
-        network = ipaddress.ip_address(str((addrStr)))
+        netmask = ipaddress.ip_address(str(netmaskStr))
+        network = ipaddress.ip_address(str(addrStr))
         return str(ipaddress.ip_network(str("{}/{}").format(network, netmask), strict=False))
     else:
         return str(ipaddress.ip_network(str(addrStr), strict=False))

--- a/virtManager/systray.py
+++ b/virtManager/systray.py
@@ -90,7 +90,7 @@ if AppIndicator3:  # pragma: no cover
 ###########################
 
 
-class _Systray(object):
+class _Systray:
     def is_embedded(self):
         raise NotImplementedError()
 

--- a/virtManager/vmmenu.py
+++ b/virtManager/vmmenu.py
@@ -132,7 +132,7 @@ class VMActionMenu(_VMMenu):
                 child.get_child().set_label(text)
 
 
-class VMActionUI(object):
+class VMActionUI:
     """
     Singleton object for handling VM actions, asking for confirmation,
     showing errors/progress dialogs, etc.

--- a/virtManager/vmmenu.py
+++ b/virtManager/vmmenu.py
@@ -191,7 +191,7 @@ class VMActionUI(object):
         if not src.err.chkbox_helper(
             src.config.get_confirm_forcepoweroff,
             src.config.set_confirm_forcepoweroff,
-            text1=_("Are you sure you want to force poweroff '%s'?" % vm.get_name()),
+            text1=_("Are you sure you want to force poweroff '%s'?") % vm.get_name(),
             text2=_(
                 "This will immediately poweroff the VM without "
                 "shutting down the OS and may cause data loss."
@@ -207,7 +207,7 @@ class VMActionUI(object):
         if not src.err.chkbox_helper(
             src.config.get_confirm_pause,
             src.config.set_confirm_pause,
-            text1=_("Are you sure you want to pause '%s'?" % vm.get_name()),
+            text1=_("Are you sure you want to pause '%s'?") % vm.get_name(),
         ):
             return
 
@@ -264,7 +264,7 @@ class VMActionUI(object):
         if not src.err.chkbox_helper(
             src.config.get_confirm_poweroff,
             src.config.set_confirm_poweroff,
-            text1=_("Are you sure you want to poweroff '%s'?" % vm.get_name()),
+            text1=_("Are you sure you want to poweroff '%s'?") % vm.get_name(),
         ):
             return
 
@@ -276,7 +276,7 @@ class VMActionUI(object):
         if not src.err.chkbox_helper(
             src.config.get_confirm_poweroff,
             src.config.set_confirm_poweroff,
-            text1=_("Are you sure you want to reboot '%s'?" % vm.get_name()),
+            text1=_("Are you sure you want to reboot '%s'?") % vm.get_name(),
         ):
             return
 
@@ -288,7 +288,7 @@ class VMActionUI(object):
         if not src.err.chkbox_helper(
             src.config.get_confirm_forcepoweroff,
             src.config.set_confirm_forcepoweroff,
-            text1=_("Are you sure you want to force reset '%s'?" % vm.get_name()),
+            text1=_("Are you sure you want to force reset '%s'?") % vm.get_name(),
             text2=_(
                 "This will immediately reset the VM without "
                 "shutting down the OS and may cause data loss."

--- a/virtinst/buildconfig.py
+++ b/virtinst/buildconfig.py
@@ -42,7 +42,7 @@ def _get_param(name, default):  # pragma: no cover
         return default
 
 
-class _BuildConfig(object):
+class _BuildConfig:
     def __init__(self):
         self.cfgpath = _cfgpath
         self.version = _get_param("version", "")

--- a/virtinst/capabilities.py
+++ b/virtinst/capabilities.py
@@ -181,7 +181,7 @@ class _CapsGuest(XMLBuilder):
 ############################
 
 
-class _CapsInfo(object):
+class _CapsInfo:
     """
     Container object to hold the results of guest_lookup, so users don't
     need to juggle two objects

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -186,7 +186,7 @@ def setupLogging(appname, debug_stdout, do_quiet, cli_app=True):
         if get_global_state().quiet:
             level = logging.ERROR
         else:
-            level = logging.WARN
+            level = logging.WARNING
         streamHandler.setLevel(level)
         streamHandler.setFormatter(logging.Formatter(streamErrorFormat))
     else:  # pragma: no cover

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -46,7 +46,7 @@ HAS_VIRTVIEWER = shutil.which("virt-viewer")
 ##########################
 
 
-class _GlobalState(object):
+class _GlobalState:
     def __init__(self):
         self.quiet = False
 
@@ -1170,7 +1170,7 @@ class _SuboptCheckerClass:
 _SuboptChecker = _SuboptCheckerClass()
 
 
-class _VirtCLIArgumentStatic(object):
+class _VirtCLIArgumentStatic:
     """
     Helper class to hold all of the static data we need for knowing
     how to parse a cli subargument, like --disk path=, or --network mac=.
@@ -1271,7 +1271,7 @@ class _VirtCLIArgumentStatic(object):
         return False
 
 
-class _VirtCLIArgument(object):
+class _VirtCLIArgument:
     """
     A class that combines the static parsing data _VirtCLIArgumentStatic
     with actual values passed on the command line.
@@ -2080,7 +2080,7 @@ def parse_location(optstr):
 ####################
 
 
-class OSInfoData(object):
+class OSInfoData:
     _REQUIRE_ON = 1
     _REQUIRE_AUTO = 3
 
@@ -2206,7 +2206,7 @@ def _determine_default_autoconsole_type(guest, installer):
     return "graphical"
 
 
-class _AutoconsoleData(object):
+class _AutoconsoleData:
     def __init__(self, autoconsole, guest, installer):
         self._autoconsole = autoconsole
         if self._autoconsole not in ["none", "default", "text", "graphical"]:

--- a/virtinst/cloner.py
+++ b/virtinst/cloner.py
@@ -303,7 +303,7 @@ class _CloneDiskInfo:
             raise ValueError(msg)
 
 
-class Cloner(object):
+class Cloner:
     @staticmethod
     def generate_clone_name(conn, basename):
         return _generate_clone_name(conn, basename)

--- a/virtinst/cloner.py
+++ b/virtinst/cloner.py
@@ -294,7 +294,7 @@ class _CloneDiskInfo:
     def raise_error(self):
         if self.is_clone_requested() and self.get_cloneable_msg():
             msg = self.get_cloneable_msg()
-            err = _("Could not determine original disk information: %s" % msg)
+            err = _("Could not determine original disk information: %s") % msg
             raise ValueError(err)
         if self.is_share_requested():
             return

--- a/virtinst/connection.py
+++ b/virtinst/connection.py
@@ -31,7 +31,7 @@ def _real_local_libvirt_version():
     return getattr(libvirt, key)
 
 
-class VirtinstConnection(object):
+class VirtinstConnection:
     """
     Wrapper for libvirt connection that provides various bits like
     - caching static data

--- a/virtinst/devices/disk.py
+++ b/virtinst/devices/disk.py
@@ -253,7 +253,7 @@ class DeviceDisk(Device):
         """
         log.debug("DeviceDisk.check_path_search path=%s", path)
 
-        class SearchData(object):
+        class SearchData:
             def __init__(self):
                 self.user = None
                 self.uid = None

--- a/virtinst/devices/disk.py
+++ b/virtinst/devices/disk.py
@@ -391,7 +391,7 @@ class DeviceDisk(Device):
         from ..storage import StorageVolume
 
         if size is None:
-            raise ValueError(_("Size must be specified for non existent volume '%s'" % volname))
+            raise ValueError(_("Size must be specified for non existent volume '%s'") % volname)
 
         # This catches --disk /dev/idontexist,size=1 if /dev is unmanaged
         if not poolobj:

--- a/virtinst/diskbackend.py
+++ b/virtinst/diskbackend.py
@@ -573,7 +573,7 @@ class CloneStorageCreator(_StorageCreator):
 
     def validate(self):
         if self._size is None:  # pragma: no cover
-            raise ValueError(_("size is required for non-existent disk '%s'" % self.get_path()))
+            raise ValueError(_("size is required for non-existent disk '%s'") % self.get_path())
 
         err, msg = self.is_size_conflict()
         if err:

--- a/virtinst/diskbackend.py
+++ b/virtinst/diskbackend.py
@@ -368,7 +368,7 @@ def is_path_searchable(path, uid, username):
 ##############################################
 
 
-class _StorageBase(object):
+class _StorageBase:
     """
     Storage base class, defining the API used by DeviceDisk
     """

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -351,7 +351,7 @@ class DomainCapabilities(XMLBuilder):
                 if re.match(pattern, path):
                     return _("UEFI %(arch)s: %(path)s") % {"arch": arch, "path": path}
 
-        return _("Custom: %(path)s" % {"path": path})
+        return _("Custom: %(path)s") % {"path": path}
 
     def arch_can_uefi(self):
         """

--- a/virtinst/install/cloudinit.py
+++ b/virtinst/install/cloudinit.py
@@ -136,7 +136,7 @@ class CloudInitData:
 
         if self.disable:
             content += "runcmd:\n"
-            content += '- echo "Disabled by virt-install" > ' "/etc/cloud/cloud-init.disabled\n"
+            content += '- echo "Disabled by virt-install" > /etc/cloud/cloud-init.disabled\n'
 
         clean_content = re.sub(r"root:(.*)", "root:[SCRUBBLED]", content)
         if "VIRTINST_TEST_SUITE_PRINT_CLOUDINIT" in os.environ:

--- a/virtinst/install/installer.py
+++ b/virtinst/install/installer.py
@@ -25,7 +25,7 @@ def _make_testsuite_path(path):
     return os.path.join("/VIRTINST-TESTSUITE", os.path.basename(path).split("-", 2)[-1])
 
 
-class Installer(object):
+class Installer:
     """
     Class for kicking off VM installs. The VM is set up separately in a Guest
     instance. This class tracks the install media/bootdev choice, alters the

--- a/virtinst/install/installertreemedia.py
+++ b/virtinst/install/installertreemedia.py
@@ -23,7 +23,7 @@ def _is_url(url):
     return url.startswith("http://") or url.startswith("https://") or url.startswith("ftp://")
 
 
-class _LocationData(object):
+class _LocationData:
     def __init__(self, osinfo, kernel_pairs, os_media, os_tree):
         self.osinfo = osinfo
         self.kernel_pairs = kernel_pairs
@@ -36,7 +36,7 @@ class _LocationData(object):
             self.kernel_url_arg = osobj.get_kernel_url_arg()
 
 
-class InstallerTreeMedia(object):
+class InstallerTreeMedia:
     """
     Class representing --location Tree media. Can be one of
 

--- a/virtinst/install/urldetect.py
+++ b/virtinst/install/urldetect.py
@@ -17,7 +17,7 @@ from ..osdict import OSDB
 ###############################################
 
 
-class _DistroCache(object):
+class _DistroCache:
     def __init__(self, fetcher):
         self._fetcher = fetcher
         self._filecache = {}
@@ -182,7 +182,7 @@ class _DistroCache(object):
         return True
 
 
-class _SUSEContent(object):
+class _SUSEContent:
     """
     Helper class tracking the SUSE 'content' files
     """
@@ -329,7 +329,7 @@ def getDistroStore(guest, fetcher, skip_error):
 ##################
 
 
-class _DistroTree(object):
+class _DistroTree:
     """
     Class for determining the kernel/initrd path for an install
     tree (URL, ISO, or local directory)

--- a/virtinst/install/urlfetcher.py
+++ b/virtinst/install/urlfetcher.py
@@ -55,7 +55,7 @@ class _XorrisoReader:
 ###########################
 
 
-class _URLFetcher(object):
+class _URLFetcher:
     """
     This is a generic base class for fetching/extracting files from
     a media source, such as CD ISO, or HTTP/HTTPS/FTP server

--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -50,7 +50,7 @@ class _OsinfoIter:
         return ret
 
 
-class _OSDB(object):
+class _OSDB:
     """
     Entry point for the public API
     """
@@ -237,7 +237,7 @@ class _OsResources:
 #####################
 
 
-class _OsVariant(object):
+class _OsVariant:
     def __init__(self, o):
         self._os = o
 
@@ -596,7 +596,7 @@ class _OsVariant(object):
         return False
 
 
-class _OsMedia(object):
+class _OsMedia:
     def __init__(self, osinfo_media):
         self._media = osinfo_media
 
@@ -623,7 +623,7 @@ class _OsMedia(object):
         return self._media
 
 
-class _OsTree(object):
+class _OsTree:
     def __init__(self, osinfo_tree):
         self._tree = osinfo_tree
 

--- a/virtinst/storage.py
+++ b/virtinst/storage.py
@@ -221,7 +221,7 @@ class StoragePool(_StorageObject):
             conn.storagePoolLookupByName(name)
         except libvirt.libvirtError:
             return
-        raise ValueError(_("Name '%s' already in use by another pool." % name))  # pragma: no cover
+        raise ValueError(_("Name '%s' already in use by another pool.") % name)  # pragma: no cover
 
     def default_target_path(self):
         if not self.supports_target_path():
@@ -567,7 +567,7 @@ class StorageVolume(_StorageObject):
         except libvirt.libvirtError:
             return
         raise ValueError(
-            _("Name '%s' already in use by another volume." % name)
+            _("Name '%s' already in use by another volume.") % name
         )  # pragma: no cover
 
     def _get_vol_type(self):

--- a/virtinst/support.py
+++ b/virtinst/support.py
@@ -74,7 +74,7 @@ def _version_str_to_int(verstr):
     )
 
 
-class _SupportCheck(object):
+class _SupportCheck:
     """
     @version: Minimum libvirt version required for this feature. Not used
         if 'args' provided.

--- a/virtinst/uri.py
+++ b/virtinst/uri.py
@@ -26,7 +26,7 @@ def sanitize_xml_for_test_define(xml):
     return xml
 
 
-class URI(object):
+class URI:
     """
     Parse an arbitrary URI into its individual parts
     """
@@ -87,7 +87,7 @@ class URI(object):
         return scheme, username, netloc, uri, query, fragment
 
 
-class MagicURI(object):
+class MagicURI:
     """
     Handle magic virtinst URIs we use for the test suite and UI testing.
     This allows a special URI to override various features like capabilities

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -983,7 +983,7 @@ def start_install(guest, installer, options):
             domain = installer.start_install(
                 guest, meter=meter, doboot=not options.noreboot, transient=options.transient
             )
-        except:  # noqa
+        except:  # noqa: E722
             virtinst.Installer.cleanup_created_disks(guest, meter)
             raise
 

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -525,10 +525,8 @@ def set_cli_defaults(options, guest):
     if storage and not storage_specified(options, guest):
         diskstr = "size=%d" % (storage // (1024**3))
         cli.print_stdout(
-            _(
-                "Using {os_name} default --disk {disk_options}".format(
-                    os_name=guest.osinfo.name, disk_options=diskstr
-                )
+            _("Using {os_name} default --disk {disk_options}").format(
+                os_name=guest.osinfo.name, disk_options=diskstr
             )
         )
         options.disk = [diskstr]

--- a/virtinst/xmlapi.py
+++ b/virtinst/xmlapi.py
@@ -12,7 +12,7 @@ from .logger import log
 # pylint: disable=protected-access
 
 
-class _XPathSegment(object):
+class _XPathSegment:
     """
     Class representing a single 'segment' of an xpath string. For example,
     the xpath:
@@ -54,7 +54,7 @@ class _XPathSegment(object):
             self.nsname, self.nodename = self.nodename.split(":")
 
 
-class _XPath(object):
+class _XPath:
     """
     Helper class for performing manipulations of XPath strings. Splits
     the xpath into segments.
@@ -84,7 +84,7 @@ class _XPath(object):
         return self.join(self.segments[:-1])
 
 
-class _XMLBase(object):
+class _XMLBase:
     NAMESPACES = {}
 
     @classmethod

--- a/virtinst/xmlbuilder.py
+++ b/virtinst/xmlbuilder.py
@@ -26,7 +26,7 @@ _allprops = []
 _seenprops = []
 
 
-class XMLManualAction(object):
+class XMLManualAction:
     """
     Helper class for tracking and performing the user requested manual
     XML action
@@ -81,7 +81,7 @@ class XMLManualAction(object):
         xmlstate.xmlapi.set_xpath_content(xpath, setval)
 
 
-class _XMLPropertyCache(object):
+class _XMLPropertyCache:
     """
     Cache lookup tables mapping classes to their associated
     XMLProperty and XMLChildProperty classes
@@ -413,7 +413,7 @@ class XMLProperty(_XMLPropertyBase):
         xmlbuilder._xmlstate.xmlapi.set_xpath_content(xpath, setval)
 
 
-class _XMLState(object):
+class _XMLState:
     def __init__(self, root_name, parsexml, parentxmlstate, relative_object_xpath):
         self._root_name = root_name
         self._namespace = ""
@@ -484,7 +484,7 @@ class _XMLState(object):
         return self._join_xpath(self.abs_xpath() or ".", xpath)
 
 
-class XMLBuilder(object):
+class XMLBuilder:
     """
     Base for all classes which build or parse domain XML
     """


### PR DESCRIPTION
- explicitly exclude E402 in wrapper scripts
- `not .. in/is` -> `not in/is`
- `logging.WARN` -> `logging.WARNING`
- explicit specify flake8 issue in `noqa`
- fix some gettext calls
- merge few strings in the same line that are implicitly concatenated
- drop unneeded `object` inheritance
- drop extra parentheses

See the commit messages for more details.

In most of the commit there are no behaviour changes. The "gettext calls fix" commit actually fixes the translation of few strings.