### PR TITLE
xmlapi: rewrite the code to use lxml instead of libxml2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable=Design,Similarities,invalid-name,missing-docstring,line-too-long,too-many-lines,superfluous-parens,bad-whitespace,locally-disabled,no-self-use,unnecessary-lambda,star-args,fixme,global-statement,bare-except,anomalous-backslash-in-string,broad-except,cyclic-import,bad-continuation,locally-enabled,unidiomatic-typecheck,redefined-variable-type,bad-option-value,wrong-import-position,consider-using-ternary,no-else-return,len-as-condition,inconsistent-return-statements,useless-object-inheritance,consider-using-in,useless-return,assignment-from-none,chained-comparison,import-outside-toplevel,use-a-generator,consider-using-with,consider-using-f-string,unspecified-encoding,use-maxsplit-arg,possibly-used-before-assignment
+disable=Design,Similarities,invalid-name,missing-docstring,line-too-long,too-many-lines,superfluous-parens,bad-whitespace,locally-disabled,no-self-use,unnecessary-lambda,star-args,fixme,global-statement,bare-except,anomalous-backslash-in-string,broad-except,cyclic-import,bad-continuation,locally-enabled,unidiomatic-typecheck,redefined-variable-type,bad-option-value,wrong-import-position,consider-using-ternary,no-else-return,len-as-condition,inconsistent-return-statements,useless-object-inheritance,consider-using-in,useless-return,assignment-from-none,chained-comparison,import-outside-toplevel,use-a-generator,consider-using-with,consider-using-f-string,unspecified-encoding,use-maxsplit-arg,possibly-used-before-assignment,c-extension-no-member
 enable=fixme
 
 

--- a/tests/data/cli/compare/virt-xml-update-nodefine-succeed.xml
+++ b/tests/data/cli/compare/virt-xml-update-nodefine-succeed.xml
@@ -11,10 +11,10 @@
    </devices>
  </domain>
 
-    <interface type="user">
-      <mac address="00:11:22:33:44:56"/>
-      <model type="e1000"/>
-    </interface>
+<interface type="user">
+  <mac address="00:11:22:33:44:56"/>
+  <model type="e1000"/>
+</interface>
 
 
 Hotplug this device to the guest 'test'? (y/n): Device hotplug successful.

--- a/tests/data/cli/compare/virt-xml-update-succeed.xml
+++ b/tests/data/cli/compare/virt-xml-update-succeed.xml
@@ -11,10 +11,10 @@
    </devices>
  </domain>
 
-    <interface type="user">
-      <mac address="00:11:22:33:44:55"/>
-      <model type="e1000"/>
-    </interface>
+<interface type="user">
+  <mac address="00:11:22:33:44:55"/>
+  <model type="e1000"/>
+</interface>
 
 
 Hotplug this device to the guest 'test'? (y/n): Device hotplug successful.

--- a/tests/data/xmlparse/add-devices-out.xml
+++ b/tests/data/xmlparse/add-devices-out.xml
@@ -8,7 +8,8 @@
     <boot dev="hd"/>
   </os>
   <features>
-    <acpi/><apic/>
+    <acpi/>
+    <apic/>
   </features>
   <clock offset="utc"/>
   <on_poweroff>destroy</on_poweroff>

--- a/tests/data/xmlparse/change-chars-out.xml
+++ b/tests/data/xmlparse/change-chars-out.xml
@@ -9,7 +9,8 @@
     <boot dev="network"/>
   </os>
   <features>
-    <acpi/><apic/>
+    <acpi/>
+    <apic/>
   </features>
   <clock offset="utc"/>
   <on_poweroff>destroy</on_poweroff>

--- a/tests/data/xmlparse/change-disk-out.xml
+++ b/tests/data/xmlparse/change-disk-out.xml
@@ -9,7 +9,8 @@
     <boot dev="hd"/>
   </os>
   <features>
-    <acpi/><apic/>
+    <acpi/>
+    <apic/>
   </features>
   <clock offset="utc"/>
   <on_poweroff>destroy</on_poweroff>

--- a/tests/data/xmlparse/change-nics-out.xml
+++ b/tests/data/xmlparse/change-nics-out.xml
@@ -9,7 +9,8 @@
     <boot dev="network"/>
   </os>
   <features>
-    <acpi/><apic/>
+    <acpi/>
+    <apic/>
   </features>
   <clock offset="utc"/>
   <on_poweroff>destroy</on_poweroff>

--- a/tests/data/xmlparse/domain-roundtrip.xml
+++ b/tests/data/xmlparse/domain-roundtrip.xml
@@ -13,32 +13,32 @@
   <!-- intentional mis-indentation -->
   <!-- more comments -->
   <metadata>
-      <herp2erp xmlns:foobar="http://foo.bar3/"/>
-      <herp2erp xmlns:foobar="http://foo.bar3/"/>
-      <herp2erp xmlns:foobar="http://foo.bar3/"/>
-      <app1:foo xmlns:app1="http://foo.org/">fooish</app1:foo>
-      <app3:foo xmlns:app3="http://foo.org/">fooish</app3:foo>
-      <app1:foo xmlns:app1="http://foo.org/">fooish</app1:foo>
-   <app2:bar xmlns:app2="http://bar.com/" maman="baz">barish</app2:bar>
-      <app1:foo xmlns:app1="http://foo.org/">fooish</app1:foo>
-   <app2:bar xmlns:app2="http://bar.com/" maman="baz">barish</app2:bar>
-      <nova:instance xmlns:nova="http://openstack.org/xmlns/libvirt/nova/1.0">
-        <nova:package version="2015.1"/>
-        <nova:name>vm1</nova:name>
-        <nova:creationTime>2015-02-19 18:23:44</nova:creationTime>
-        <nova:flavor name="m1.tiny">
-          <nova:memory>512</nova:memory>
-          <nova:disk>1</nova:disk>
-          <nova:swap>0</nova:swap>
-          <nova:ephemeral>0</nova:ephemeral>
-          <nova:vcpus>1</nova:vcpus>
-        </nova:flavor>
-        <nova:owner>
-          <nova:user uuid="ef53a6031fc643f2af7add439ece7e9d">admin</nova:user>
-          <nova:project uuid="60a60883d7de429aa45f8f9d689c1fd6">demo</nova:project>
-        </nova:owner>
-        <nova:root type="image" uuid="2344a0fc-a34b-4e2d-888e-01db795fc89a"/>
-      </nova:instance>
+    <herp2erp xmlns:foobar="http://foo.bar3/"/>
+    <herp2erp xmlns:foobar="http://foo.bar3/"/>
+    <herp2erp xmlns:foobar="http://foo.bar3/"/>
+    <app1:foo xmlns:app1="http://foo.org/">fooish</app1:foo>
+    <app3:foo xmlns:app3="http://foo.org/">fooish</app3:foo>
+    <app1:foo xmlns:app1="http://foo.org/">fooish</app1:foo>
+    <app2:bar xmlns:app2="http://bar.com/" maman="baz">barish</app2:bar>
+    <app1:foo xmlns:app1="http://foo.org/">fooish</app1:foo>
+    <app2:bar xmlns:app2="http://bar.com/" maman="baz">barish</app2:bar>
+    <nova:instance xmlns:nova="http://openstack.org/xmlns/libvirt/nova/1.0">
+      <nova:package version="2015.1"/>
+      <nova:name>vm1</nova:name>
+      <nova:creationTime>2015-02-19 18:23:44</nova:creationTime>
+      <nova:flavor name="m1.tiny">
+        <nova:memory>512</nova:memory>
+        <nova:disk>1</nova:disk>
+        <nova:swap>0</nova:swap>
+        <nova:ephemeral>0</nova:ephemeral>
+        <nova:vcpus>1</nova:vcpus>
+      </nova:flavor>
+      <nova:owner>
+        <nova:user uuid="ef53a6031fc643f2af7add439ece7e9d">admin</nova:user>
+        <nova:project uuid="60a60883d7de429aa45f8f9d689c1fd6">demo</nova:project>
+      </nova:owner>
+      <nova:root type="image" uuid="2344a0fc-a34b-4e2d-888e-01db795fc89a"/>
+    </nova:instance>
     <boxes:gnome-boxes xmlns:boxes="https://wiki.gnome.org/Apps/Boxes">
       <os-state>installed</os-state>
       <media>/tmp/media.iso</media>

--- a/tests/data/xmlparse/network-vf-pool-out.xml
+++ b/tests/data/xmlparse/network-vf-pool-out.xml
@@ -1,6 +1,6 @@
 <network>
   <name>new-foo</name>
-    <forward mode="hostdev" managed="yes">
-      <pf dev="eth3"/>
-    </forward>
+  <forward mode="hostdev" managed="yes">
+    <pf dev="eth3"/>
+  </forward>
 </network>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1147,7 +1147,7 @@ c.add_invalid(
 )  # URI doesn't support UEFI bits
 c.add_invalid("--graphics type=vnc,keymap", grep="Option 'keymap' had no value set.")
 c.add_invalid("--xml FOOXPATH", grep="form of XPATH=VALUE")  # failure parsing xpath value
-c.add_invalid("--xml /@foo=bar", grep="/@foo xmlXPathEval")  # failure processing xpath
+c.add_invalid("--xml /@foo=bar", grep="/@foo Invalid expression")  # failure processing xpath
 
 
 ########################

--- a/tests/test_xmlparse.py
+++ b/tests/test_xmlparse.py
@@ -419,10 +419,11 @@ def testAlterDevicesBootorder():
 
 def testSingleDisk():
     conn = utils.URIs.open_testdefault_cached()
-    xml = (
-        """<disk type="file" device="disk"><source file="/a.img"/>\n"""
-        """<target dev="hda" bus="ide"/></disk>\n"""
-    )
+    xml = """<disk type="file" device="disk">
+  <source file="/a.img"/>
+  <target dev="hda" bus="ide"/>
+</disk>
+"""
     conn = utils.URIs.open_testdefault_cached()
     d = virtinst.DeviceDisk(conn, parsexml=xml)
     _set_and_check(d, "target", "hda", "hdb")
@@ -1008,7 +1009,7 @@ def testXMLBuilderCoverage():
         # Ensure we validate root element
         virtinst.DeviceDisk(conn, parsexml="<foo/>")
 
-    with pytest.raises(Exception, match=".*xmlParseDoc.*"):
+    with pytest.raises(Exception, match="can only parse strings"):
         # Ensure we validate root element
         virtinst.DeviceDisk(conn, parsexml=-1)
 
@@ -1041,11 +1042,11 @@ def testXMLBuilderCoverage():
     xml = conn.lookupByName("test-for-virtxml").XMLDesc(0)
     guest = virtinst.Guest(conn, parsexml=xml)
 
-    assert guest.features.get_xml().startswith("  <features")
-    assert guest.clock.get_xml().startswith("  <clock")
+    assert guest.features.get_xml().startswith("<features")
+    assert guest.clock.get_xml().startswith("<clock")
     assert guest.seclabels[0].get_xml().startswith("<seclabel")
-    assert guest.cpu.get_xml().startswith("  <cpu")
-    assert guest.os.get_xml().startswith("  <os")
+    assert guest.cpu.get_xml().startswith("<cpu")
+    assert guest.os.get_xml().startswith("<os")
     assert guest.cpu.get_xml_id() == "./cpu"
     assert guest.cpu.get_xml_idx() == 0
     assert guest.get_xml_id() == "."

--- a/virt-manager.spec.in
+++ b/virt-manager.spec.in
@@ -77,7 +77,7 @@ Summary: Common files used by the different Virtual Machine Manager interfaces
 
 Requires: python3-argcomplete
 Requires: python3-libvirt
-Requires: python3-libxml2
+Requires: python3-lxml
 Requires: python3-requests
 Requires: libosinfo >= 0.2.10
 # Required for gobject-introspection infrastructure

--- a/virtinst/xmlapi.py
+++ b/virtinst/xmlapi.py
@@ -4,7 +4,7 @@
 # This work is licensed under the GNU GPLv2 or later.
 # See the COPYING file in the top-level directory.
 
-import libxml2
+from lxml import etree
 
 from . import xmlutil
 from .logger import log
@@ -248,7 +248,7 @@ class _XMLBase:
         xpathobj = _XPath(fullxpath)
         parentxpath = "."
         parentnode = self._find(parentxpath)
-        if not parentnode:
+        if parentnode is None:
             raise xmlutil.DevError("Did not find XML root node for xpath=%s" % fullxpath)
 
         for xpathseg in xpathobj.segments[1:]:
@@ -299,30 +299,11 @@ def node_is_text(n):
     return bool(n and n.type == "text")
 
 
-class _Libxml2API(_XMLBase):
+class _LxmlAPI(_XMLBase):
     def __init__(self, xml):
         _XMLBase.__init__(self)
-
-        # Use of gtksourceview in virt-manager changes this libxml
-        # global setting which messes up whitespace after parsing.
-        # We can probably get away with calling this less but it
-        # would take some investigation
-        libxml2.keepBlanksDefault(1)
-
-        self._doc = libxml2.parseDoc(xml)
-        self._ctx = self._doc.xpathNewContext()
-        self._ctx.setContextNode(self._doc.children)
-        for key, val in self.NAMESPACES.items():
-            self._ctx.xpathRegisterNs(key, val)
-
-    def __del__(self):
-        if not hasattr(self, "_doc"):
-            # In case we error when parsing the doc
-            return
-        self._doc.freeDoc()
-        self._doc = None
-        self._ctx.xpathFreeContext()
-        self._ctx = None
+        self._parser = etree.XMLParser(remove_blank_text=True)
+        self._doc = etree.fromstring(xml, parser=self._parser)
 
     def _sanitize_xml(self, xml):
         if not xml.endswith("\n") and "\n" in xml:
@@ -330,113 +311,74 @@ class _Libxml2API(_XMLBase):
         return xml
 
     def copy_api(self):
-        return _Libxml2API(self._doc.children.serialize())
+        return _LxmlAPI(etree.tostring(self._doc, encoding="unicode", pretty_print=True))
 
     def _find(self, fullxpath):
         xpath = _XPath(fullxpath).xpath
         try:
-            node = self._ctx.xpathEval(xpath)
+            node = self._doc.xpath(xpath, namespaces=self.NAMESPACES)
         except Exception as e:
             log.debug("fullxpath=%s xpath=%s eval failed", fullxpath, xpath, exc_info=True)
             raise RuntimeError("%s %s" % (fullxpath, str(e))) from None
-        return node and node[0] or None
+        return node[0] if len(node) else None
 
     def count(self, xpath):
-        return len(self._ctx.xpathEval(xpath))
+        return len(self._doc.xpath(xpath, namespaces=self.NAMESPACES))
 
     def _node_tostring(self, node):
-        return node.serialize()
+        return etree.tostring(node, encoding="unicode", pretty_print=True)
 
     def _node_from_xml(self, xml):
-        return libxml2.parseDoc(xml).children
+        return etree.fromstring(xml, parser=self._parser)
 
     def _node_get_text(self, node):
-        return node.content
+        return node.text
 
     def _node_set_text(self, node, setval):
-        if setval is not None:
-            setval = xmlutil.xml_escape(setval)
-        node.setContent(setval)
+        node.text = setval
 
     def _node_get_property(self, node, propname):
-        prop = node.hasProp(propname)
-        if prop:
-            return prop.content
+        return node.get(propname)
 
     def _node_set_property(self, node, propname, setval):
         if setval is None:
-            prop = node.hasProp(propname)
-            if prop:
-                prop.unlinkNode()
-                prop.freeNode()
+            node.attrib.pop(propname, None)
         else:
-            node.setProp(propname, setval)
+            node.set(propname, setval)
 
     def _node_new(self, xpathseg, parentnode):
-        newnode = libxml2.newNode(xpathseg.nodename)
-        if not xpathseg.nsname:
-            return newnode
+        name = xpathseg.nodename
+        nsmap = None
+        if xpathseg.nsname:
+            name = etree.QName(self.NAMESPACES[xpathseg.nsname], name)
+            nsmap = {xpathseg.nsname: self.NAMESPACES[xpathseg.nsname]}
 
-        def _find_parent_ns():
-            parent = parentnode
-            while parent:
-                for ns in xmlutil.listify(parent.nsDefs()):
-                    if ns.name == xpathseg.nsname:
-                        return ns
-                parent = parent.get_parent()
-
-        ns = _find_parent_ns()
-        if not ns:
-            ns = newnode.newNs(self.NAMESPACES[xpathseg.nsname], xpathseg.nsname)
-        newnode.setNs(ns)
-        return newnode
+        return etree.Element(name, nsmap=nsmap)
 
     def node_clear(self, xpath):
         node = self._find(xpath)
         if node:
-            propnames = [p.name for p in (node.properties or [])]
-            for p in propnames:
-                node.unsetProp(p)
-            node.setContent(None)
+            node.clear()
 
     def _node_has_content(self, node):
-        return node.type == "element" and (node.children or node.properties)
+        return etree.iselement(node) and (node.keys() or node.getchildren() or node.text)
 
     def _node_get_name(self, node):
-        return node.name
+        return etree.QName(node).localname
 
     def _node_remove_child(self, parentnode, childnode):
-        node = childnode
-
-        # Look for preceding whitespace and remove it
-        white = node.get_prev()
-        if node_is_text(white):
-            white.unlinkNode()
-            white.freeNode()
-
-        node.unlinkNode()
-        node.freeNode()
-        if all([node_is_text(n) for n in parentnode.children]):
-            parentnode.setContent(None)
+        parentnode.remove(childnode)
+        if len(parentnode.getchildren()) == 0:
+            parentnode.text = None
 
     def _node_add_child(self, parentxpath, parentnode, newnode):
-        ignore = parentxpath
-        if not node_is_text(parentnode.get_last()):
-            prevsib = parentnode.get_prev()
-            if node_is_text(prevsib):
-                newlast = libxml2.newText(prevsib.content)
-            else:
-                newlast = libxml2.newText("\n")
-            parentnode.addChild(newlast)
-
-        endtext = parentnode.get_last().content
-        parentnode.addChild(libxml2.newText("  "))
-        parentnode.addChild(newnode)
-        parentnode.addChild(libxml2.newText(endtext))
+        parentnode.append(newnode)
+        if parentnode.text and parentnode.text.isspace():
+            parentnode.text = None
 
     def _node_replace_child(self, xpath, newnode):
         oldnode = self._find(xpath)
-        oldnode.replaceNode(newnode)
+        oldnode.getparent().replace(oldnode, newnode)
 
 
-XMLAPI = _Libxml2API
+XMLAPI = _LxmlAPI


### PR DESCRIPTION
The python module libxml2 is part of the libxml2 library and they are planning to deprecate and remove this binding in favor of lxml that also uses libxml2 but the binding is done in more pythonic way.

The change to use lxml uncovered some incorrectly formatted bits in our test XMLs that are now fixed.

Disable new pylint category c-extension-no-member as lxml is not introspected by default and pylint complains about it.

Resolves: https://github.com/virt-manager/virt-manager/issues/897