### PR TITLE
virtinst: add support for iommufd

### DIFF
--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -928,6 +928,12 @@
         <zpci uid="0xffff" fid="0xffffffff"/>
       </address>
     </hostdev>
+    <hostdev mode="subsystem" type="pci" managed="yes">
+      <source>
+        <address domain="0" bus="21" slot="0" function="4"/>
+      </source>
+      <driver name="vfio" iommufd="yes"/>
+    </hostdev>
     <hostdev mode="subsystem" type="usb" managed="yes">
       <source>
         <vendor id="0x062a"/>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -748,6 +748,7 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --hostdev 15:0.1
 --host-device 2:15:0.2
 --hostdev 0:15:0.3,address.type=pci,address.zpci.uid=0xffff,address.zpci.fid=0xffffffff
+--hostdev 0:15:0.4,driver_name=vfio,driver.iommufd=yes
 --host-device 0x062a:0x0001,driver_name=vfio
 --host-device 0483:2016
 --host-device pci_8086_2829_scsi_host_scsi_device_lun0,rom.bar=on,acpi.nodeset=0-2

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -5287,6 +5287,7 @@ class ParserHostdev(VirtCLIParser):
         cls.add_arg("type", "type")
         cls.add_arg("name", None, cb=cls.set_name_cb, lookup_cb=cls.name_lookup_cb)
         cls.add_arg("driver.name", "driver_name")
+        cls.add_arg("driver.iommufd", "driver_iommufd")
         cls.add_arg("rom.bar", "rom_bar", is_onoff=True)
         cls.add_arg("acpi.nodeset", "acpi_nodeset", can_comma=True)
         cls.add_arg("source.startupPolicy", "startup_policy")

--- a/virtinst/devices/hostdev.py
+++ b/virtinst/devices/hostdev.py
@@ -127,6 +127,7 @@ class DeviceHostdev(Device):
     slot = XMLProperty("./source/address/@slot")
 
     driver_name = XMLProperty("./driver/@name")
+    driver_iommufd = XMLProperty("./driver/@iommufd", is_yesno=True)
     rom_bar = XMLProperty("./rom/@bar", is_onoff=True)
     acpi_nodeset = XMLProperty("./acpi/@nodeset")
 


### PR DESCRIPTION
A minimal config to enable iommufd would be

 $ virt-install
     ...args...
     --host-device 0x062a:0x0001,driver.iommufd=yes