### PR TITLE
build: update minimum required Python version to 3.9

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ A detailed dependency list can be found in [virt-manager.spec.in](virt-manager.s
 Minimum version requirements of major components:
 
    - gettext >= 0.19.6
-   - python >= 3.4
+   - python >= 3.9
    - gtk3 >= 3.22
    - libvirt-python >= 0.6.0
    - pygobject3 >= 3.31.3

--- a/virtinst/buildconfig.py
+++ b/virtinst/buildconfig.py
@@ -12,8 +12,8 @@ Configuration variables that can be set at build time
 import os
 import sys
 
-if sys.version_info.major != 3 or sys.version_info.minor < 4:  # pragma: no cover
-    print("python 3.4 or later is required, your's is %s" % sys.version_info)
+if sys.version_info.major != 3 or sys.version_info.minor < 9:  # pragma: no cover
+    print("python 3.9 or later is required, your's is %s" % sys.version_info)
     sys.exit(1)
 
 import configparser


### PR DESCRIPTION
The documented minimum Python version (3.4) is outdated.  The code base already relies on newer Python features, e.g. str.removeprefix() in DeviceDisk.set_source_path(), which was introduced in Python 3.9 and fails with AttributeError on older interpreters.

Update INSTALL.md and the buildconfig runtime version check to require Python >= 3.9.