### PR TITLE
Calling loader.close() before pixbuf assignment to avoid NoneType pixbuf

### DIFF
--- a/virtManager/details/snapshots.py
+++ b/virtManager/details/snapshots.py
@@ -32,8 +32,8 @@ mimemap = {
 def _make_screenshot_pixbuf(mime, sdata):
     loader = GdkPixbuf.PixbufLoader.new_with_mime_type(mime)
     loader.write(sdata)
-    pixbuf = loader.get_pixbuf()
     loader.close()
+    pixbuf = loader.get_pixbuf()
 
     maxsize = 450
 


### PR DESCRIPTION
In the case `loader.close()` has more parsing to do, `get_pixbuf()` can return a `NoneType` which causes issues in the snapshot view. Calling `loader.close()` before this allows for proper cleanup before calling `get_pixbuf()`.

https://docs.gtk.org/gdk-pixbuf/method.PixbufLoader.close.html
https://docs.gtk.org/gdk-pixbuf/method.PixbufLoader.get_pixbuf.html

Fixes https://github.com/virt-manager/virt-manager/issues/1002