### PR TITLE
virtinst: add support for creating TDX guests

### DIFF
--- a/tests/data/cli/compare/virt-install-x86_64-launch-security-tdx-full.xml
+++ b/tests/data/cli/compare/virt-install-x86_64-launch-security-tdx-full.xml
@@ -1,0 +1,83 @@
+<domain type="kvm">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os firmware="efi">
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000e"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <tpm model="tpm-crb">
+      <backend type="emulator"/>
+    </tpm>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="qxl"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+  <launchSecurity type="tdx">
+    <policy>0x10000000</policy>
+    <mrConfigId>ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8BI0VniavN7wEjRWeJq83v</mrConfigId>
+    <mrOwner>ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8BI0VniavN7wEjRWeJq83v</mrOwner>
+    <mrOwnerConfig>ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8BI0VniavN7wEjRWeJq83v</mrOwnerConfig>
+    <quoteGenerationService path="/var/run/tdx-qgs/qgs.socket"/>
+  </launchSecurity>
+</domain>

--- a/tests/data/cli/compare/virt-install-x86_64-launch-security-tdx-qgs.xml
+++ b/tests/data/cli/compare/virt-install-x86_64-launch-security-tdx-qgs.xml
@@ -1,0 +1,79 @@
+<domain type="kvm">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os firmware="efi">
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000e"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <tpm model="tpm-crb">
+      <backend type="emulator"/>
+    </tpm>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="qxl"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+  <launchSecurity type="tdx">
+    <quoteGenerationService/>
+  </launchSecurity>
+</domain>

--- a/tests/data/cli/compare/virt-install-x86_64-launch-security-tdx.xml
+++ b/tests/data/cli/compare/virt-install-x86_64-launch-security-tdx.xml
@@ -1,0 +1,79 @@
+<domain type="kvm">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os firmware="efi">
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000e"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <tpm model="tpm-crb">
+      <backend type="emulator"/>
+    </tpm>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="qxl"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+  <launchSecurity type="tdx">
+    <policy>0x10000000</policy>
+  </launchSecurity>
+</domain>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1853,6 +1853,27 @@ c.add_invalid(
     prerun_check="10.5.0",
 )
 
+c.add_compare(
+    "--boot uefi --machine q35 --launchSecurity type=tdx,policy=0x10000000",
+    "x86_64-launch-security-tdx",
+    prerun_check="11.6.0",
+)
+c.add_compare(
+    "--boot uefi --machine q35 --launchSecurity type=tdx,quoteGenerationService=on",
+    "x86_64-launch-security-tdx-qgs",
+    prerun_check="11.6.0",
+)
+c.add_compare(
+    "--boot uefi --machine q35 --launchSecurity type=tdx,policy=0x10000000,mrConfigId=ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8BI0VniavN7wEjRWeJq83v,mrOwner=ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8BI0VniavN7wEjRWeJq83v,mrOwnerConfig=ASNFZ4mrze8BI0VniavN7wEjRWeJq83vASNFZ4mrze8BI0VniavN7wEjRWeJq83v,quoteGenerationSocket=/var/run/tdx-qgs/qgs.socket",
+    "x86_64-launch-security-tdx-full",
+    prerun_check="11.6.0",
+)
+c.add_invalid(
+    "--machine pc --launchSecurity type=tdx,policy=0x10000000",
+    grep="TDX launch security requires a Q35 UEFI machine",
+    prerun_check="11.6.0",
+)
+
 
 ######################
 # LXC specific tests #

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -5310,6 +5310,11 @@ class ParserLaunchSecurity(VirtCLIParser):
         cls.add_arg("kernelHashes", "kernelHashes", is_onoff=True)
         cls.add_arg("authorKey", "authorKey", is_onoff=True)
         cls.add_arg("vcek", "vcek", is_onoff=True)
+        cls.add_arg("mrConfigId", "mrConfigId")
+        cls.add_arg("mrOwner", "mrOwner")
+        cls.add_arg("mrOwnerConfig", "mrOwnerConfig")
+        cls.add_arg("quoteGenerationService", "quoteGenerationService", is_onoff=True)
+        cls.add_arg("quoteGenerationSocket", "quoteGenerationSocket")
 
 
 ###########################

--- a/virtinst/domain/launch_security.py
+++ b/virtinst/domain/launch_security.py
@@ -22,6 +22,11 @@ class DomainLaunchSecurity(XMLBuilder):
     kernelHashes = XMLProperty("./@kernelHashes", is_yesno=True)
     authorKey = XMLProperty("./@authorKey", is_yesno=True)
     vcek = XMLProperty("./@vcek", is_yesno=True)
+    mrConfigId = XMLProperty("./mrConfigId")
+    mrOwner = XMLProperty("./mrOwner")
+    mrOwnerConfig = XMLProperty("./mrOwnerConfig")
+    quoteGenerationService = XMLProperty("./quoteGenerationService", is_bool=True)
+    quoteGenerationSocket = XMLProperty("./quoteGenerationService/@path")
 
     def _set_defaults_sev(self, guest):
         if not guest.os.is_q35() or not guest.is_uefi():
@@ -41,8 +46,14 @@ class DomainLaunchSecurity(XMLBuilder):
         if not guest.os.is_q35() or not guest.is_uefi():
             raise RuntimeError(_("SEV-SNP launch security requires a Q35 UEFI machine"))
 
+    def _set_defaults_tdx(self, guest):
+        if not guest.os.is_q35() or not guest.is_uefi():
+            raise RuntimeError(_("TDX launch security requires a Q35 UEFI machine"))
+
     def set_defaults(self, guest):
         if self.type == "sev":
             return self._set_defaults_sev(guest)
         elif self.type == "sev-snp":
             return self._set_defaults_sev_snp(guest)
+        elif self.type == "tdx":
+            return self._set_defaults_tdx(guest)


### PR DESCRIPTION
A minimal config to enable TDX, with support for attestation would be

 $ virt-install
     ...args...
     --boot uefi \
     --machine q35 \
     --launchSecurity type=tdx,quoteGenerationService=on


NB, libvirt support for TDX is NOT yet merged, and this PR XML does NOT patch the XML of the latest patches - it is written based on my suggested XML rename of one of the elements. 

IOW this PR must wait until the final libvirt merge.