### PR TITLE
virt-manager.desktop.in: add 'virt-manager' and 'virtmanager' keywords

### DIFF
--- a/data/virt-manager.desktop.in
+++ b/data/virt-manager.desktop.in
@@ -7,4 +7,4 @@ Exec=virt-manager
 Type=Application
 Terminal=false
 Categories=System;Emulator;GTK;
-Keywords=virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;
+Keywords=virtualization;libvirt;vm;vmm;qemu;xen;lxc;kvm;virt-manager;virtmanager;


### PR DESCRIPTION
So that the program can be found by the name of the program, since 'Exec' field does not match the name in the 'Name' field.