### PR TITLE
Detect optional is_recommended attribute in the osinfo-db firmware

### DIFF
--- a/virtinst/osdict.py
+++ b/virtinst/osdict.py
@@ -443,6 +443,17 @@ class _OsVariant:
             return self._os.get_complete_firmware_list().get_elements()
         return []  # pragma: no cover
 
+    def _recommends_efi(self, arch):
+        if hasattr(Libosinfo.Firmware, "is_recommended"):
+            firmwares = self._get_firmware_list()
+            for firmware in firmwares:  # pragma: no cover
+                if firmware.get_architecture() != arch:
+                    continue
+                if firmware.get_firmware_type() == "efi":
+                    return firmware.is_recommended()
+
+        return False
+
     def _supports_firmware_type(self, name, arch, default):
         firmwares = self._get_firmware_list()
 
@@ -457,6 +468,8 @@ class _OsVariant:
     def requires_firmware_efi(self, arch):
         ret = False
         try:
+            if self._recommends_efi(arch):
+                return True
             supports_efi = self._supports_firmware_type("efi", arch, False)
             supports_bios = self._supports_firmware_type("bios", arch, True)
             ret = supports_efi and not supports_bios


### PR DESCRIPTION
The is_recommended firmware attribute in the osinfo database allows an OS to declare efi as preferred for its security features while still supporting legacy bios. This patch checks for the attribute and defaults to the recommended firmware if specified.