### PR TITLE
domain: make memory usage reporting more flexible

### DIFF
--- a/virtManager/lib/statsmanager.py
+++ b/virtManager/lib/statsmanager.py
@@ -351,8 +351,8 @@ class vmmStatsManager(vmmGObject):
         curmem = 0
         try:
             stats = vm.get_backend().memoryStats()
-            totalmem = stats.get("actual", 1)
-            curmem = max(0, totalmem - stats.get("unused", totalmem))
+            totalmem = stats.get("actual", stats.get("available", 1))
+            curmem = max(0, stats.get("rss", totalmem - stats.get("unused", totalmem)))
         except libvirt.libvirtError as err:  # pragma: no cover
             if vm.conn.support.is_error_nosupport(err):
                 log.debug("conn does not support memoryStats")
@@ -388,7 +388,7 @@ class vmmStatsManager(vmmGObject):
         return currMemPercent, curmem
 
     ####################
-    # alltats handling #
+    # allstats handling #
     ####################
 
     def _get_all_stats(self, conn):


### PR DESCRIPTION
Currently, the _old_mem_stats_helper() method
calculates used memory as 'actual' - 'unused'.
However, it does not work all drivers, e.g. for the bhyve driver which reports 'rss' and 'available' memory.

So try use 'actual' as a total memory and 'rss' a currently used memory and in case these fields are missing, fall back to the original fields.