### PR TITLE
virtinst: Prefer NVMe over IDE, SATA, SD and USB

### DIFF
--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -438,6 +438,10 @@ class _OsVariant:
         devids = ["http://qemu.org/chipset/x86/q35"]
         return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
 
+    def supports_nvme(self, extra_devs=None):
+        devids = ["http://nvmexpress.org/1.0"]
+        return bool(self._device_filter(devids=devids, extra_devs=extra_devs))
+
     def _get_firmware_list(self):
         if hasattr(self._os, "get_complete_firmware_list"):  # pragma: no cover
             return self._os.get_complete_firmware_list().get_elements()


### PR DESCRIPTION
NVMe is a modern and more efficient alternative to IDE, SATA, SD and USB.

It is explicitly checked that both the host and guest support the bus because its support is relatively limited compared to the legacy buses.

It is only compatible with disk (i.e., not floppy or CD-ROM).