### PR TITLE
chore: avoid using 'l' as variable/parameter name

### DIFF
--- a/tests/test_dist.py
+++ b/tests/test_dist.py
@@ -45,8 +45,8 @@ def test_validate_pot_strings():
         out = subprocess.check_output(
             ["meson", "compile", "-C", "build", "virt-manager-pot"], stderr=subprocess.STDOUT
         )
-        warnings = [l for l in out.decode("utf-8").splitlines() if "warning:" in l]
-        warnings = [w for w in warnings if "a fallback ITS rule file" not in w]
+        warnings = [line for line in out.decode("utf-8").splitlines() if "warning:" in line]
+        warnings = [warning for warning in warnings if "a fallback ITS rule file" not in warning]
         if warnings:
             raise AssertionError("xgettext has warnings:\n\n%s" % "\n".join(warnings))
     finally:

--- a/tests/uitests/test_about.py
+++ b/tests/uitests/test_about.py
@@ -15,10 +15,10 @@ def testAbout(app):
     app.root.find("Help", "menu").click()
     app.root.find("About", "menu item").click()
     win = app.root.find_fuzzy("About", "dialog")
-    l = win.find_fuzzy("Copyright", "label")
+    label = win.find_fuzzy("Copyright", "label")
 
     curyear = datetime.datetime.today().strftime("%Y")
-    if curyear not in l.text:
+    if curyear not in label.text:
         print("Current year=%s not in about.ui dialog!" % curyear)
 
     win.keyCombo("<ESC>")

--- a/virtManager/details/sshtunnels.py
+++ b/virtManager/details/sshtunnels.py
@@ -305,15 +305,15 @@ class SSHTunnels:
         return retfd
 
     def close_all(self):
-        for l in self._tunnels:
-            l.close()
+        for tunnel in self._tunnels:
+            tunnel.close()
         self._tunnels = []
         self.unlock()
 
     def get_err_output(self):
         errstrings = []
-        for l in self._tunnels:
-            e = l.get_err_output().strip()
+        for tunnel in self._tunnels:
+            e = tunnel.get_err_output().strip()
             if e and e not in errstrings:
                 errstrings.append(e)
         return "\n".join(errstrings)

--- a/virtinst/devices/__init__.py
+++ b/virtinst/devices/__init__.py
@@ -30,4 +30,4 @@ from .watchdog import DeviceWatchdog
 from .pstore import DevicePstore
 
 
-__all__ = [l for l in locals() if l.startswith("Device")]
+__all__ = [local for local in locals() if local.startswith("Device")]

--- a/virtinst/diskbackend.py
+++ b/virtinst/diskbackend.py
@@ -635,16 +635,16 @@ class CloneStorageCreator(_StorageCreator):
 
                 i = 0
                 while 1:
-                    l = os.read(src_fd, clone_block_size)
-                    s = len(l)
+                    data = os.read(src_fd, clone_block_size)
+                    s = len(data)
                     if s == 0:
                         meter.end()
                         break
                     # check sequence of zeros
-                    if sparse and zeros == l:
+                    if sparse and zeros == data:
                         os.lseek(dst_fd, s, 1)
                     else:
-                        b = os.write(dst_fd, l)
+                        b = os.write(dst_fd, data)
                         if s != b:  # pragma: no cover
                             meter.end()
                             break

--- a/virtinst/domain/__init__.py
+++ b/virtinst/domain/__init__.py
@@ -22,4 +22,4 @@ from .vcpus import DomainVCPUs
 from .xmlnsqemu import DomainXMLNSQemu
 from .launch_security import DomainLaunchSecurity
 
-__all__ = [l for l in locals() if l.startswith("Domain")]
+__all__ = [local for local in locals() if local.startswith("Domain")]

--- a/virtinst/virtinstall.py
+++ b/virtinst/virtinstall.py
@@ -96,10 +96,10 @@ def _do_convert_old_disks(options):
     paths = virtinst.xmlutil.listify(options.file_paths)
     sizes = virtinst.xmlutil.listify(options.disksize)
 
-    def padlist(l, padsize):
-        l = virtinst.xmlutil.listify(l)
-        l.extend((padsize - len(l)) * [None])
-        return l
+    def padlist(lst, padsize):
+        lst = virtinst.xmlutil.listify(lst)
+        lst.extend((padsize - len(lst)) * [None])
+        return lst
 
     disklist = padlist(paths, max(0, len(sizes)))
     sizelist = padlist(sizes, len(disklist))
@@ -188,10 +188,10 @@ def convert_old_networks(options):
         # Convert old --bridges to --networks
         networks = ["bridge:" + b for b in bridges]
 
-    def padlist(l, padsize):
-        l = virtinst.xmlutil.listify(l)
-        l.extend((padsize - len(l)) * [None])
-        return l
+    def padlist(lst, padsize):
+        lst = virtinst.xmlutil.listify(lst)
+        lst.extend((padsize - len(lst)) * [None])
+        return lst
 
     # If a plain mac is specified, have it imply a default network
     networks = padlist(networks, max(len(macs), 1))

--- a/virtinst/xmlutil.py
+++ b/virtinst/xmlutil.py
@@ -13,13 +13,13 @@ class DevError(RuntimeError):
         RuntimeError.__init__(self, "programming error: %s" % msg)
 
 
-def listify(l):
-    if l is None:
+def listify(lst):
+    if lst is None:
         return []
-    elif not isinstance(l, list):
-        return [l]
+    elif not isinstance(lst, list):
+        return [lst]
     else:
-        return l
+        return lst
 
 
 def xml_escape(xml):


### PR DESCRIPTION
According to PEP8 [1], 'l' (lowercase 'L') is name to avoid, as potentially hard to read.

Switch the occurrences to more clear names representing better what the variables/parameters represent (e.g. "tunnel", "data", etc). In case the variable/parameter is really a list, use "lst" to not use "list" and override the builtin.

Additionally, a 'w' variable was changed for consistency with the 'l' changed in the line above it.

There should be no behaviour changes.

[1] https://peps.python.org/pep-0008/#names-to-avoid