### PR TITLE
tests: properly skip win11 aarch64 test on old osinfo

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,7 +137,7 @@ def no_osinfo_win11():
 
 def no_osinfo_win11_aarch64():
     win11 = OSDB.lookup_os("win11")
-    if not win11 or win11.get_recommended_resources().get_recommended_ncpus("aarch64") == 1:
+    if not win11 or win11.get_recommended_resources().get_recommended_ncpus("aarch64") is None:
         return "osinfo is too old: no win11 aarch64 entry"
 
 


### PR DESCRIPTION
Fixes my previous commit 23d6f9088f1007f2468d38d3a1e80d1e8cf9bcde