### PR TITLE
virtinst: cloudinit: include empty meta-data file

### DIFF
--- a/virtinst/install/cloudinit.py
+++ b/virtinst/install/cloudinit.py
@@ -36,7 +36,7 @@ class _CloudInitConfig:
     def _create_file(self):
         content = self._content()
 
-        if not content:
+        if content is None:
             return None
 
         fileobj = tempfile.NamedTemporaryFile(


### PR DESCRIPTION
Refactor creation of cloud-init config files introduced a bug where we stopped including empty meta-data file.

Introduced-by: 5b2d0997a1d2d213b17c227169da64e2fa7d09a6
Fixes: https://github.com/virt-manager/virt-manager/issues/975