### PR TITLE
add custom model for loongarch64

### DIFF
--- a/tests/data/cli/compare/virt-install-loongarch64-cdrom.xml
+++ b/tests/data/cli/compare/virt-install-loongarch64-cdrom.xml
@@ -15,6 +15,9 @@
   <features>
     <acpi/>
   </features>
+  <cpu mode="custom" match="exact">
+    <model>la464</model>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-loongarch64</emulator>
@@ -94,6 +97,9 @@
   <features>
     <acpi/>
   </features>
+  <cpu mode="custom" match="exact">
+    <model>la464</model>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-loongarch64</emulator>

--- a/tests/data/cli/compare/virt-install-loongarch64-cloud-init.xml
+++ b/tests/data/cli/compare/virt-install-loongarch64-cloud-init.xml
@@ -15,6 +15,9 @@
   <features>
     <acpi/>
   </features>
+  <cpu mode="custom" match="exact">
+    <model>la464</model>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-loongarch64</emulator>
@@ -92,6 +95,9 @@
   <features>
     <acpi/>
   </features>
+  <cpu mode="custom" match="exact">
+    <model>la464</model>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-loongarch64</emulator>

--- a/tests/data/cli/compare/virt-install-loongarch64-graphics.xml
+++ b/tests/data/cli/compare/virt-install-loongarch64-graphics.xml
@@ -15,6 +15,9 @@
   <features>
     <acpi/>
   </features>
+  <cpu mode="custom" match="exact">
+    <model>la464</model>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-loongarch64</emulator>

--- a/tests/data/cli/compare/virt-install-loongarch64-headless.xml
+++ b/tests/data/cli/compare/virt-install-loongarch64-headless.xml
@@ -15,6 +15,9 @@
   <features>
     <acpi/>
   </features>
+  <cpu mode="custom" match="exact">
+    <model>la464</model>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-loongarch64</emulator>

--- a/tests/data/cli/compare/virt-install-loongarch64-kernel-boot.xml
+++ b/tests/data/cli/compare/virt-install-loongarch64-kernel-boot.xml
@@ -18,6 +18,9 @@
   <features>
     <acpi/>
   </features>
+  <cpu mode="custom" match="exact">
+    <model>la464</model>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-loongarch64</emulator>

--- a/tests/data/cli/compare/virt-install-loongarch64-unattended.xml
+++ b/tests/data/cli/compare/virt-install-loongarch64-unattended.xml
@@ -15,6 +15,9 @@
   <features>
     <acpi/>
   </features>
+  <cpu mode="custom" match="exact">
+    <model>la464</model>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-loongarch64</emulator>
@@ -92,6 +95,9 @@
   <features>
     <acpi/>
   </features>
+  <cpu mode="custom" match="exact">
+    <model>la464</model>
+  </cpu>
   <clock offset="utc"/>
   <devices>
     <emulator>/usr/bin/qemu-system-loongarch64</emulator>

--- a/virtManager/createvm.py
+++ b/virtManager/createvm.py
@@ -459,7 +459,7 @@ class vmmCreateVM(vmmGObjectUI):
         is_vz_container = is_vz and guest.os.is_container()
         can_remote_url = self.conn.get_backend().support_remote_url_install()
 
-        installable_arch = bool(guest.os.is_x86() or guest.os.is_ppc64() or guest.os.is_s390x())
+        installable_arch = bool(guest.os.is_x86() or guest.os.is_ppc64() or guest.os.is_s390x() or guest.os.is_loongarch64())
 
         default_efi = (
             self.config.get_default_firmware_setting() == "uefi"
@@ -830,7 +830,8 @@ class vmmCreateVM(vmmGObjectUI):
         if recommended_machine:
             defmachine = recommended_machine
             prios = [defmachine]
-
+        if self._capsinfo.arch in ["loongarch64"]:
+            defmachine = "virt"
         for p in prios[:]:
             if p not in machines:
                 prios.remove(p)  # pragma: no cover

--- a/virtinst/devices/disk.py
+++ b/virtinst/devices/disk.py
@@ -1049,6 +1049,8 @@ class DeviceDisk(Device):
             return "virtio"
         if guest.os.is_q35():
             return "sata"
+         if self.is_cdrom() and guest.os.is_loongarch64():
+            return "scsi"
         if self.conn.is_bhyve():
             # IDE bus is not supported by bhyve
             return "sata"

--- a/virtinst/domain/cpu.py
+++ b/virtinst/domain/cpu.py
@@ -522,6 +522,9 @@ class DomainCpu(XMLBuilder):
 
         elif guest.os.is_x86() and guest.type == "kvm":
             self._set_cpu_x86_kvm_default(guest)
+         
+        elif guest.os.is_loongarch64():
+            self.set_model(guest, "la464")
 
         else:
             domcaps = guest.lookup_domcaps()


### PR DESCRIPTION
I encountered missing default configurations and machine types while testing the virtual machine using the official latest ISO on Alpine. Therefore, I have made the following additions. The relevant test cases have also been successfully executed and updated, resulting in a perfect operational outcome as shown below:
<img width="1283" height="888" alt="Screenshot From 2026-01-21 10-28-44" src="https://github.com/user-attachments/assets/e37a79ce-1d73-43d3-9d23-7ba91d6eb72c" />
<img width="1293" height="933" alt="Screenshot From 2026-01-21 10-30-18" src="https://github.com/user-attachments/assets/22b42ca7-29cb-4cfc-9f45-2a3975765fa2" />

Official Alpine ISO Image:
https://dl-cdn.alpinelinux.org/alpine/v3.23/releases/loongarch64/alpine-standard-3.23.0-loongarch64.iso

The ISO provided above works without issues on both the 3A6000 and 3C5000 models. However, there may be minor issues on other LoongArch physical machines. Alternatively, you can obtain the latest openEuler operating system that supports the LoongArch architecture via the following link:
https://atomgit.com/src-openeuler/virt-manager/tree/openEuler-24.03-LTS-SP3