### PR TITLE
virt-clone: validate --mac count matches interface count

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2594,12 +2594,20 @@ c.add_valid(
     + " --file %(EXISTIMG3)s --file %(EXISTIMG4)s --check path_exists=off"
 )  # Skip existing file check
 c.add_valid(
-    "-n clonetest " + _CLONE_UNMANAGED + " --auto-clone --mac 22:11:11:11:11:11 --check all=off"
+    "--connect %(URI-KVM-X86)s -o test-clone --auto-clone --mac 22:22:33:12:34:AB --mac 22:11:11:11:11:12 --check all=off"
 )  # Colliding mac but we skip the check
 c.add_invalid(
-    "-n clonetest " + _CLONE_UNMANAGED + " --auto-clone --mac 22:11:11:11:11:11",
+    "--connect %(URI-KVM-X86)s -o test-clone --auto-clone --mac 22:22:33:12:34:AB --mac 22:11:11:11:11:11",
     grep="--check mac_in_use=off",
 )  # Colliding mac should fail
+c.add_invalid(
+    "--connect %(URI-KVM-X86)s -o test-clone -n test-newclone --mac 12:34:56:1A:B2:C3 --file /dev/pool-logical/newclone1.img --file /pool-dir/newclone2.img --skip-copy=hdb --force-copy=sdb",
+    grep="does not match the number of network interfaces",
+)  # Too few MACs: test-clone has 2 interfaces but only 1 MAC provided
+c.add_invalid(
+    "--connect %(URI-KVM-X86)s -o test-clone -n test-newclone --mac 12:34:56:1A:B2:C3 --mac 12:34:56:1A:B7:C3 --mac 12:34:56:1A:B8:C3 --file /dev/pool-logical/newclone1.img --file /pool-dir/newclone2.img --skip-copy=hdb --force-copy=sdb",
+    grep="does not match the number of network interfaces",
+)  # Too many MACs: test-clone has 2 interfaces but 3 MACs provided
 c.add_invalid("--auto-clone", grep="An original machine name is required")  # No clone VM specified
 c.add_invalid(
     _CLONE_EMPTY + " --file foo", grep="use '--name NEW_VM_NAME'"

--- a/virtinst/virtclone.py
+++ b/virtinst/virtclone.py
@@ -26,6 +26,14 @@ def _process_macs(options, cloner):
     if not new_macs or new_macs[0] == "RANDOM":
         return
 
+    ninterfaces = len(cloner.new_guest.devices.interface)
+    if len(new_macs) != ninterfaces:
+        fail(
+            _("Number of MAC addresses (%d) does not match the number of "
+              "network interfaces in the original guest (%d).")
+            % (len(new_macs), ninterfaces)
+        )
+
     for mac in new_macs:
         cli.validate_mac(cloner.conn, mac)
 


### PR DESCRIPTION
## Description

Fixes #1120

When the user provides fewer `--mac` addresses than the number of network interfaces in the original guest, `virt-clone` crashes with an unhandled `IndexError` from `list.pop(0)`. When too many MACs are provided, the extras are silently ignored after validation, giving no feedback to the user.

## Changes

- Added validation in `_process_macs` to check that the number of provided MAC addresses matches the number of network interfaces before the assignment loop
- Updated two existing tests that were relying on the buggy behavior (passing a MAC to a guest with 0 interfaces in `clone-disk.xml`). These tests were updated to use `test-clone` (which has 2 interfaces) with the correct number of MAC addresses
- Added two new invalid test cases covering the too-few and too-many MAC scenarios

## Testing

All clone tests pass (except pre-existing failures due to missing test image files in the environment).