### PR TITLE
details: snapshots: Fix error when external snapshot has no thumbnail

### DIFF
--- a/virtManager/details/snapshots.py
+++ b/virtManager/details/snapshots.py
@@ -34,6 +34,8 @@ def _make_screenshot_pixbuf(mime, sdata):
     loader.write(sdata)
     loader.close()
     pixbuf = loader.get_pixbuf()
+    if not pixbuf:
+        return None
 
     maxsize = 450
 


### PR DESCRIPTION
### Summary
This PR fixes a `NoneType` AttributeError in `virtManager/details/snapshots.py` that prevents snapshot details from loading when an external snapshot (or one with missing metadata) does not have an associated screenshot.

### The Issue
In `virt-manager` 5.1.0, the UI attempts to load a preview thumbnail for snapshots. While internal snapshots often have these embedded, external snapshots can cause `GdkPixbuf.PixbufLoader` to return a `None` object. The current implementation of `_make_screenshot_pixbuf` attempts to call `.get_width()` on this object without a null check, triggering an AttributeError and preventing the snapshot metadata from being displayed in the UI.

**Traceback:**
```python
Traceback (most recent call last):
  File "/usr/share/virt-manager/virtManager/details/snapshots.py", line 850, in _snapshot_selected
    self._set_snapshot_state(snap[0])
  File "/usr/share/virt-manager/virtManager/details/snapshots.py", line 657, in _set_snapshot_state
    sn = self._read_screenshot_file(name)
  File "/usr/share/virt-manager/virtManager/details/snapshots.py", line 615, in _read_screenshot_file
    return _make_screenshot_pixbuf(mime, open(filename, "rb").read())
  File "/usr/share/virt-manager/virtManager/details/snapshots.py", line 46, in _make_screenshot_pixbuf
    width = pixbuf.get_width()
AttributeError: 'NoneType' object has no attribute 'get_width'
```

<img width="1231" height="258" alt="image" src="https://github.com/user-attachments/assets/bf6618dd-eda2-4036-9894-a3fa62f6567b" />

I've tested the changes locally and it seems to work fine, apologies if I missed something!