### PR TITLE
Add D-Bus display

### DIFF
--- a/tests/data/cli/compare/virt-xml-change-spice-to-dbus.xml
+++ b/tests/data/cli/compare/virt-xml-change-spice-to-dbus.xml
@@ -1,0 +1,25 @@
+     <emulator>/usr/bin/qemu-system-x86_64</emulator>
+     <controller type="usb" index="0" model="qemu-xhci" ports="15"/>
+     <controller type="virtio-serial" index="0"/>
+-    <channel type="spicevmc">
+-      <target type="virtio" name="com.redhat.spice.0"/>
+-    </channel>
+-    <graphics type="spice" autoport="yes">
+-      <listen type="address"/>
++    <graphics type="dbus">
+       <image compression="off"/>
+       <gl enable="no"/>
+     </graphics>
+-    <audio id="1" type="spice"/>
+     <video>
+       <model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
+     </video>
+-    <redirdev bus="usb" type="spicevmc">
+-    </redirdev>
+-    <redirdev bus="usb" type="spicevmc">
+-    </redirdev>
+   </devices>
+ </domain>
+
+Domain 'test-spice' defined successfully.
+Changes will take effect after the domain is fully powered off.

--- a/tests/data/cli/compare/virt-xml-edit-graphics-dbus.xml
+++ b/tests/data/cli/compare/virt-xml-edit-graphics-dbus.xml
@@ -5,9 +5,31 @@
 -      <listen type="address"/>
 +    <graphics type="dbus">
 +      <gl enable="yes"/>
++      <audio id="1"/>
      </graphics>
-     <sound model="sb16"/>
-     <sound model="es1370"/>
+-    <sound model="sb16"/>
+-    <sound model="es1370"/>
+-    <sound model="ich6"/>
++    <sound model="sb16">
++      <audio id="1"/>
++    </sound>
++    <sound model="es1370">
++      <audio id="1"/>
++    </sound>
++    <sound model="ich6">
++      <audio id="1"/>
++    </sound>
+     <video>
+       <model type="vmvga" vram="16384" heads="1" primary="yes"/>
+     </video>
+@@
+     <vsock model="virtio">
+       <cid auto="no" address="5"/>
+     </vsock>
++    <audio type="dbus" id="1"/>
+   </devices>
+   <seclabel type="dynamic" model="selinux" relabel="yes"/>
+   <keywrap>
 
 Domain 'test-for-virtxml' defined successfully.
 Changes will take effect after the domain is fully powered off.

--- a/tests/data/cli/compare/virt-xml-edit-graphics-dbus.xml
+++ b/tests/data/cli/compare/virt-xml-edit-graphics-dbus.xml
@@ -1,0 +1,13 @@
+         <device path="/dev/tzz"/>
+       </backend>
+     </tpm>
+-    <graphics type="vnc" port="-1" autoport="yes">
+-      <listen type="address"/>
++    <graphics type="dbus">
++      <gl enable="yes"/>
+     </graphics>
+     <sound model="sb16"/>
+     <sound model="es1370"/>
+
+Domain 'test-for-virtxml' defined successfully.
+Changes will take effect after the domain is fully powered off.

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -98,6 +98,7 @@ def testDomainCapabilitiesx86():
     assert "UEFI" in caps.label_for_firmware_path("OVMF")
 
     assert caps.supports_filesystem_virtiofs()
+    assert caps.supports_graphics_dbus()
     assert caps.supports_memorybacking_memfd()
     assert caps.supports_redirdev_usb()
     assert caps.supports_channel_spicevmc()
@@ -117,6 +118,7 @@ def testDomainCapabilitiesAArch64():
     assert "UEFI" in caps.label_for_firmware_path("aarch64/QEMU_EFI")
 
     assert caps.supports_filesystem_virtiofs()
+    assert caps.supports_graphics_dbus()
     assert caps.supports_memorybacking_memfd()
     assert caps.supports_redirdev_usb()
     assert caps.supports_channel_spicevmc()
@@ -136,6 +138,7 @@ def testDomainCapabilitiesPPC64le():
     assert "Default" in caps.label_for_firmware_path(None)
 
     assert caps.supports_filesystem_virtiofs()
+    assert caps.supports_graphics_dbus()
     assert caps.supports_memorybacking_memfd()
     assert caps.supports_redirdev_usb()
     assert not caps.supports_channel_spicevmc()
@@ -167,6 +170,7 @@ def testDomainCapabilitiesRISCV64():
     assert "UEFI" in caps.label_for_firmware_path("RISCV_VIRT_CODE.fd")
 
     assert caps.supports_filesystem_virtiofs()
+    assert caps.supports_graphics_dbus()
     assert caps.supports_memorybacking_memfd()
     assert caps.supports_redirdev_usb()
     assert caps.supports_channel_spicevmc()
@@ -198,7 +202,15 @@ def testDomainCapabilitiesLoongArch64():
     assert "UEFI" in caps.label_for_firmware_path("loongarch64/QEMU_CODE.fd")
 
     assert caps.supports_filesystem_virtiofs()
+    assert caps.supports_graphics_dbus()
     assert caps.supports_memorybacking_memfd()
     assert caps.supports_redirdev_usb()
     assert caps.supports_channel_spicevmc()
     assert caps.supported_panic_models() == ["pvpanic"]
+
+
+def testDomainCapabilitiesDBusUnsupported():
+    xml = open(DATADIR + "/kvm-x86_64-domcaps-insecure.xml").read()
+    caps = DomainCapabilities(utils.URIs.open_testdriver_cached(), xml)
+
+    assert not caps.supports_graphics_dbus()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2364,6 +2364,7 @@ c.add_compare(
 c.add_compare("--network source=br0,type=bridge,model=virtio,mac=", "edit-simple-network")
 c.add_compare("--graphics tlsport=5902,keymap=ja", "edit-simple-graphics")
 c.add_compare("--graphics listen=none", "edit-graphics-listen-none")
+c.add_compare("--graphics type=dbus,gl=on", "edit-graphics-dbus")
 c.add_compare("--controller index=15,model=lsilogic", "edit-simple-controller")
 c.add_compare("--controller index=15,model=lsilogic", "edit-simple-controller")
 c.add_compare("--smartcard type=spicevmc", "edit-simple-smartcard")
@@ -2462,6 +2463,7 @@ c.add_compare(
 
 c = vixml.add_category("edit/remove spice graphics", "test-spice --print-diff --define")
 c.add_compare("--edit --graphics type=vnc", "change-spice-to-vnc")
+c.add_compare("--edit --graphics type=dbus", "change-spice-to-dbus")
 c.add_compare("--remove-device --graphics type=spice", "remove-spice-graphics")
 
 c = vixml.add_category("add/rm devices and start", "test-state-shutoff --print-diff --start")

--- a/tests/test_xmlparse.py
+++ b/tests/test_xmlparse.py
@@ -1239,3 +1239,36 @@ def testConvertToVNC():
     _test("convert-to-vnc-spice-devices")
     _test("convert-to-vnc-spice-manyopts", qemu_vdagent=True)
     _test("convert-to-vnc-has-vnc", qemu_vdagent=True)
+
+
+def testGraphicsDBusXML():
+    conn = utils.URIs.open_testdefault_cached()
+    dev = virtinst.DeviceGraphics(conn)
+
+    dev.type = "dbus"
+    dev.p2p = True
+    dev.dbus_address = "unix:path=/tmp/qemu-dbus-display"
+    dev.audio_id = 7
+    dev.gl = True
+    dev.rendernode = "/dev/dri/renderD128"
+
+    expected = """
+<graphics type="dbus" p2p="yes" address="unix:path=/tmp/qemu-dbus-display">
+  <gl enable="yes" rendernode="/dev/dri/renderD128"/>
+  <audio id="7"/>
+</graphics>
+""".strip()
+    assert _sanitize_file_xml(dev.get_xml()).strip() == expected
+
+    dev.port = 6001
+    dev.listen = "127.0.0.1"
+    dev.passwd = "secret"
+    dev.type = "dbus"
+    assert dev.port is None
+    assert dev.listen is None
+    assert dev.passwd is None
+
+    dev.type = "vnc"
+    assert dev.p2p is None
+    assert dev.dbus_address is None
+    assert dev.audio_id is None

--- a/tests/test_xmlparse.py
+++ b/tests/test_xmlparse.py
@@ -1272,3 +1272,60 @@ def testGraphicsDBusXML():
     assert dev.p2p is None
     assert dev.dbus_address is None
     assert dev.audio_id is None
+
+
+def testChangeGraphicsClearsSpiceAudioRefs():
+    conn = utils.URIs.open_testdefault_cached()
+    xml = """
+<domain type='kvm'>
+  <name>dbus-audio-cleanup</name>
+  <memory unit='KiB'>1048576</memory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch='x86_64'>hvm</type>
+  </os>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <graphics type='spice' autoport='yes'/>
+    <audio id='1' type='spice'/>
+    <sound model='ich9'>
+      <audio id='1'/>
+    </sound>
+  </devices>
+</domain>
+""".strip()
+    guest = virtinst.Guest(conn, xml)
+
+    gfx = guest.devices.graphics[0]
+    guest.change_graphics("dbus", gfx)
+
+    assert guest.devices.audio[0].type == "dbus"
+    assert str(gfx.audio_id) == guest.devices.audio[0].id
+    assert str(guest.devices.sound[0].audio_id) == guest.devices.audio[0].id
+
+
+def testChangeGraphicsAddsDBusAudioBackend():
+    conn = utils.URIs.open_testdefault_cached()
+    xml = """
+<domain type='kvm'>
+  <name>dbus-audio-backend</name>
+  <memory unit='KiB'>1048576</memory>
+  <vcpu>1</vcpu>
+  <os>
+    <type arch='x86_64'>hvm</type>
+  </os>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <graphics type='spice' autoport='yes'/>
+    <sound model='virtio'/>
+  </devices>
+</domain>
+""".strip()
+    guest = virtinst.Guest(conn, xml)
+
+    gfx = guest.devices.graphics[0]
+    guest.change_graphics("dbus", gfx)
+
+    assert guest.devices.audio[0].type == "dbus"
+    assert str(gfx.audio_id) == guest.devices.audio[0].id
+    assert str(guest.devices.sound[0].audio_id) == guest.devices.audio[0].id

--- a/virtManager/config.py
+++ b/virtManager/config.py
@@ -497,7 +497,7 @@ class vmmConfig:
     # New VM preferences
     def get_graphics_type(self, raw=False):
         ret = self.conf.get("/new-vm/graphics-type")
-        if ret not in ["system", "vnc", "spice"]:
+        if ret not in ["system", "vnc", "spice", "dbus"]:
             ret = "system"  # pragma: no cover
         if ret == "system" and not raw:
             return self.default_graphics_from_config

--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -193,7 +193,10 @@ def _cant_embed_graphics(ginfo):
     if ginfo.gtype in ["vnc", "spice"]:
         return
     if ginfo.gtype == "dbus":
-        return _("Cannot display D-Bus graphics directly. Use an external D-Bus viewer.")
+        return _(
+            "Graphical console is not available in D-Bus mode. "
+            "Use an external tool to connect to the D-Bus display."
+        )
 
     msg = _("Cannot display graphical console type '%s'") % ginfo.gtype
     return msg
@@ -852,6 +855,15 @@ class vmmConsolePages(vmmGObjectUI):
         self._populate_console_menu()
         found = self._consolemenu.activate_default()
         if not found:
+            if self.vm.xmlobj.devices.graphics:
+                gdev = self.vm.xmlobj.devices.graphics[0]
+                ginfo = ConnectionInfo(self.vm.conn, gdev)
+                errmsg = _cant_embed_graphics(ginfo)
+                if errmsg:
+                    self.widget("console-pages").set_current_page(_CONSOLE_PAGE_GRAPHICS)
+                    self.idle_add(self._init_viewer, ginfo, errmsg)
+                    return
+
             # Calling this with dev=None will trigger _init_viewer
             # which shows some meaningful errors
             self._console_menu_view_selected()

--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -192,6 +192,8 @@ class vmmOverlayToolbar:
 def _cant_embed_graphics(ginfo):
     if ginfo.gtype in ["vnc", "spice"]:
         return
+    if ginfo.gtype == "dbus":
+        return _("Cannot display D-Bus graphics directly. Use an external D-Bus viewer.")
 
     msg = _("Cannot display graphical console type '%s'") % ginfo.gtype
     return msg

--- a/virtManager/device/gfxdetails.py
+++ b/virtManager/device/gfxdetails.py
@@ -74,6 +74,8 @@ class vmmGraphicsDetails(vmmGObjectUI):
             virtinst.DeviceGraphics.TYPE_RDP,
         ]:
             return str(gtype).upper()
+        if gtype == virtinst.DeviceGraphics.TYPE_DBUS:
+            return "D-Bus"
         return str(gtype).capitalize()
 
     ##########################
@@ -88,6 +90,7 @@ class vmmGraphicsDetails(vmmGObjectUI):
         graphics_model.clear()
         graphics_model.append(["spice", _("Spice server")])
         graphics_model.append(["vnc", _("VNC server")])
+        graphics_model.append(["dbus", _("D-Bus server")])
 
         graphics_listen_list = self.widget("graphics-listen-type")
         graphics_listen_model = Gtk.ListStore(str, str)
@@ -127,6 +130,8 @@ class vmmGraphicsDetails(vmmGObjectUI):
         gtype = uiutil.get_list_selection(self.widget("graphics-type"))
         is_vnc = gtype == "vnc"
         is_spice = gtype == "spice"
+        is_dbus = gtype == "dbus"
+        has_gl = is_spice or is_dbus
 
         listen = uiutil.get_list_selection(self.widget("graphics-listen-type"))
         has_listen_none = listen in ["none", "socket"]
@@ -135,8 +140,12 @@ class vmmGraphicsDetails(vmmGObjectUI):
             [v for v in self.vm.xmlobj.devices.video if (v.model == "virtio" and v.accel3d)]
         )
 
-        uiutil.set_grid_row_visible(self.widget("graphics-warn-virtio"), not has_virtio_3d)
-        uiutil.set_grid_row_visible(self.widget("graphics-warn-listen"), not has_listen_none)
+        uiutil.set_grid_row_visible(
+            self.widget("graphics-warn-virtio"), has_gl and not has_virtio_3d
+        )
+        uiutil.set_grid_row_visible(
+            self.widget("graphics-warn-listen"), is_spice and not has_listen_none
+        )
 
         passwd_enabled = self.widget("graphics-password-chk").get_active()
         self.widget("graphics-password").set_sensitive(passwd_enabled)
@@ -146,7 +155,7 @@ class vmmGraphicsDetails(vmmGObjectUI):
         self.widget("graphics-password").set_visibility(passwd_visible)
 
         glval = self.widget("graphics-opengl").get_active()
-        uiutil.set_grid_row_visible(self.widget("graphics-opengl-subopts-box"), glval and is_spice)
+        uiutil.set_grid_row_visible(self.widget("graphics-opengl-subopts-box"), glval and has_gl)
 
         all_rows = [
             "graphics-listen-type",
@@ -163,16 +172,15 @@ class vmmGraphicsDetails(vmmGObjectUI):
         )
         self.widget("graphics-port").set_visible(not is_auto)
 
-        rows = ["graphics-password-box", "graphics-listen-type"]
-        if listen == "address":
+        rows = []
+        if is_vnc or is_spice:
+            rows.extend(["graphics-password-box", "graphics-listen-type"])
+        if (is_vnc or is_spice) and listen == "address":
             rows.extend(["graphics-port-box", "graphics-address"])
-        if is_spice:
+        if has_gl:
             rows.append("graphics-opengl")
             if glval:
                 rows.append("graphics-opengl-subopts-box")
-
-        if not is_vnc and not is_spice:
-            rows = []
 
         for row in all_rows:
             uiutil.set_grid_row_visible(self.widget(row), row in rows)
@@ -254,31 +262,37 @@ class vmmGraphicsDetails(vmmGObjectUI):
         if not self.widget("graphics-rendernode").is_visible():
             rendernode = None
 
-        passwd = self.widget("graphics-password").get_text()
-        if not self.widget("graphics-password-chk").get_active():
-            passwd = None
+        passwd = None
+        if self.widget("graphics-password-box").is_visible():
+            passwd = self.widget("graphics-password").get_text()
+            if not self.widget("graphics-password-chk").get_active():
+                passwd = None
 
-        portauto = self.widget("graphics-port-auto").get_active()
-        port = uiutil.spin_get_helper(self.widget("graphics-port"))
+        port = None
+        if self.widget("graphics-port-box").is_visible():
+            portauto = self.widget("graphics-port-auto").get_active()
+            port = uiutil.spin_get_helper(self.widget("graphics-port"))
 
-        if (
-            self.widget("graphics-port-auto").get_inconsistent()
-            and self.widget("graphics-port-auto").is_visible()
-        ):
-            # When switching from listen=None to listen=address with
-            # Hypervisor default, we need to force autoport otherwise
-            # the XML change doesn't stick
-            self._active_edits.append(_EDIT_GFX_PORT)
-            portauto = True
-        if portauto:
-            port = -1
+            if (
+                self.widget("graphics-port-auto").get_inconsistent()
+                and self.widget("graphics-port-auto").is_visible()
+            ):
+                # When switching from listen=None to listen=address with
+                # Hypervisor default, we need to force autoport otherwise
+                # the XML change doesn't stick
+                self._active_edits.append(_EDIT_GFX_PORT)
+                portauto = True
+            if portauto:
+                port = -1
 
-        listen = uiutil.get_list_selection(self.widget("graphics-listen-type"))
-        addr = uiutil.get_list_selection(self.widget("graphics-address"))
-        if listen and listen == "none":
-            port = None
-        elif listen:
-            listen = addr
+        listen = None
+        if self.widget("graphics-listen-type").is_visible():
+            listen = uiutil.get_list_selection(self.widget("graphics-listen-type"))
+            addr = uiutil.get_list_selection(self.widget("graphics-address"))
+            if listen and listen == "none":
+                port = None
+            elif listen:
+                listen = addr
 
         gtype = uiutil.get_list_selection(self.widget("graphics-type"))
 

--- a/virtManager/object/domain.py
+++ b/virtManager/object/domain.py
@@ -892,7 +892,7 @@ class vmmDomain(vmmLibvirtObject):
         if passwd != _SENTINEL:
             editdev.passwd = passwd
         if gtype != _SENTINEL:
-            editdev.type = gtype
+            xmlobj.change_graphics(gtype, editdev)
         if gl != _SENTINEL:
             editdev.gl = gl
         if rendernode != _SENTINEL:

--- a/virtManager/preferences.py
+++ b/virtManager/preferences.py
@@ -147,6 +147,7 @@ class vmmPreferences(vmmGObjectUI):
             ["system", _("System default (%s)") % self.config.default_graphics_from_config],
             ["vnc", "VNC"],
             ["spice", "Spice"],
+            ["dbus", "D-Bus"],
         ]:
             model.append(row)
         combo.set_model(model)

--- a/virtinst/devices/graphics.py
+++ b/virtinst/devices/graphics.py
@@ -37,9 +37,13 @@ class DeviceGraphics(Device):
     TYPE_VNC = "vnc"
     TYPE_RDP = "rdp"
     TYPE_SPICE = "spice"
+    TYPE_EGL_HEADLESS = "egl-headless"
+    TYPE_DBUS = "dbus"
 
     _XML_PROP_ORDER = [
         "_type",
+        "p2p",
+        "dbus_address",
         "gl",
         "_port",
         "_tlsPort",
@@ -50,9 +54,24 @@ class DeviceGraphics(Device):
         "passwd",
         "display",
         "xauth",
+        "audio_id",
     ]
 
     keymap = XMLProperty("./@keymap")
+
+    def _clear_net_config(self):
+        self._remove_all_listens()
+        self._listen = None
+        self._port = None
+        self._tlsPort = None
+        self.autoport = None
+        self.websocket = None
+        self.socket = None
+
+    def _clear_dbus_config(self):
+        self.p2p = None
+        self.dbus_address = None
+        self.audio_id = None
 
     def _set_type(self, val):
         self._type = val
@@ -60,6 +79,19 @@ class DeviceGraphics(Device):
         # libvirt errors out if there is any other value
         if val == "vnc" and self.connected != "keep":
             self.connected = None
+        elif val not in [self.TYPE_VNC, self.TYPE_SPICE]:
+            self.connected = None
+
+        if val == self.TYPE_DBUS:
+            self._clear_net_config()
+            self.keymap = None
+            self.passwd = None
+            self.passwdValidTo = None
+            self.display = None
+            self.xauth = None
+            self.defaultMode = None
+        else:
+            self._clear_dbus_config()
 
     def _get_type(self):
         return self._type
@@ -117,6 +149,9 @@ class DeviceGraphics(Device):
     socket = XMLProperty("./@socket")
     connected = XMLProperty("./@connected")
     defaultMode = XMLProperty("./@defaultMode")
+    p2p = XMLProperty("./@p2p", is_yesno=True)
+    dbus_address = XMLProperty("./@address")
+    audio_id = XMLProperty("./audio/@id", is_int=True)
 
     listens = XMLChildProperty(_GraphicsListen)
 
@@ -191,6 +226,12 @@ class DeviceGraphics(Device):
         if gtype == "spice" and not guest.lookup_domcaps().supports_graphics_spice():
             log.debug("spice requested but HV doesn't support it. Using vnc.")
             gtype = "vnc"
+        if gtype == "dbus" and not guest.lookup_domcaps().supports_graphics_dbus():
+            fallback = "spice"
+            if not guest.lookup_domcaps().supports_graphics_spice():
+                fallback = "vnc"
+            log.debug("dbus requested but HV doesn't support it. Using %s.", fallback)
+            gtype = fallback
         return gtype
 
     def _default_image_compression(self, _guest):

--- a/virtinst/domcapabilities.py
+++ b/virtinst/domcapabilities.py
@@ -471,6 +471,12 @@ class DomainCapabilities(XMLBuilder):
 
         return self.devices.graphics.get_enum("type").has_value("spice")
 
+    def supports_graphics_dbus(self):
+        if not self.devices.graphics.supported:
+            return False
+
+        return self.devices.graphics.get_enum("type").has_value("dbus")
+
     def supports_channel_spicevmc(self):
         """
         Return False if libvirt explicitly advertises no support for

--- a/virtinst/guest.py
+++ b/virtinst/guest.py
@@ -853,9 +853,14 @@ class Guest(XMLBuilder):
     def change_graphics(self, val, inst):
         inst.type = val
         if val == "spice":
+            self._remove_dbus_audio()
             self._add_spice_devices()
+        elif val == "dbus":
+            self._remove_spice_devices(inst)
+            self._ensure_dbus_audio()
         else:
             self._remove_spice_devices(inst)
+            self._remove_dbus_audio()
 
     def convert_to_q35(self, num_pcie_root_ports=None):
         self.os.machine = "q35"
@@ -1447,15 +1452,76 @@ class Guest(XMLBuilder):
         self._add_spice_sound()
         self._add_spice_usbredir()
 
+    def _has_dbus_graphics(self):
+        for gfx in self.devices.graphics:
+            if gfx.type == gfx.TYPE_DBUS:
+                return True
+        return False
+
+    def _next_audio_id(self):
+        ids = []
+        for audio in self.devices.audio:
+            try:
+                ids.append(int(audio.id))
+            except Exception:
+                pass
+        return str(max(ids or [0]) + 1)
+
+    def _ensure_dbus_audio(self):
+        if not self._has_dbus_graphics():
+            return
+        if not self.devices.sound:
+            return
+
+        dbus_audio = None
+        for audio in self.devices.audio:
+            if audio.type == "dbus":
+                dbus_audio = audio
+                break
+
+        if dbus_audio is None:
+            dbus_audio = DeviceAudio(self.conn)
+            dbus_audio.type = "dbus"
+            dbus_audio.id = self._next_audio_id()
+            self.add_device(dbus_audio)
+
+        for gfx in self.devices.graphics:
+            if gfx.type == gfx.TYPE_DBUS:
+                gfx.audio_id = dbus_audio.id
+
+        for sound in self.devices.sound:
+            if sound.audio_id is None:
+                sound.audio_id = dbus_audio.id
+
     def _remove_duplicate_console(self, dev):
         condup = DeviceConsole.get_console_duplicate(self, dev)
         if condup:
             log.debug("Found duplicate console device:\n%s", condup.get_xml())
             self.devices.remove_child(condup)
 
+    def _remove_dbus_audio(self):
+        if self._has_dbus_graphics():
+            return
+
+        for audio in list(self.devices.audio):
+            if audio.type == "dbus":
+                for sound in self.devices.sound:
+                    if sound.audio_id == audio.id:
+                        sound.audio_id = None
+                for gfx in self.devices.graphics:
+                    if gfx.audio_id == audio.id:
+                        gfx.audio_id = None
+                self.devices.remove_child(audio)
+
     def _remove_spice_audio(self):
-        for audio in self.devices.audio:
+        for audio in list(self.devices.audio):
             if audio.type == "spice":
+                for sound in self.devices.sound:
+                    if sound.audio_id == audio.id:
+                        sound.audio_id = None
+                for gfx in self.devices.graphics:
+                    if gfx.audio_id == audio.id:
+                        gfx.audio_id = None
                 self.devices.remove_child(audio)
 
     def _remove_spice_channels(self):


### PR DESCRIPTION
## Add D-Bus display backend support

This implements the feature I asked myself some time ago [here](https://github.com/virt-manager/virt-manager/issues/918).

This adds D-Bus graphics support to virt-manager and virtinst, so a VM can be configured with `<graphics type='dbus'/>` from the UI and used with an external D-Bus display client.

### What changed

- Add `dbus` as a supported graphics type in virtinst and virt-manager
- Expose `D-Bus` in the graphics UI and New VM preferences
- Preserve D-Bus-specific XML fields such as:
  - `p2p`
  - `address`
  - nested `audio id`
- Update existing-VM graphics edits to correctly switch between SPICE, VNC, and D-Bus
- Remove SPICE-only helper devices when moving away from SPICE
- Create and wire a D-Bus audio backend when needed for guests with sound devices
- Show a clear message in the console page for D-Bus graphics, and fall back to serial when available

### Notes

- virt-manager does not embed a D-Bus graphical console
- When a guest uses D-Bus graphics, users need an external tool to connect to the D-Bus display
- This change focuses on virt-manager/libvirt XML support and UI integration

### Testing

- `pytest -q tests/test_capabilities.py tests/test_xmlparse.py`
- `pytest -q tests/test_cli.py -k 'edit_graphics_dbus or change_spice_to_dbus or change_spice_to_vnc'`