### PR TITLE
console: add minimize button to the fullscreen overlay toolbar

### DIFF
--- a/virtManager/details/console.py
+++ b/virtManager/details/console.py
@@ -133,22 +133,41 @@ def build_keycombo_menu(on_send_key_fn):
     return menu
 
 
+def _wm_supports_minimize():
+    settings = Gtk.Settings.get_default()
+    if settings is None:
+        return False
+
+    layout = settings.get_property("gtk-decoration-layout") or ""
+    return "minimize" in layout.replace(":", ",").split(",")
+
+
 class vmmOverlayToolbar:
-    def __init__(self, on_leave_fn, on_send_key_fn):
+    def __init__(self, on_leave_fn, on_send_key_fn, on_minimize_fn):
         self._send_key_button = None
         self._keycombo_menu = None
         self._toolbar = None
 
         self.timed_revealer = None
-        self._init_ui(on_leave_fn, on_send_key_fn)
+        self._init_ui(on_leave_fn, on_send_key_fn, on_minimize_fn)
 
-    def _init_ui(self, on_leave_fn, on_send_key_fn):
+    def _init_ui(self, on_leave_fn, on_send_key_fn, on_minimize_fn):
         self._keycombo_menu = build_keycombo_menu(on_send_key_fn)
 
         self._toolbar = Gtk.Toolbar()
         self._toolbar.set_show_arrow(False)
         self._toolbar.set_style(Gtk.ToolbarStyle.BOTH_HORIZ)
         self._toolbar.get_accessible().set_name("Fullscreen Toolbar")
+
+        if _wm_supports_minimize():
+            button = Gtk.ToolButton()
+            button.set_label(_("Minimize"))
+            button.set_icon_name("window-minimize")
+            button.set_tooltip_text(_("Minimize window"))
+            button.show()
+            button.get_accessible().set_name("Fullscreen Minimize")
+            self._toolbar.add(button)
+            button.connect("clicked", on_minimize_fn)
 
         # Exit button
         button = Gtk.ToolButton()
@@ -369,7 +388,9 @@ class vmmConsolePages(vmmGObjectUI):
         self._keycombo_menu = build_keycombo_menu(self._do_send_key)
 
         self._overlay_toolbar_fullscreen = vmmOverlayToolbar(
-            on_leave_fn=self._leave_fullscreen, on_send_key_fn=self._do_send_key
+            on_leave_fn=self._leave_fullscreen,
+            on_send_key_fn=self._do_send_key,
+            on_minimize_fn=self._minimize_window,
         )
         self.widget("console-overlay").add_overlay(
             self._overlay_toolbar_fullscreen.timed_revealer.get_overlay_widget()
@@ -518,6 +539,9 @@ class vmmConsolePages(vmmGObjectUI):
 
     def _leave_fullscreen(self, ignore=None):
         self.emit("leave-fullscreen")
+
+    def _minimize_window(self, ignore=None):
+        self.topwin.iconify()
 
     def _change_fullscreen(self, do_fullscreen):
         if do_fullscreen:


### PR DESCRIPTION
Adds a Minimize button to the fullscreen overlay toolbar, so the window can be minimized without leaving fullscreen first.
Continues #985 by @gdarko, which stalled. Picking it up with the review feedback  addressed:
  
- squashed into a single commit with a description
- formatted with `black` 
- the button is only shown when GTK's `gtk-decoration-layout` advertises `minimize`, so it does not appear on window managers that ignore the request
- dropped the `test_livetests.py` addition from #985: it calls `win.window_deiconify()`, which doesn't exist in dogtail or `lib/_node.py`. Clicking the button also strands the fullscreen window, since the test suite can't restore it
    
Credit for the original implementation goes to @gdarko; authorship is preserved on the commit. Happy to close this in favour of the original PR if he picks it back up.
