### PR TITLE
virtinst: add support for acpi-generic-initiator

### DIFF
--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -886,6 +886,7 @@
         <address domain="0" bus="0" slot="25" function="0"/>
       </source>
       <rom bar="off"/>
+      <acpi nodeset="0,2"/>
       <boot order="4"/>
     </hostdev>
     <hostdev mode="subsystem" type="usb" managed="yes">
@@ -937,6 +938,7 @@
         <address bus="0" target="0" unit="0"/>
       </source>
       <rom bar="on"/>
+      <acpi nodeset="0-2"/>
     </hostdev>
     <hostdev mode="subsystem" type="usb" managed="yes">
       <source>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -740,7 +740,7 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --console pty,target_type=virtio
 
 
---hostdev net_00_1c_25_10_b1_e4,boot_order=4,rom_bar=off
+--hostdev net_00_1c_25_10_b1_e4,boot_order=4,rom_bar=off,acpi.nodeset=0,2
 --host-device usb_device_781_5151_2004453082054CA1BEEE
 --host-device 001.003
 --hostdev 15:0.1
@@ -748,7 +748,7 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --hostdev 0:15:0.3,address.type=pci,address.zpci.uid=0xffff,address.zpci.fid=0xffffffff
 --host-device 0x062a:0x0001,driver_name=vfio
 --host-device 0483:2016
---host-device pci_8086_2829_scsi_host_scsi_device_lun0,rom.bar=on
+--host-device pci_8086_2829_scsi_host_scsi_device_lun0,rom.bar=on,acpi.nodeset=0-2
 --hostdev usb_5_20 --hostdev usb_5_21
 --hostdev wlan0,type=net
 --hostdev /dev/vdz,type=storage

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -5282,6 +5282,7 @@ class ParserHostdev(VirtCLIParser):
         cls.add_arg("name", None, cb=cls.set_name_cb, lookup_cb=cls.name_lookup_cb)
         cls.add_arg("driver.name", "driver_name")
         cls.add_arg("rom.bar", "rom_bar", is_onoff=True)
+        cls.add_arg("acpi.nodeset", "acpi_nodeset", can_comma=True)
         cls.add_arg("source.startupPolicy", "startup_policy")
 
 

--- a/virtinst/devices/hostdev.py
+++ b/virtinst/devices/hostdev.py
@@ -128,6 +128,7 @@ class DeviceHostdev(Device):
 
     driver_name = XMLProperty("./driver/@name")
     rom_bar = XMLProperty("./rom/@bar", is_onoff=True)
+    acpi_nodeset = XMLProperty("./acpi/@nodeset")
 
     # type=scsi handling
     scsi_adapter = XMLProperty("./source/adapter/@name")


### PR DESCRIPTION
A minimal config to enable acpi-generic-initiator would be

 $ virt-install
     ...args...
     --hostdev net_00_1c_25_10_b1_e4,acpi_nodeset=0,2-4

Signed-off-by: Nathan Chen <nathanc@nvidia.com>