### PR TITLE
tests: use more pytest 7+ pathlib bits

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,8 +87,14 @@ else:
 
 
 def pytest_collection_modifyitems(config, items):
+    def item_path_basename(item):
+        try:
+            return item.path.name
+        except AttributeError:
+            return os.path.basename(item.fspath)
+
     def find_items(basename):
-        return [i for i in items if os.path.basename(i.fspath) == basename]
+        return [i for i in items if item_path_basename(i) == basename]
 
     # Move test_cli cases to the end, because they are slow
     # Move test_checkprops to the very end, because it needs to run


### PR DESCRIPTION
pytest 7 adds various bits using `pathlib`, deprecating the old counterparts based on `py.path`; in particular, in virt-manager I found two places:
- the `pytest_ignore_collect()` hook: there is a new `collection_path` parameter replacing `path`, however there is no way to keep a single implementation, extra steps are done to implement the right hook depending on the pytest version
- `Node.fspath`, in particular as used in the `pytest_collection_modifyitems()` hook: add a new helper to use the new `Node.path` when available

See the messages of the commits for longer explanations. This should make it possible to run the tests without any behaviour change in any pytest version.