### PR TITLE
cli: add --boot secure-boot option

### DIFF
--- a/man/virt-install.rst
+++ b/man/virt-install.rst
@@ -973,6 +973,12 @@ Some examples:
 ``--boot uefi=off``
     Do not use UEFI if the VM would normally default to it.
 
+``--boot uefi=on,secure-boot=off``
+    Configure the VM to boot from UEFI with secure-boot enabled and enforced.
+    This requires libvirt with firmware auto-selection. Setting ``secure-boot``
+    to off ensures the firmware can boot unsigned binaries.
+    This is a convenience option to control the enrolled-keys firmware feature.
+
 ``--boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=yes,firmware.feature1.name=enrolled-keys,firmware.feature1.enabled=yes``
     Configure the VM to boot from UEFI with Secure Boot support enabled.
     Only signed operating systems will be able to boot with this configuration.

--- a/tests/data/cli/compare/virt-install-boot-uefi-secure-boot.xml
+++ b/tests/data/cli/compare/virt-install-boot-uefi-secure-boot.xml
@@ -1,0 +1,63 @@
+<domain type="kvm">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os firmware="efi">
+    <type arch="x86_64" machine="pc-i440fx-6.1">hvm</type>
+    <firmware>
+      <feature enabled="yes" name="enrolled-keys"/>
+    </firmware>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <controller type="usb" model="ich9-ehci1"/>
+    <controller type="usb" model="ich9-uhci1">
+      <master startport="0"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci2">
+      <master startport="2"/>
+    </controller>
+    <controller type="usb" model="ich9-uhci3">
+      <master startport="4"/>
+    </controller>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="e1000"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <tpm model="tpm-crb">
+      <backend type="emulator"/>
+    </tpm>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich6"/>
+    <video>
+      <model type="qxl"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-xml-edit-boot-secure-boot-off.xml
+++ b/tests/data/cli/compare/virt-xml-edit-boot-secure-boot-off.xml
@@ -1,0 +1,18 @@
+@@
+   <os firmware="efi">
+     <type arch="i686">hvm</type>
+     <firmware>
+-      <feature enabled="yes" name="enrolled-keys"/>
+-      <feature enabled="yes" name="secure-boot"/>
++      <feature enabled="no" name="enrolled-keys"/>
+     </firmware>
+-    <loader readonly="yes" secure="yes" type="pflash" format="qcow2">/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd.qcow2</loader>
+-    <nvram template="/usr/share/OVMF/OVMF_VARS.fd.qcow2" type="file" format="qcow2">
+-      <source file="/var/lib/libvirt/nvram/guest_VARS.fd"/>
+-    </nvram>
+     <boot dev="hd"/>
+   </os>
+   <cpu mode="host-model"/>
+
+Domain 'test-alternate-devs' defined successfully.
+Changes will take effect after the domain is fully powered off.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1634,6 +1634,7 @@ c.add_compare(
     "amd-sev",
     prerun_check=no_osinfo_linux2020_virtio,
 )
+c.add_compare("--osinfo generic --boot uefi,secure-boot=yes --disk none", "boot-uefi-secure-boot")
 
 c.add_invalid(
     "--disk none --location nfs:example.com/fake --nonetworks",
@@ -2216,6 +2217,10 @@ c.add_compare(
 c.add_compare(
     "--print-diff --define --connect %(URI-KVM-X86)s test-alternate-devs --edit --boot uefi=off",
     "edit-boot-uefi-off",
+)
+c.add_compare(
+    "--print-diff --define --connect %(URI-KVM-X86)s test-alternate-devs --edit --boot uefi,secure-boot=off",
+    "edit-boot-secure-boot-off",
 )
 c.add_compare(
     "--print-diff --define --connect %(URI-KVM-X86)s test-many-devices --edit --cpu host-copy",

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -3237,6 +3237,7 @@ class ParserBoot(VirtCLIParser):
         cls.add_arg("domain_type", None, lookup_cb=None, cb=cls.set_domain_type_cb)
         cls.add_arg("emulator", None, lookup_cb=None, cb=cls.set_emulator_cb)
         cls.add_arg("uefi", None, lookup_cb=None, cb=cls.set_uefi_cb)
+        cls.add_arg("secure-boot", "secure_boot", is_onoff=True)
 
         # Common/Shared boot options
         cls.add_arg("loader", "loader")


### PR DESCRIPTION
The new option can be used to enable/disable secure boot verification of UEFI firmware.

If virt-xml is used to change secure-boot print warning that resetting NVRAM is required to make the change effective.

Fixes: https://github.com/virt-manager/virt-manager/issues/495