### PR TITLE
virtinst: fixes for iommufd - CLI parsing and CLI test update

### DIFF
--- a/tests/data/cli/compare/virt-install-iommufd.xml
+++ b/tests/data/cli/compare/virt-install-iommufd.xml
@@ -1,0 +1,88 @@
+<domain type="kvm">
+  <name>fedora</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/unknown"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/var/lib/libvirt/images/fedora.qcow2"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="virtio"/>
+    </video>
+    <hostdev mode="subsystem" type="pci" managed="yes">
+      <source>
+        <address domain="0" bus="21" slot="0" function="4"/>
+      </source>
+      <driver name="vfio" iommufd="yes"/>
+    </hostdev>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -928,12 +928,6 @@
         <zpci uid="0xffff" fid="0xffffffff"/>
       </address>
     </hostdev>
-    <hostdev mode="subsystem" type="pci" managed="yes">
-      <source>
-        <address domain="0" bus="21" slot="0" function="4"/>
-      </source>
-      <driver name="vfio" iommufd="yes"/>
-    </hostdev>
     <hostdev mode="subsystem" type="usb" managed="yes">
       <source>
         <vendor id="0x062a"/>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -754,7 +754,6 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --hostdev 15:0.1
 --host-device 2:15:0.2
 --hostdev 0:15:0.3,address.type=pci,address.zpci.uid=0xffff,address.zpci.fid=0xffffffff
---hostdev 0:15:0.4,driver_name=vfio,driver.iommufd=yes
 --host-device 0x062a:0x0001,driver_name=vfio
 --host-device 0483:2016
 --host-device pci_8086_2829_scsi_host_scsi_device_lun0,rom.bar=on,acpi.nodeset=0-2
@@ -869,6 +868,14 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 """,
     "many-devices",
     predefine_check="8.4.0",
+)
+
+c.add_compare(
+    """
+--hostdev 0:15:0.4,driver_name=vfio,driver.iommufd=yes
+    """,
+    "iommufd",
+    prerun_check="12.1.0",
 )
 
 # Need to extract from the many-devices test as it was fixed in libvirt 10.4.0

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -5306,7 +5306,7 @@ class ParserHostdev(VirtCLIParser):
         cls.add_arg("type", "type")
         cls.add_arg("name", None, cb=cls.set_name_cb, lookup_cb=cls.name_lookup_cb)
         cls.add_arg("driver.name", "driver_name")
-        cls.add_arg("driver.iommufd", "driver_iommufd")
+        cls.add_arg("driver.iommufd", "driver_iommufd", is_onoff=True)
         cls.add_arg("rom.bar", "rom_bar", is_onoff=True)
         cls.add_arg("acpi.nodeset", "acpi_nodeset", can_comma=True)
         cls.add_arg("source.startupPolicy", "startup_policy")


### PR DESCRIPTION
This PR introduces two fixes for iommufd support in virtinst:

- driver.iommufd=on emits invalid-looking iommufd="on" instead of iommufd="yes". Add is_onoff=True to cli.py to address this.

- Separate iommufd test out of many-devices test to avoid Libvirt version mismatch. Gate iommufd test behind Libvirt 12.1.0.

Testing:

- driver.iommufd=on emits iommufd="yes"