### PR TITLE
devices: disk: replace str.removeprefix with startswith for Python < 3.9 compat

### DIFF
--- a/virtinst/devices/disk.py
+++ b/virtinst/devices/disk.py
@@ -694,8 +694,8 @@ class DeviceDisk(Device):
     def set_source_path(self, newpath):
         # Some file managers use 'file://' when passing files to
         # virt-manager, we need to strip it from the newpath.
-        if newpath is not None:
-            newpath = newpath.removeprefix("file://")
+        if newpath is not None and newpath.startswith("file://"):
+            newpath = newpath[len("file://"):]
 
         if self._storage_backend.will_create_storage():
             raise xmlutil.DevError("Can't change disk path if storage creation info has been set.")


### PR DESCRIPTION
str.removeprefix() was introduced in Python 3.9, but the project documents python >= 3.4 as the minimum requirement in INSTALL.md.  When virt-manager is run on Python 3.8 or older, setting the install media path via a file:// URI (E.g., from a file manager) fails with:

  'str' object has no attribute 'removeprefix'

Replace it with startswith() + slicing, which is equivalent and compatible with all supported Python versions.