### PR TITLE
virtinst: Fix XDG_DATA_HOME handling

### DIFF
--- a/virtinst/connection.py
+++ b/virtinst/connection.py
@@ -186,7 +186,8 @@ class VirtinstConnection:
     def get_libvirt_data_root_dir(self):
         if self.is_privileged():
             return "/var/lib/libvirt"
-        return os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share/libvirt"))
+        path = os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
+        return os.path.join(path, "libvirt")
 
     ####################
     # Polling routines #


### PR DESCRIPTION
The default value of XDG_DATA_HOME should be ~/.local/share.

It will not by default contain libvirt at the end of the path, so subsequently append libvirt after retrieving the value of XDG_DATA_HOME