### PR TITLE
Display snapshots as a tree sorted by creation date

### DIFF
--- a/ui/snapshots.ui
+++ b/ui/snapshots.ui
@@ -32,6 +32,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="headers-visible">False</property>
+                    <property name="enable-tree-lines">True</property>
                     <signal name="button-press-event" handler="on_snapshot_list_button_press_event" swapped="no"/>
                     <signal name="row-activated" handler="on_snapshot_list_row_activated" swapped="no"/>
                     <child internal-child="selection">

--- a/ui/snapshots.ui
+++ b/ui/snapshots.ui
@@ -16,7 +16,7 @@
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child>
-          <object class="GtkPaned" id="spaned1">
+          <object class="GtkPaned" id="snapshot-paned">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="position">200</property>
@@ -25,7 +25,7 @@
               <object class="GtkScrolledWindow" id="scrolledwindow7">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="hscrollbar-policy">never</property>
+                <property name="hscrollbar-policy">automatic</property>
                 <property name="shadow-type">in</property>
                 <child>
                   <object class="GtkTreeView" id="snapshot-list">
@@ -48,7 +48,7 @@
                 </child>
               </object>
               <packing>
-                <property name="resize">False</property>
+                <property name="resize">True</property>
                 <property name="shrink">False</property>
               </packing>
             </child>

--- a/virtManager/details/snapshots.py
+++ b/virtManager/details/snapshots.py
@@ -10,8 +10,8 @@ import io
 import os
 
 from gi.repository import GdkPixbuf
+from gi.repository import GLib
 from gi.repository import Gtk
-from gi.repository import Pango
 
 from virtinst import DomainSnapshot
 from virtinst import generatename
@@ -464,11 +464,12 @@ class vmmSnapshotPage(vmmGObjectUI):
         self.widget("snapshot-description").set_buffer(buf)
 
         # [name, row label, tooltip, icon name, sortname, current]
-        model = Gtk.ListStore(str, str, str, str, str, bool)
+        model = Gtk.TreeStore(str, str, str, str, str, bool)
         model.set_sort_column_id(4, Gtk.SortType.ASCENDING)
 
         col = Gtk.TreeViewColumn("")
         col.set_min_width(150)
+        col.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
         col.set_spacing(6)
 
         img = Gtk.CellRendererPixbuf()
@@ -477,7 +478,6 @@ class vmmSnapshotPage(vmmGObjectUI):
         col.add_attribute(img, "icon-name", 3)
 
         txt = Gtk.CellRendererText()
-        txt.set_property("ellipsize", Pango.EllipsizeMode.END)
         col.pack_start(txt, False)
         col.add_attribute(txt, "markup", 1)
 
@@ -488,14 +488,10 @@ class vmmSnapshotPage(vmmGObjectUI):
         col.pack_start(img, False)
         col.add_attribute(img, "visible", 5)
 
-        def _sep_cb(_model, _iter, ignore):
-            return not bool(_model[_iter][0])
-
         slist = self.widget("snapshot-list")
         slist.set_model(model)
         slist.set_tooltip_column(2)
         slist.append_column(col)
-        slist.set_row_separator_func(_sep_cb, None)
 
         # Snapshot popup menu
         menu = Gtk.Menu()
@@ -551,7 +547,8 @@ class vmmSnapshotPage(vmmGObjectUI):
         for i in self._get_selected_snapshots():
             cursnaps.append(i.get_name())
 
-        model = self.widget("snapshot-list").get_model()
+        slist = self.widget("snapshot-list")
+        model = slist.get_model()
         model.clear()
 
         try:
@@ -561,28 +558,27 @@ class vmmSnapshotPage(vmmGObjectUI):
             self._set_error_page(_("Error refreshing snapshot list: %s") % str(e))
             return
 
-        has_external = False
-        has_internal = False
-        for snap in snapshots:
-            desc = snap.get_xmlobj().description
-            name = snap.get_name()
-            state = snap.run_status()
-            if snap.is_external():
-                has_external = True
-                sortname = "3%s" % name
-                label = _("%(vm)s\n<span size='small'>VM State: %(state)s (External)</span>")
-            else:
-                has_internal = True
-                sortname = "1%s" % name
-                label = _("%(vm)s\n<span size='small'>VM State: %(state)s</span>")
+        snapshots.sort(key=lambda s: s.get_xmlobj().creationTime or 0)
 
-            label = label % {"vm": xmlutil.xml_escape(name), "state": xmlutil.xml_escape(state)}
-            model.append(
-                [name, label, desc, snap.run_status_icon_name(), sortname, snap.is_current()]
+        parent_iters = {}
+        for snap in snapshots:
+            name = snap.get_name()
+            xmlobj = snap.get_xmlobj()
+            desc = xmlobj.description
+            state = snap.run_status()
+            sortname = "%010d%s" % (xmlobj.creationTime or 0, name)
+            snap_type = _("External") if snap.is_external() else _("Internal")
+            label = _("%(vm)s\n<span size='small'>VM State: %(state)s (%(snap_type)s)</span>") % {
+                "vm": xmlutil.xml_escape(name),
+                "state": xmlutil.xml_escape(state),
+                "snap_type": snap_type,
+            }
+            parent_iters[name] = model.append(
+                parent_iters.get(xmlobj.parent),
+                [name, label, desc, snap.run_status_icon_name(), sortname, snap.is_current()],
             )
 
-        if has_internal and has_external:
-            model.append([None, None, None, None, "2", False])
+        slist.expand_all()
 
         def check_selection(treemodel, path, it, snaps):
             if select_name:
@@ -591,11 +587,20 @@ class vmmSnapshotPage(vmmGObjectUI):
             elif treemodel[it][0] in snaps:
                 selection.select_path(path)
 
-        selection = self.widget("snapshot-list").get_selection()
-        model = self.widget("snapshot-list").get_model()
+        selection = slist.get_selection()
         selection.unselect_all()
         model.foreach(check_selection, cursnaps)
 
+        if not self._initial_populate:
+
+            def _on_first_allocate(widget, allocation):
+                if allocation.width <= 1:
+                    return
+                widget.disconnect_by_func(_on_first_allocate)
+                pos = min(slist.get_preferred_width()[1], allocation.width // 2)
+                GLib.idle_add(widget.set_position, pos)
+
+            self.widget("snapshot-paned").connect("size-allocate", _on_first_allocate)
         self._initial_populate = True
 
     def _read_screenshot_file(self, name):

--- a/virtManager/details/snapshots.py
+++ b/virtManager/details/snapshots.py
@@ -549,6 +549,11 @@ class vmmSnapshotPage(vmmGObjectUI):
 
         slist = self.widget("snapshot-list")
         model = slist.get_model()
+
+        expanded_names = set()
+        if self._initial_populate:
+            slist.map_expanded_rows(lambda _tv, path: expanded_names.add(model[path][0]))
+
         model.clear()
 
         try:
@@ -578,7 +583,20 @@ class vmmSnapshotPage(vmmGObjectUI):
                 [name, label, desc, snap.run_status_icon_name(), sortname, snap.is_current()],
             )
 
-        slist.expand_all()
+        if not self._initial_populate:
+            slist.expand_all()
+        else:
+            current_snap = self.vm.get_current_snapshot()
+            if current_snap:
+                current_iter = parent_iters.get(current_snap.get_name())
+                if current_iter is not None:
+                    slist.expand_to_path(model.get_path(current_iter))
+
+            def _expand_saved(treemodel, path, it):
+                if treemodel[it][0] in expanded_names:
+                    slist.expand_row(path, False)
+
+            model.foreach(_expand_saved)
 
         def check_selection(treemodel, path, it, snaps):
             if select_name:


### PR DESCRIPTION
As a daily `virt-manager` user who has recently been heavily relying on snapshots, I realized it is quite hard to see which snapshots are parents or children of others. Thus I changed the snapshot list to a tree view ordered by creation date, which has helped me a lot when managing (deleting, reverting, branching) my snapshots.


### The commit include:
- Switch `GtkListStore` to `GtkTreeStore` to render parent/child snapshot relationships
- Sort snapshots by creationTime for chronological sibling ordering
- Label both internal and external snapshots with their type
- Auto-size the paned divider to the tree's natural width on first populate
- Drop the internal/external separator row, now redundant with the tree structure
- Preserve tree expansion state across refresh, while always expanding the currently in-use snapshot


### Example: 
<img width="1117" height="640" alt="Screenshot_2026-06-29_17:34:29" src="https://github.com/user-attachments/assets/2f17bdee-b946-4a24-aa81-704ad7ef08e7" />



### Related issues:
 * https://github.com/virt-manager/virt-manager/issues/142
 * https://github.com/virt-manager/virt-manager/issues/847
