### PR TITLE
virtinst: add support for vCMDQ

### DIFF
--- a/tests/data/cli/compare/virt-install-aarch64-nested-smmuv3-cmdqv.xml
+++ b/tests/data/cli/compare/virt-install-aarch64-nested-smmuv3-cmdqv.xml
@@ -1,0 +1,55 @@
+<domain type="kvm">
+  <name>vm1</name>
+  <uuid>00000000-1111-2222-3333-444444444444</uuid>
+  <memory>65536</memory>
+  <currentMemory>65536</currentMemory>
+  <vcpu>1</vcpu>
+  <os firmware="efi">
+    <type arch="aarch64" machine="virt">hvm</type>
+  </os>
+  <features>
+    <acpi/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="utc"/>
+  <devices>
+    <emulator>/usr/bin/qemu-system-aarch64</emulator>
+    <controller type="pci" index="1" model="pcie-expander-bus"/>
+    <controller type="pci" index="2" model="pcie-root-port">
+      <address type="pci" domain="0" bus="1" function="0" devno="0"/>
+    </controller>
+    <controller type="usb" model="qemu-xhci" ports="15"/>
+    <interface type="bridge">
+      <source bridge="testsuitebr0"/>
+      <mac address="00:11:22:33:44:55"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <input type="keyboard" bus="usb"/>
+    <tpm>
+      <backend type="emulator"/>
+    </tpm>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <sound model="ich9"/>
+    <video>
+      <model type="ramfb"/>
+    </video>
+    <hostdev mode="subsystem" type="pci" managed="yes">
+      <source>
+        <address domain="0" bus="0" slot="4" function="0"/>
+      </source>
+      <address type="pci" bus="2" function="0" devno="0"/>
+    </hostdev>
+    <iommu model="smmuv3">
+      <driver pciBus="0" accel="on" cmdqv="on"/>
+    </iommu>
+    <iommu model="smmuv3">
+      <driver pciBus="1" accel="on" cmdqv="on"/>
+    </iommu>
+  </devices>
+</domain>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1084,6 +1084,20 @@ c.add_compare(
     prerun_check="12.7.0",
 )
 
+###########################
+# Nested Smmuv3 and vCMDQ #
+###########################
+c = vinst.add_category(
+    "kvm-aarch64-nested-smmuv3-cmdqv",
+    "--disk none --noautoconsole --osinfo generic --connect %(URI-KVM-AARCH64)s"
+)
+
+c.add_compare(
+    "--controller type=pci,index=1,model=pcie-expander-bus --controller type=pci,index=2,model=pcie-root-port,address.domain=0,address.bus=1,address.devno=0,address.function=0,address.type=pci --iommu model=smmuv3,driver.pciBus=0,driver.accel=on,driver.cmdqv=on --iommu model=smmuv3,driver.pciBus=1,driver.accel=on,driver.cmdqv=on --hostdev 0:0:4.0,type=pci,address.bus=2,address.devno=0,address.function=0,address.type=pci",
+    "aarch64-nested-smmuv3-cmdqv",
+    prerun_check="12.7.0",
+)
+
 ########################
 # Storage provisioning #
 ########################

--- a/virtinst/cli.py
+++ b/virtinst/cli.py
@@ -4579,6 +4579,7 @@ class ParserIommu(VirtCLIParser):
         cls.add_arg("driver.ril", "ril", is_onoff=True)
         cls.add_arg("driver.ssidsize", "ssidsize")
         cls.add_arg("driver.oas", "oas")
+        cls.add_arg("driver.cmdqv", "cmdqv", is_onoff=True)
 
 
 #######################

--- a/virtinst/devices/iommu.py
+++ b/virtinst/devices/iommu.py
@@ -33,3 +33,4 @@ class DeviceIommu(Device):
     ril = XMLProperty("./driver/@ril", is_onoff=True)
     ssidsize = XMLProperty("./driver/@ssidsize")
     oas = XMLProperty("./driver/@oas")
+    cmdqv = XMLProperty("./driver/@cmdqv",is_onoff=True)


### PR DESCRIPTION
A minimal config to specify multiple user-creatable SMMUv3 IOMMUs with vCMDQ support enabled and HW-accelerated SMMUv3 features specified would be

 $ virt-install
     ...args...
     --iommu model=smmuv3,driver.pciBus=0,driver.accel=on,driver.cmdqv=on
     --iommu model=smmuv3,driver.pciBus=1,driver.accel=on,driver.cmdqv=on