### PR TITLE
Rename AppStream metadata to rDNS format

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -2,7 +2,7 @@ fs = import('fs')
 
 desktop_file = files('virt-manager.desktop.in')
 
-appdata_file = files('virt-manager.appdata.xml.in')
+metainfo_file = files('org.virt_manager.virt-manager.metainfo.xml.in')
 
 install_data(
   'org.virt-manager.virt-manager.gschema.xml',

--- a/data/org.virt_manager.virt-manager.metainfo.xml.in
+++ b/data/org.virt_manager.virt-manager.metainfo.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
-  <id>virt-manager.desktop</id>
+<component type="desktop-application">
+  <id>org.virt_manager.virt-manager</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>Virtual Machine Manager</name>

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,4 +1,4 @@
-data/virt-manager.appdata.xml.in
+data/org.virt_manager.virt-manager.metainfo.xml.in
 data/virt-manager.desktop.in
 ui/about.ui
 ui/addhardware.ui

--- a/po/meson.build
+++ b/po/meson.build
@@ -10,7 +10,7 @@ i18n.merge_file(
 )
 
 i18n.merge_file(
-  input: appdata_file,
+  input: metainfo_file,
   output: '@BASENAME@',
   type: 'xml',
   po_dir: meson.current_source_dir(),

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,9 +7,9 @@ lint_files = [
 spell_files = lint_files + [
   '*.md',
   'man/*.rst',
-  'data/virt-manager.appdata.xml.in',
-  'data/virt-manager.desktop.in',
   'data/org.virt-manager.virt-manager.gschema.xml',
+  'data/org.virt_manager.virt-manager.metainfo.xml.in',
+  'data/virt-manager.desktop.in',
   'virt-manager.spec.in',
 ]
 

--- a/tests/test_dist.py
+++ b/tests/test_dist.py
@@ -120,4 +120,4 @@ def test_ui_translatable_atknames():
 
 
 def test_appstream_validate():
-    subprocess.check_call(["appstream-util", "validate", "data/virt-manager.appdata.xml.in"])
+    subprocess.check_call(["appstream-util", "validate", "data/org.virt_manager.virt-manager.metainfo.xml.in"])

--- a/virt-manager.spec.in
+++ b/virt-manager.spec.in
@@ -149,7 +149,7 @@ machine).
 
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/glib-2.0/schemas/org.virt-manager.virt-manager.gschema.xml
-%{_datadir}/metainfo/%{name}.appdata.xml
+%{_datadir}/metainfo/org.virt_manager.virt-manager.metainfo.xml
 
 
 %files common -f %{name}.lang


### PR DESCRIPTION
Use proper reverse DNS format for AppStream metadata id as recommended by the spec. Also change the suffix to metainfo.xml and component type to desktop-application.