### PR TITLE
xmletree: fix serialization of default (unprefixed) XML namespaces

### DIFF
--- a/virtinst/xmletree.py
+++ b/virtinst/xmletree.py
@@ -97,7 +97,8 @@ def _convert_qname(tag, namespaces):
         uri, tag = tag[1:].rsplit("}", 1)
         for key, val in namespaces.items():
             if uri == val:
-                tag = key + ":" + tag
+                if key:
+                    tag = key + ":" + tag
                 break
     return tag
 
@@ -120,7 +121,10 @@ def _serialize_node(write, elem, namespaces):
         else:
             write("<" + tag)
             for nsprefix, nsuri in elem.virtinst_namespaces.items():
-                write(' xmlns:%s="%s"' % (nsprefix, nsuri))
+                if nsprefix:
+                    write(' xmlns:%s="%s"' % (nsprefix, nsuri))
+                else:
+                    write(' xmlns="%s"' % nsuri)
             for k, v in list(elem.items()):
                 k = _convert_qname(k, use_ns)
                 v = xmlutil.xml_escape(v)


### PR DESCRIPTION
When working with [virter](https://github.com/LINBIT/virter) that stores its own metadata in libvirt XML entries, I found my own system (openSUSE Tumbleweed, no `python3-libxml2` package available) failing on both  `virt-xml --edit` and `virt-install --reinstall`.

To my surprise, the root cause turned out to be here in `xmletree.py`, not in virter, just a couple lines of code to patch. The test suite passes with the new fix.

This only affects the `xmletree.py` backend, used as a fallback when the libxml2 Python bindings aren't available. Verified the `xmllibxml2.py` backend doesn't have this bug, it delegates straight to libxml2, which handles it correctly.
