### PR TITLE
ci: Fix test-against-libvirt-git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         dnf install -y \
           gettext \
+          gobject-introspection \
           python3-devel \
           python3-docutils \
           meson

--- a/.github/workflows/test-against-libvirt-git.yml
+++ b/.github/workflows/test-against-libvirt-git.yml
@@ -26,6 +26,7 @@ jobs:
 
         dnf install -y \
           gettext \
+          gobject-introspection \
           python3-devel \
           python3-docutils \
           meson

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,6 +8,7 @@ specfile_path: build/virt-manager.spec
 
 srpm_build_deps:
   - gettext
+  - gobject-introspection
   - python3-devel
   - python3-docutils
   - meson


### PR DESCRIPTION
pytest-error-for-skips was dropped from fedora.
get it from pip instead