### PR TITLE
virtinst: fix locale when running in flatpak

### DIFF
--- a/virtinst/__init__.py
+++ b/virtinst/__init__.py
@@ -24,6 +24,7 @@ def _setup_i18n():
 
     gettext.install("virt-manager", BuildConfig.gettext_dir, names=["ngettext"])
     gettext.bindtextdomain("virt-manager", BuildConfig.gettext_dir)
+    locale.bindtextdomain("virt-manager", BuildConfig.gettext_dir)
 
 
 def _set_libvirt_error_handler():


### PR DESCRIPTION
Module locale is used to configure C libraries. When running in flatpak we need to set correct path using locale module as well.

Resolves: https://github.com/virt-manager/virt-manager/issues/1023