### PR TITLE
serialcon: add 'nmdm' console support

### DIFF
--- a/virtManager/details/serialcon.py
+++ b/virtManager/details/serialcon.py
@@ -180,7 +180,7 @@ class vmmSerialConsole(vmmGObject):
         """
         Check if we think we can actually open passed console/serial dev
         """
-        usable_types = ["pty"]
+        usable_types = ["pty", "nmdm"]
         ctype = dev.type
 
         err = ""


### PR DESCRIPTION
The 'nmdm' is a console type used by the bhyve driver. It works like a pty console, so adding support is just a matter of adding it to the 'usable_types' list.