### PR TITLE
virt-manager: improve feedback for unavailable system tray icon

### DIFF
--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -33,7 +33,7 @@
                 <property name="label-xalign">0</property>
                 <property name="shadow-type">none</property>
                 <child>
-                  <!-- n-columns=1 n-rows=3 -->
+                  <!-- n-columns=1 n-rows=4 -->
                   <object class="GtkGrid" id="table5">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -116,7 +116,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">2</property>
+                        <property name="top-attach">3</property>
                       </packing>
                     </child>
                     <child>
@@ -129,6 +129,40 @@
                         <property name="use-underline">True</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_prefs_xmleditor_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="prefs-system-tray-warn-box">
+                        <property name="can-focus">False</property>
+                        <property name="spacing">3</property>
+                        <child>
+                          <object class="GtkImage">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="icon-name">dialog-warning</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="prefs-system-tray-warn-label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-markup">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>

--- a/virtManager/preferences.py
+++ b/virtManager/preferences.py
@@ -9,6 +9,7 @@ from gi.repository import Gdk
 
 from virtinst import DomainCpu
 from virtinst import log
+from virtinst import xmlutil
 
 from .lib import uiutil
 from .baseclass import vmmGObjectUI
@@ -198,10 +199,15 @@ class vmmPreferences(vmmGObjectUI):
 
     def refresh_view_system_tray(self):
         errmsg = vmmSystray.systray_disabled_message()
-        val = bool(self.config.get_view_system_tray() and not errmsg)
-        self.widget("prefs-system-tray").set_sensitive(not bool(errmsg))
-        self.widget("prefs-system-tray").set_tooltip_text(errmsg)
+        has_errmsg = bool(errmsg)
+        val = bool(self.config.get_view_system_tray()) and not has_errmsg
+        self.widget("prefs-system-tray").set_sensitive(not has_errmsg)
         self.widget("prefs-system-tray").set_active(val)
+        if has_errmsg:
+            self.widget("prefs-system-tray-warn-label").set_markup(
+                "<small>%s</small>" % xmlutil.xml_escape(errmsg)
+            )
+        uiutil.set_grid_row_visible(self.widget("prefs-system-tray-warn-box"), has_errmsg)
 
     def refresh_xmleditor(self):
         val = self.config.get_xmleditor_enabled()

--- a/virtManager/systray.py
+++ b/virtManager/systray.py
@@ -416,7 +416,7 @@ class vmmSystray(vmmGObject):
             return
         if _USING_APPINDICATOR:
             return
-        return "No appindicator listener found, which is required on wayland."
+        return _("AppIndicator not installed or usable, system tray icon not available on Wayland")
 
     def __init__(self):
         vmmGObject.__init__(self)


### PR DESCRIPTION
In case the system tray icon is not available on Wayland (because of the lack of Ayatana AppIndicator), the only notification of that is an untranslated message shown only as tooltip on the check box of the option.

To make that notification a bit more visible, use the same approach for the libguestfs option change: add a row below the check box with a warning icon and text next to it. This row is shown only in case there is an error message to show, and it is used instead of setting the tooltop of the check box.

Also, reword the error message to make it a bit less technical, and make it translatable.

Screenshot region of the preferences window without AppIndicator installed and running on Wayland:
![Screenshot_20250625_064710](https://github.com/user-attachments/assets/3f068a0e-e1b0-4b88-8cfc-a0df4edb4acb)