### PR TITLE
tests: Separate acpi nodeset test out of many-devices

### DIFF
--- a/tests/data/cli/compare/virt-install-acpi-nodeset.xml
+++ b/tests/data/cli/compare/virt-install-acpi-nodeset.xml
@@ -1,0 +1,88 @@
+<domain type="kvm">
+  <name>fedora</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://fedoraproject.org/fedora/unknown"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>2</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="/var/lib/libvirt/images/fedora.qcow2"/>
+      <target dev="vda" bus="virtio"/>
+      <boot order="1"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="virtio"/>
+    </video>
+    <hostdev mode="subsystem" type="pci" managed="yes">
+      <source>
+        <address domain="0" bus="21" slot="0" function="4"/>
+      </source>
+      <acpi nodeset="0,2"/>
+    </hostdev>
+    <redirdev bus="usb" type="spicevmc"/>
+    <redirdev bus="usb" type="spicevmc"/>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+  </devices>
+</domain>

--- a/tests/data/cli/compare/virt-install-many-devices.xml
+++ b/tests/data/cli/compare/virt-install-many-devices.xml
@@ -895,7 +895,6 @@
         <address domain="0" bus="0" slot="25" function="0"/>
       </source>
       <rom bar="off"/>
-      <acpi nodeset="0,2"/>
       <boot order="4"/>
     </hostdev>
     <hostdev mode="subsystem" type="usb" managed="yes">
@@ -947,7 +946,6 @@
         <address bus="0" target="0" unit="0"/>
       </source>
       <rom bar="on"/>
-      <acpi nodeset="0-2"/>
     </hostdev>
     <hostdev mode="subsystem" type="usb" managed="yes">
       <source>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -759,7 +759,7 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --console pty,target_type=virtio
 
 
---hostdev net_00_1c_25_10_b1_e4,boot_order=4,rom_bar=off,acpi.nodeset=0,2
+--hostdev net_00_1c_25_10_b1_e4,boot_order=4,rom_bar=off
 --host-device usb_device_781_5151_2004453082054CA1BEEE
 --host-device 001.003
 --hostdev 15:0.1
@@ -767,7 +767,7 @@ source.reservations.managed=no,source.reservations.source.type=unix,source.reser
 --hostdev 0:15:0.3,address.type=pci,address.zpci.uid=0xffff,address.zpci.fid=0xffffffff
 --host-device 0x062a:0x0001,driver_name=vfio
 --host-device 0483:2016
---host-device pci_8086_2829_scsi_host_scsi_device_lun0,rom.bar=on,acpi.nodeset=0-2
+--host-device pci_8086_2829_scsi_host_scsi_device_lun0,rom.bar=on
 --hostdev usb_5_20 --hostdev usb_5_21
 --hostdev wlan0,type=net
 --hostdev /dev/vdz,type=storage
@@ -887,6 +887,14 @@ c.add_compare(
     """,
     "iommufd",
     prerun_check="12.1.0",
+)
+
+c.add_compare(
+    """
+--hostdev 0:15:0.4,acpi.nodeset=0,2
+    """,
+    "acpi-nodeset",
+    prerun_check="11.8.0",
 )
 
 # Need to extract from the many-devices test as it was fixed in libvirt 10.4.0


### PR DESCRIPTION
This PR separates acpi nodeset test out of many-devices test to avoid Libvirt version mismatch. Gate acpi nodeset test behind Libvirt 11.8.0.